### PR TITLE
chore(release): prepare v1.0.14

### DIFF
--- a/docs/changelog/v1.0.14.md
+++ b/docs/changelog/v1.0.14.md
@@ -1,0 +1,43 @@
+This release adds sealed OCR configuration modes, improves OCR result compatibility for formulas and adjacent table captions, and prepares pdf-craft for VGE worktree-based development.
+
+## What's Changed
+
+### Features
+
+* **Sealed OCR configuration modes** in https://github.com/oomol-lab/pdf-craft/pull/371
+  - Added public OCR configuration objects for local DeepSeek OCR, vendor DeepSeek OCR, and vendor Unlimited OCR
+  - Keeps `doc-page-extractor` construction behind pdf-craft's public configuration surface
+  - Updated README and development documentation for the supported OCR modes
+
+### Bug Fixes
+
+* **Inline LaTeX formula parsing** in https://github.com/oomol-lab/pdf-craft/pull/373
+  - Preserves inline LaTeX before Markdown and HTML parsing can split formula text
+  - Adds regression coverage for formula-heavy OCR text
+
+* **Adjacent table caption joining** in https://github.com/oomol-lab/pdf-craft/commit/ad3c064
+  - Improves compatibility when OCR returns table titles, captions, or adjacent descriptive blocks as separate records
+  - Adds tests for table caption and description joining behavior
+
+* **VGE worktree environment inheritance** in https://github.com/oomol-lab/pdf-craft/pull/372
+  - Copies the source workspace `.env` into new worktrees when available
+  - Keeps vendor OCR credentials in private worktree configuration rather than committed files
+
+### Documentation and Release Workflow
+
+* Added VGE-oriented Agent documentation and worktree guidance in https://github.com/oomol-lab/pdf-craft/commit/82e4caf
+* Added the manual GitHub Actions release workflow in https://github.com/oomol-lab/pdf-craft/pull/375
+* Updated related project, OOMOL links, changelog, and maintenance coverage in https://github.com/oomol-lab/pdf-craft/pull/358, https://github.com/oomol-lab/pdf-craft/pull/359, https://github.com/oomol-lab/pdf-craft/pull/366, and https://github.com/oomol-lab/pdf-craft/pull/367
+
+## Pull Requests Included
+
+* https://github.com/oomol-lab/pdf-craft/pull/358
+* https://github.com/oomol-lab/pdf-craft/pull/359
+* https://github.com/oomol-lab/pdf-craft/pull/366
+* https://github.com/oomol-lab/pdf-craft/pull/367
+* https://github.com/oomol-lab/pdf-craft/pull/371
+* https://github.com/oomol-lab/pdf-craft/pull/372
+* https://github.com/oomol-lab/pdf-craft/pull/373
+* https://github.com/oomol-lab/pdf-craft/pull/375
+
+**Full Changelog**: https://github.com/oomol-lab/pdf-craft/compare/v1.0.13...v1.0.14

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "poetry.core.masonry.api"
 
 [tool.poetry]
 name = "pdf-craft"
-version = "1.0.13"
+version = "1.0.14"
 description = "PDF craft can convert PDF files into various other formats. This project will focus on processing PDF files of scanned books."
 license = "MIT"
 authors = ["Tao Zeyu <i@taozeyu.com>"]


### PR DESCRIPTION
## Summary
- bump pdf-craft version to 1.0.14
- add docs/changelog/v1.0.14.md for the GitHub Release body

## Validation
- git diff --check
- poetry check (passes with existing Poetry 2 metadata deprecation warnings)
- poetry run pyright pdf_craft tests
- poetry run pylint pdf_craft tests
- poetry run python test.py
- poetry build

## Release note
After this PR is merged to main, run the manual GitHub Actions Release workflow from main with version: 1.0.14