### PR TITLE
fix(parser): protect inline LaTeX before Markdown parsing

### DIFF
--- a/pdf_craft/sequence/jointer.py
+++ b/pdf_craft/sequence/jointer.py
@@ -31,6 +31,7 @@ _FOOTNOTE_PATTERN = re.compile(
 
 _MAX_TABLE_TITLE_CHARS = 180
 _MAX_TABLE_CAPTION_CHARS = 260
+_LATEX_PLACEHOLDER_MARKER = "\uE000PDF_CRAFT_LATEX"
 
 
 @dataclass
@@ -494,23 +495,43 @@ def _parse_block_content(text: str | None) -> Content:
     if not text:
         return []
 
-    root_content: Content = parse_raw_markdown(text)
+    protected_text, expressions = _protect_latex_expressions(text)
+    root_content: Content = parse_raw_markdown(protected_text)
 
     def expand_text(text: str):
-        for item in parse_latex_expressions(text):
-            if item.kind != ExpressionKind.TEXT:
-                yield InlineExpression(
-                    kind=item.kind,
-                    content=item.content,
-                )
-            elif item.content:  # Only add non-empty strings
-                yield item.content
+        pos = 0
+        for match in _LATEX_PLACEHOLDER_PATTERN.finditer(text):
+            if match.start() > pos:
+                yield text[pos : match.start()]
+            expression = expressions[int(match.group(1))]
+            yield InlineExpression(
+                kind=expression.kind,
+                content=expression.content,
+            )
+            pos = match.end()
+        if pos < len(text):
+            yield text[pos:]
 
     expand_text_in_content(
         content=root_content,
         expand=expand_text,
     )
     return root_content
+
+
+def _protect_latex_expressions(text: str) -> tuple[str, list[ParsedItem]]:
+    expressions: list[ParsedItem] = []
+    parts: list[str] = []
+
+    for item in parse_latex_expressions(text):
+        if item.kind == ExpressionKind.TEXT:
+            parts.append(item.content)
+            continue
+
+        parts.append(f"\uE000PDF_CRAFT_LATEX_{len(expressions)}\uE001")
+        expressions.append(item)
+
+    return "".join(parts), expressions
 
 
 def _is_splitted_word(text1: str, text2: str) -> bool:

--- a/pdf_craft/sequence/jointer.py
+++ b/pdf_craft/sequence/jointer.py
@@ -495,12 +495,12 @@ def _parse_block_content(text: str | None) -> Content:
     if not text:
         return []
 
-    protected_text, expressions = _protect_latex_expressions(text)
+    protected_text, expressions, placeholder_pattern = _protect_latex_expressions(text)
     root_content: Content = parse_raw_markdown(protected_text)
 
     def expand_text(text: str):
         pos = 0
-        for match in _LATEX_PLACEHOLDER_PATTERN.finditer(text):
+        for match in placeholder_pattern.finditer(text):
             if match.start() > pos:
                 yield text[pos : match.start()]
             expression = expressions[int(match.group(1))]
@@ -519,19 +519,30 @@ def _parse_block_content(text: str | None) -> Content:
     return root_content
 
 
-def _protect_latex_expressions(text: str) -> tuple[str, list[ParsedItem]]:
+def _protect_latex_expressions(text: str) -> tuple[str, list[ParsedItem], re.Pattern]:
     expressions: list[ParsedItem] = []
     parts: list[str] = []
+    placeholder_prefix = _create_latex_placeholder_prefix(text)
 
     for item in parse_latex_expressions(text):
         if item.kind == ExpressionKind.TEXT:
             parts.append(item.content)
             continue
 
-        parts.append(f"\uE000PDF_CRAFT_LATEX_{len(expressions)}\uE001")
+        parts.append(f"{placeholder_prefix}{len(expressions)}\uE001")
         expressions.append(item)
 
-    return "".join(parts), expressions
+    placeholder_pattern = re.compile(f"{re.escape(placeholder_prefix)}(\\d+)\uE001")
+    return "".join(parts), expressions, placeholder_pattern
+
+
+def _create_latex_placeholder_prefix(text: str) -> str:
+    index = 0
+    while True:
+        prefix = f"{_LATEX_PLACEHOLDER_MARKER}_{index}_"
+        if prefix not in text:
+            return prefix
+        index += 1
 
 
 def _is_splitted_word(text1: str, text2: str) -> bool:

--- a/tests/test_jointer.py
+++ b/tests/test_jointer.py
@@ -1,7 +1,7 @@
 import unittest
 
-from pdf_craft.pdf import PageLayout
 from pdf_craft.markdown.paragraph import HTMLTag
+from pdf_craft.pdf import PageLayout
 from pdf_craft.sequence.chapter import AssetLayout, ParagraphLayout
 from pdf_craft.sequence.chapter import InlineExpression
 from pdf_craft.sequence.jointer import (
@@ -655,6 +655,51 @@ class TestParseLineContent(unittest.TestCase):
         assert isinstance(result[1], InlineExpression)
         self.assertEqual(result[1].content, r"\int_0^\infty e^{-x^2} dx")
         self.assertEqual(result[2], " converges")
+
+    def test_inline_formula_with_angle_brackets(self):
+        """测试公式内的 < 不会被 HTML 解析破坏边界"""
+        result = _parse_block_content(
+            r"A non-trivial zero of $ L(s,\chi) $ is any $ s\in C $ "
+            r"such that $ L(s,\chi)=0 $ and $ 0<\Re(s)<1 $ . "
+            r"(In particular, a zero at s=0 is called “trivial”.)"
+        )
+        formulas = [item for item in result if isinstance(item, InlineExpression)]
+        texts = [item for item in result if isinstance(item, str)]
+
+        self.assertEqual(
+            [formula.content for formula in formulas],
+            [r" L(s,\chi) ", r" s\in C ", r" L(s,\chi)=0 ", r" 0<\Re(s)<1 "],
+        )
+        self.assertTrue(
+            any(
+                "(In particular, a zero at s=0 is called “trivial”.)" in text
+                for text in texts
+            )
+        )
+
+    def test_latex_protection_keeps_html_table_parsing(self):
+        """测试保护公式时不回退 HTML/table 解析"""
+        result = _parse_block_content(
+            r"<table><tr><td>$ 0<\Re(s)<1 $</td></tr></table>"
+        )
+
+        self.assertEqual(len(result), 1)
+        table = result[0]
+        self.assertIsInstance(table, HTMLTag)
+        assert isinstance(table, HTMLTag)
+        self.assertEqual(table.definition.name, "table")
+        row = table.children[0]
+        self.assertIsInstance(row, HTMLTag)
+        assert isinstance(row, HTMLTag)
+        cell = row.children[0]
+        self.assertIsInstance(cell, HTMLTag)
+        assert isinstance(cell, HTMLTag)
+        self.assertEqual(cell.definition.name, "td")
+        self.assertEqual(len(cell.children), 1)
+        expression = cell.children[0]
+        self.assertIsInstance(expression, InlineExpression)
+        assert isinstance(expression, InlineExpression)
+        self.assertEqual(expression.content, r" 0<\Re(s)<1 ")
 
 
 def _page_layout(

--- a/tests/test_jointer.py
+++ b/tests/test_jointer.py
@@ -701,6 +701,25 @@ class TestParseLineContent(unittest.TestCase):
         assert isinstance(expression, InlineExpression)
         self.assertEqual(expression.content, r" 0<\Re(s)<1 ")
 
+    def test_literal_latex_placeholder_text_without_formula(self):
+        """测试普通文本中的占位符形状内容不会被当作公式"""
+        text = "\uE000PDF_CRAFT_LATEX_0_0\uE001"
+        result = _parse_block_content(text)
+
+        self.assertEqual(result, [text])
+
+    def test_literal_latex_placeholder_text_with_formula(self):
+        """测试普通占位符形状文本和真实公式不会互相串扰"""
+        literal = "\uE000PDF_CRAFT_LATEX_0_0\uE001"
+        result = _parse_block_content(f"{literal} and $x<y$")
+
+        self.assertEqual(len(result), 2)
+        self.assertEqual(result[0], literal + " and ")
+        expression = result[1]
+        self.assertIsInstance(expression, InlineExpression)
+        assert isinstance(expression, InlineExpression)
+        self.assertEqual(expression.content, "x<y")
+
 
 def _page_layout(
     ref: str,


### PR DESCRIPTION
## Summary
- protect parsed LaTeX spans with private placeholders before running Markdown/HTML parsing
- restore placeholders to InlineExpression nodes inside parsed text nodes
- add regression coverage for inline formulas containing bare angle brackets and formulas inside HTML table cells

## Verification
- poetry run pyright pdf_craft tests
- poetry run pylint pdf_craft tests
- poetry run python test.py
- poetry run python -m unittest tests.test_jointer