### PR TITLE
Wrap TOC LLM request errors for fallback

### DIFF
--- a/pdf_craft/toc/llm_analyser.py
+++ b/pdf_craft/toc/llm_analyser.py
@@ -567,7 +567,13 @@ class _LLMAnalyser(Generic[_P, _R]):
         tail_messages: list[Message] = []
 
         for attempt in range(_MAX_RETRIES):
-            response = self._llm.request(input=head_messages + tail_messages)
+            try:
+                response = self._llm.request(input=head_messages + tail_messages)
+            except Exception as error:
+                raise LLMAnalysisError(
+                    f"LLM request failed at attempt {attempt + 1}: {error}"
+                ) from error
+
             result, error_msg = self._validate(response, payload)
             if result is not None:
                 return result

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "poetry.core.masonry.api"
 
 [tool.poetry]
 name = "pdf-craft"
-version = "1.0.12"
+version = "1.0.13"
 description = "PDF craft can convert PDF files into various other formats. This project will focus on processing PDF files of scanned books."
 license = "MIT"
 authors = ["Tao Zeyu <i@taozeyu.com>"]

--- a/tests/test_toc_llm_analyser.py
+++ b/tests/test_toc_llm_analyser.py
@@ -1,0 +1,33 @@
+import unittest
+
+from pdf_craft.llm.types import Message, MessageRole
+from pdf_craft.toc.llm_analyser import LLMAnalysisError, _LLMAnalyser
+
+
+class _BrokenLLM:
+    def request(self, input):  # pylint: disable=redefined-builtin,unused-argument
+        raise RuntimeError("blocked by upstream")
+
+
+class TestLLMAnalyser(unittest.TestCase):
+    def test_wraps_llm_request_errors_as_analysis_error(self):
+        analyser = _LLMAnalyser(
+            llm=_BrokenLLM(),
+            validate=lambda response, payload: (response, payload),  # pragma: no cover
+        )
+
+        with self.assertRaises(LLMAnalysisError) as context:
+            analyser.request(
+                payload=1,
+                messages=(
+                    Message(role=MessageRole.SYSTEM, message="system"),
+                    Message(role=MessageRole.USER, message="user"),
+                ),
+            )
+
+        self.assertIn("LLM request failed at attempt 1", str(context.exception))
+        self.assertIsInstance(context.exception.__cause__, RuntimeError)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_toc_llm_analyser.py
+++ b/tests/test_toc_llm_analyser.py
@@ -1,6 +1,8 @@
 import unittest
+from typing import cast
 
 from pdf_craft.llm.types import Message, MessageRole
+from pdf_craft.llm.core import LLM
 from pdf_craft.toc.llm_analyser import LLMAnalysisError, _LLMAnalyser
 
 
@@ -12,8 +14,8 @@ class _BrokenLLM:
 class TestLLMAnalyser(unittest.TestCase):
     def test_wraps_llm_request_errors_as_analysis_error(self):
         analyser = _LLMAnalyser(
-            llm=_BrokenLLM(),
-            validate=lambda response, payload: (response, payload),  # pragma: no cover
+            llm=cast(LLM, _BrokenLLM()),
+            validate=lambda response, payload: (response, None),  # pragma: no cover
         )
 
         with self.assertRaises(LLMAnalysisError) as context:


### PR DESCRIPTION
## Summary
- wrap exceptions raised by TOC LLM requests as 
- preserve the original exception as the cause so existing fallback logic in  can handle upstream request failures
- add a regression test covering request-time failures in 

## Testing
- .........                                                                [100%]
9 passed in 1.55s
