### PR TITLE
chore(release): add manual release workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -26,6 +26,7 @@ jobs:
         uses: actions/checkout@v4
         with:
           fetch-depth: 0
+          persist-credentials: false
 
       - name: Set up Python
         uses: actions/setup-python@v5
@@ -101,12 +102,13 @@ jobs:
 
       - name: Push release tag
         env:
+          GITHUB_TOKEN: ${{ github.token }}
           TAG: ${{ steps.release-inputs.outputs.tag }}
         run: |
           git config user.name "github-actions[bot]"
           git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
           git tag "${TAG}" "${GITHUB_SHA}"
-          git push origin "${TAG}"
+          git push "https://x-access-token:${GITHUB_TOKEN}@github.com/${GITHUB_REPOSITORY}.git" "${TAG}"
 
       - name: Create GitHub Release
         env:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,120 @@
+name: Release
+
+on:
+  workflow_dispatch:
+    inputs:
+      version:
+        description: "Version to release, without the leading v. Example: 1.0.14"
+        required: true
+        type: string
+
+permissions:
+  contents: write
+  id-token: write
+
+concurrency:
+  group: release
+  cancel-in-progress: false
+
+jobs:
+  release:
+    runs-on: ubuntu-latest
+    environment: pypi
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: "3.11"
+
+      - name: Setup Poetry
+        uses: abatilo/actions-poetry@v3
+        with:
+          poetry-version: "2.1.3"
+
+      - name: Configure Poetry
+        run: |
+          poetry config virtualenvs.create true
+          poetry config virtualenvs.in-project true
+
+      - name: Check release inputs
+        env:
+          VERSION: ${{ inputs.version }}
+        run: |
+          set -euo pipefail
+
+          if [[ "${GITHUB_REF}" != "refs/heads/main" ]]; then
+            echo "Release workflow must run from main. Current ref: ${GITHUB_REF}"
+            exit 1
+          fi
+
+          if [[ ! "${VERSION}" =~ ^[0-9]+\.[0-9]+\.[0-9]+([A-Za-z0-9.-]+)?$ ]]; then
+            echo "Version must be provided without the leading v, for example: 1.0.14"
+            exit 1
+          fi
+
+          TAG="v${VERSION}"
+          PROJECT_VERSION="$(poetry version -s)"
+          CHANGELOG_PATH="docs/changelog/${TAG}.md"
+
+          if [[ "${PROJECT_VERSION}" != "${VERSION}" ]]; then
+            echo "pyproject.toml version is ${PROJECT_VERSION}, expected ${VERSION}"
+            exit 1
+          fi
+
+          if [[ ! -s "${CHANGELOG_PATH}" ]]; then
+            echo "Missing or empty changelog: ${CHANGELOG_PATH}"
+            exit 1
+          fi
+
+          if git ls-remote --exit-code --tags origin "refs/tags/${TAG}" >/dev/null 2>&1; then
+            echo "Remote tag already exists: ${TAG}"
+            exit 1
+          fi
+
+          echo "tag=${TAG}" >> "${GITHUB_OUTPUT}"
+          echo "changelog_path=${CHANGELOG_PATH}" >> "${GITHUB_OUTPUT}"
+        id: release-inputs
+
+      - name: Install dependencies
+        run: poetry install --with dev
+
+      - name: Run pyright checking
+        run: poetry run pyright pdf_craft tests
+
+      - name: Run linting
+        run: poetry run pylint pdf_craft tests
+
+      - name: Run tests
+        run: poetry run python test.py
+
+      - name: Build package
+        run: poetry build
+
+      - name: Publish to PyPI
+        uses: pypa/gh-action-pypi-publish@release/v1
+
+      - name: Push release tag
+        env:
+          TAG: ${{ steps.release-inputs.outputs.tag }}
+        run: |
+          git config user.name "github-actions[bot]"
+          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+          git tag "${TAG}" "${GITHUB_SHA}"
+          git push origin "${TAG}"
+
+      - name: Create GitHub Release
+        env:
+          GH_TOKEN: ${{ github.token }}
+          TAG: ${{ steps.release-inputs.outputs.tag }}
+          CHANGELOG_PATH: ${{ steps.release-inputs.outputs.changelog_path }}
+        run: |
+          gh release create "${TAG}" dist/* \
+            --title "${TAG}" \
+            --notes-file "${CHANGELOG_PATH}" \
+            --verify-tag

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -16,6 +16,7 @@ pdf-craft 是一个把扫描书籍 PDF 转换为 Markdown 或 EPUB 的 Python �
 - 当需要判断模块归属、公共 API 边界或新代码应放在哪里时，阅读[架构与模块边界](references/architecture.md)。
 - 当修改 PDF 提取、OCR 归一化、缓存 XML 产物、目录生成、章节生成、Markdown 渲染或 EPUB 渲染时，阅读[转换流水线](references/conversion-pipeline.md)。
 - 当选择 setup、验证、worktree 行为、发布或外部依赖处理方式时，阅读[开发与 Worktree](references/development-and-worktrees.md)。
+- 当准备发版、更新版本号、编写 changelog 或调整发布流程时，阅读[发版流程](references/release-workflow.md)。
 
 ## 项目特有默认规则
 

--- a/docs/RELEASE.md
+++ b/docs/RELEASE.md
@@ -1,19 +1,36 @@
-# how to release
+# Release
 
-## 1. Configure PyPI token (first time only)
+Releases are published by the manual GitHub Actions release workflow. Do not publish the package from a local machine.
 
-```shell
-poetry config pypi-token.pypi $PYPI_TOKEN
+## 1. Configure PyPI trusted publishing
+
+This is required once for the PyPI project.
+
+Configure the PyPI trusted publisher for this repository:
+
+- PyPI project: `pdf-craft`
+- GitHub owner: `oomol-lab`
+- GitHub repository: `pdf-craft`
+- Workflow: `release.yml`
+- Environment: `pypi`
+
+## 2. Prepare a release PR
+
+For a target version such as `1.0.14`, prepare and merge a PR that includes:
+
+- `pyproject.toml` version set to `1.0.14`
+- `docs/changelog/v1.0.14.md` with the release notes
+
+Use the existing files in `docs/changelog/` as the changelog style reference.
+
+## 3. Run the release workflow
+
+After the release PR is merged to `main`, open the GitHub Actions `Release` workflow and run it manually from `main`.
+
+Enter the version without the leading `v`, for example:
+
+```text
+1.0.14
 ```
 
-## 2. Build the package
-
-```shell
-poetry build
-```
-
-## 3. Publish to PyPI
-
-```shell
-poetry publish
-```
+The workflow checks that the repository is ready, builds the package, publishes it to PyPI, pushes the `v1.0.14` tag, and creates the GitHub Release using `docs/changelog/v1.0.14.md` as the release notes.

--- a/references/release-workflow.md
+++ b/references/release-workflow.md
@@ -1,0 +1,39 @@
+# Release Workflow
+
+**Scope:** release preparation, version alignment, changelog expectations, and the repository state required by the manual GitHub Actions release workflow. **Out of scope:** conversion internals, dependency upgrades unrelated to a release, and manual PyPI publishing.
+
+## Release Model
+
+Releases are executed by the manual GitHub Actions release workflow. The repository must be prepared before that workflow runs. The workflow is the release gate: it checks that the requested version matches the repository state, publishes the package to PyPI, pushes the version tag, and creates the GitHub Release using the changelog file as the release notes.
+
+Agent work should focus on preparing the release prerequisites in the repository. Do not publish to PyPI manually, create release tags manually, or create GitHub Releases manually as part of release preparation.
+
+## Preparing a Release
+
+For a target version `X.Y.Z`, prepare the repository so these facts are true:
+
+- [pyproject.toml](../pyproject.toml) has `tool.poetry.version = "X.Y.Z"`.
+- `docs/changelog/vX.Y.Z.md` exists and contains the release notes.
+- The changelog includes a concise summary, grouped changes when useful, linked PRs/issues when available, and a full changelog compare link.
+- The release preparation changes are reviewed through the normal PR path before the manual release workflow is run from `main`.
+
+Keep the release preparation PR focused. Do not combine release preparation with unrelated refactors or dependency changes unless the release is specifically about those changes.
+
+## Validation
+
+Use the normal lightweight validation surface for release preparation:
+
+```bash
+poetry run pyright pdf_craft tests
+poetry run pylint pdf_craft tests
+poetry run python test.py
+poetry build
+```
+
+If a validation step cannot be run locally, state that clearly in the handoff.
+
+## Changelog Notes
+
+The GitHub Release body is read directly from `docs/changelog/vX.Y.Z.md` by the release workflow. Write changelog files as reader-facing release notes, not as internal implementation notes.
+
+Use the existing changelog files in `docs/changelog/` as the style reference. The release title and tag use the `vX.Y.Z` form.

--- a/references/release-workflow.md
+++ b/references/release-workflow.md
@@ -1,27 +1,27 @@
-# Release Workflow
+# 发版流程
 
-**Scope:** release preparation, version alignment, changelog expectations, and the repository state required by the manual GitHub Actions release workflow. **Out of scope:** conversion internals, dependency upgrades unrelated to a release, and manual PyPI publishing.
+**约束范围：** 发版准备、版本号对齐、变更日志要求，以及手动 GitHub Actions 发版工作流所需的仓库状态。**不约束：** 转换内部逻辑、与发版无关的依赖升级，以及手动发布 PyPI。
 
-## Release Model
+## 发版模型
 
-Releases are executed by the manual GitHub Actions release workflow. The repository must be prepared before that workflow runs. The workflow is the release gate: it checks that the requested version matches the repository state, publishes the package to PyPI, pushes the version tag, and creates the GitHub Release using the changelog file as the release notes.
+发版由手动触发的 GitHub Actions 发版工作流执行。在运行该工作流之前，仓库必须先完成准备。该工作流是发版关口：它会检查请求发版的版本号是否与仓库状态一致，发布包到 PyPI，推送版本标签，并使用变更日志文件作为发布说明创建 GitHub Release。
 
-Agent work should focus on preparing the release prerequisites in the repository. Do not publish to PyPI manually, create release tags manually, or create GitHub Releases manually as part of release preparation.
+Agent 的工作应聚焦于准备仓库内的发版前置条件。发版准备过程中，不要手动发布 PyPI，不要手动创建 release tag，也不要手动创建 GitHub Release。
 
-## Preparing a Release
+## 准备发版
 
-For a target version `X.Y.Z`, prepare the repository so these facts are true:
+对于目标版本 `X.Y.Z`，准备仓库时要确保以下事实成立：
 
-- [pyproject.toml](../pyproject.toml) has `tool.poetry.version = "X.Y.Z"`.
-- `docs/changelog/vX.Y.Z.md` exists and contains the release notes.
-- The changelog includes a concise summary, grouped changes when useful, linked PRs/issues when available, and a full changelog compare link.
-- The release preparation changes are reviewed through the normal PR path before the manual release workflow is run from `main`.
+- [pyproject.toml](../pyproject.toml) 中有 `tool.poetry.version = "X.Y.Z"`。
+- `docs/changelog/vX.Y.Z.md` 存在，并包含发布说明。
+- 变更日志应包含简洁摘要；在有帮助时按类别组织变更；在可取得时链接相关 PR 或 issue；并包含完整变更日志的 compare 链接。
+- 发版准备变更应先通过普通 PR 流程审查，再从 `main` 运行手动发版工作流。
 
-Keep the release preparation PR focused. Do not combine release preparation with unrelated refactors or dependency changes unless the release is specifically about those changes.
+发版准备 PR 应保持聚焦。不要把发版准备和无关重构或依赖变更混在一起，除非该版本本身就是围绕这些变更发布。
 
-## Validation
+## 验证
 
-Use the normal lightweight validation surface for release preparation:
+发版准备使用常规轻量验证面：
 
 ```bash
 poetry run pyright pdf_craft tests
@@ -30,10 +30,10 @@ poetry run python test.py
 poetry build
 ```
 
-If a validation step cannot be run locally, state that clearly in the handoff.
+如果某个验证步骤无法在本地运行，应在交接说明中明确写出。
 
-## Changelog Notes
+## 变更日志说明
 
-The GitHub Release body is read directly from `docs/changelog/vX.Y.Z.md` by the release workflow. Write changelog files as reader-facing release notes, not as internal implementation notes.
+发版工作流会直接读取 `docs/changelog/vX.Y.Z.md` 作为 GitHub Release 正文。变更日志文件应写成面向读者的发布说明，而不是内部实现说明。
 
-Use the existing changelog files in `docs/changelog/` as the style reference. The release title and tag use the `vX.Y.Z` form.
+使用 `docs/changelog/` 中已有变更日志文件作为风格参考。发布标题和版本标签使用 `vX.Y.Z` 形式。


### PR DESCRIPTION
## Summary
- add a manual GitHub Actions release workflow that validates version/changelog alignment, publishes to PyPI, tags the release, and creates the GitHub Release from the changelog
- add an agent-facing release preparation guide and route release work to it from AGENTS.md
- update the human release docs to use the GitHub Actions workflow instead of local publishing

## Validation
- ruby YAML parser loaded .github/workflows/release.yml
- poetry check
- git diff --check

Note: full pyright/pylint/test.py was not run because this change only touches release automation and documentation.