### PR TITLE
chore: improve pdf-craft maintenance path

### DIFF
--- a/tests/test_jointer.py
+++ b/tests/test_jointer.py
@@ -450,6 +450,13 @@ class TestParseLineContent(unittest.TestCase):
     def test_empty_string(self):
         """测试空字符串"""
         result = _parse_block_content("")
+        self.assertIsInstance(result, list)
+        self.assertEqual(len(result), 0)
+
+    def test_none_input(self):
+        """测试 None 输入"""
+        result = _parse_block_content(None)
+        self.assertIsInstance(result, list)
         self.assertEqual(len(result), 0)
 
     def test_formula_only(self):

--- a/tests/test_parser.py
+++ b/tests/test_parser.py
@@ -424,6 +424,23 @@ class TestParseRawMarkdown(unittest.TestCase):
         self.assertEqual(inner_div.definition.name, "div")
         self.assertEqual(inner_div.children, ["Inner"])
 
+    def test_empty_input(self):
+        """测试空字符串输入"""
+        result = parse_raw_markdown("")
+        self.assertIsInstance(result, list)
+        self.assertEqual(len(result), 0)
+
+    def test_single_quoted_attributes(self):
+        """测试单引号属性值"""
+        result = parse_raw_markdown("<div id='test' title='Test Div'>Content</div>")
+        self.assertEqual(len(result), 1)
+        tag = result[0]
+        self.assertIsInstance(tag, HTMLTag)
+        assert isinstance(tag, HTMLTag)
+        attr_dict = dict(tag.attributes)
+        self.assertEqual(attr_dict["id"], "test")
+        self.assertEqual(attr_dict["title"], "Test Div")
+
 
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
Summary:
- Add or tighten focused edge-case tests or type assertions in tests/test_parser.py, tests/test_jointer.py related to Python typing, tests, CLI ergonomics, observability; avoid docs-only changes and broad refactors.
- Keep the change narrow so it is straightforward to review.

Notes:
- I kept this scoped to the relevant implementation and tests.