### PR TITLE
feat(ocr): support doc-page-extractor 1.2 backends

### DIFF
--- a/.env.template
+++ b/.env.template
@@ -1,32 +1,39 @@
-# Local private OCR settings. This file is gitignored; do not commit it.
+# Private OCR settings for scripts in this repository. This file is gitignored.
 #
-# The pdf-craft scripts can read either this upstream-compatible layout or the
-# newer PDF_CRAFT_* aliases. Prefer the adapter-specific keys below.
-
-# DeepSeek OCR via OpenAI-compatible Vendor.
-DOC_PAGE_EXTRACTOR_DEEPSEEK_VENDOR_BASE_URL=
-DOC_PAGE_EXTRACTOR_DEEPSEEK_VENDOR_API_KEY=
-DOC_PAGE_EXTRACTOR_DEEPSEEK_VENDOR_MODEL=deepseek-ocr
-DOC_PAGE_EXTRACTOR_DEEPSEEK_VENDOR_TEMPERATURE=0.0
-DOC_PAGE_EXTRACTOR_DEEPSEEK_VENDOR_TOP_P=0.7
-DOC_PAGE_EXTRACTOR_DEEPSEEK_VENDOR_MAX_TOKENS=8000
-DOC_PAGE_EXTRACTOR_DEEPSEEK_VENDOR_TIMEOUT_SECONDS=180
-
-# Baidu Unlimited-OCR cloud backend.
-DOC_PAGE_EXTRACTOR_BAIDU_AK=
-DOC_PAGE_EXTRACTOR_BAIDU_SK=
-DOC_PAGE_EXTRACTOR_BAIDU_BASE_URL=https://aip.baidubce.com
-DOC_PAGE_EXTRACTOR_BAIDU_POLL_INTERVAL_SECONDS=2
-DOC_PAGE_EXTRACTOR_BAIDU_TIMEOUT_SECONDS=180
+# OCR_MODE:
+# deepseek-ocr-local, deepseek-ocr2-local, unlimited-ocr-local,
+# deepseek-ocr-vendor, deepseek-ocr2-vendor, unlimited-ocr-vendor
+OCR_MODE=deepseek-ocr-local
 
 # DeepSeek local Hugging Face backend. Used only when explicitly testing CUDA.
-DOC_PAGE_EXTRACTOR_MODEL_PATH=./models-cache
-DOC_PAGE_EXTRACTOR_LOCAL_ONLY=true
+DEEPSEEK_LOCAL_MODEL_PATH=./models-cache
+DEEPSEEK_LOCAL_ONLY=true
 
-# Legacy compatibility for old scripts; prefer the adapter-specific keys above.
-DOC_PAGE_EXTRACTOR_BACKEND=vendor
-DOC_PAGE_EXTRACTOR_VENDOR_BASE_URL=
-DOC_PAGE_EXTRACTOR_VENDOR_API_KEY=
-DOC_PAGE_EXTRACTOR_VENDOR_MODEL=deepseek-ocr
-DOC_PAGE_EXTRACTOR_VENDOR_TEMPERATURE=0.0
-DOC_PAGE_EXTRACTOR_VENDOR_TOP_P=0.7
+# Unlimited OCR local Hugging Face backend. Used only when explicitly testing CUDA.
+UNLIMITED_LOCAL_MODEL_PATH=./models-cache
+UNLIMITED_LOCAL_ONLY=true
+
+# DeepSeek OCR through an OpenAI-compatible endpoint.
+DEEPSEEK_OCR_BASE_URL=
+DEEPSEEK_OCR_API_KEY=
+DEEPSEEK_OCR_MODEL=deepseek-ocr
+DEEPSEEK_OCR_TEMPERATURE=0.0
+DEEPSEEK_OCR_TOP_P=0.7
+DEEPSEEK_OCR_MAX_TOKENS=8000
+DEEPSEEK_OCR_TIMEOUT_SECONDS=180
+
+# DeepSeek OCR 2 through an OpenAI-compatible endpoint.
+DEEPSEEK_OCR2_BASE_URL=
+DEEPSEEK_OCR2_API_KEY=
+DEEPSEEK_OCR2_MODEL=
+DEEPSEEK_OCR2_TEMPERATURE=0.0
+DEEPSEEK_OCR2_TOP_P=0.7
+DEEPSEEK_OCR2_MAX_TOKENS=8000
+DEEPSEEK_OCR2_TIMEOUT_SECONDS=180
+
+# Unlimited OCR cloud backend.
+UNLIMITED_OCR_ACCESS_KEY=
+UNLIMITED_OCR_SECRET_KEY=
+UNLIMITED_OCR_BASE_URL=https://aip.baidubce.com
+UNLIMITED_OCR_POLL_INTERVAL_SECONDS=2
+UNLIMITED_OCR_TIMEOUT_SECONDS=180

--- a/README.md
+++ b/README.md
@@ -39,7 +39,7 @@ pip install torch torchvision --index-url https://download.pytorch.org/whl/cpu
 pip install pdf-craft
 ```
 
-The above commands are for quick setup only. To actually use pdf-craft, you need to **install Poppler** for PDF parsing (required for all use cases) and **configure a CUDA environment** for OCR recognition (required for actual conversion). Please refer to the [Installation Guide](docs/INSTALLATION.md) for detailed instructions.
+The above commands are for quick setup only. To actually use pdf-craft, you need to **install Poppler** for PDF parsing. Local OCR also requires a CUDA-capable PyTorch environment; vendor OCR does not. Please refer to the [Installation Guide](docs/INSTALLATION.md) for detailed instructions.
 
 ### Quick Start
 
@@ -79,7 +79,7 @@ transform_epub(
 ### Convert to Markdown
 
 ```python
-from pdf_craft import LocalDeepSeekOCRConfig, transform_markdown
+from pdf_craft import DeepSeekOCRLocalConfig, transform_markdown
 
 transform_markdown(
     pdf_path="input.pdf",
@@ -87,7 +87,7 @@ transform_markdown(
     markdown_assets_path="images",
     analysing_path="temp",  # Optional: specify temporary folder
     ocr_size="gundam",  # Optional: tiny, small, base, large, gundam
-    ocr=LocalDeepSeekOCRConfig(models_cache_path="models"),
+    ocr=DeepSeekOCRLocalConfig(models_cache_path="models"),
     dpi=300,  # Optional: DPI for rendering PDF pages (default: 300)
     max_page_image_file_size=None,  # Optional: max image file size in bytes, auto-adjust DPI if exceeded
     includes_cover=False,  # Optional: include cover
@@ -106,7 +106,7 @@ transform_markdown(
 from pdf_craft import (
     BookMeta,
     LaTeXRender,
-    LocalDeepSeekOCRConfig,
+    DeepSeekOCRLocalConfig,
     TableRender,
     transform_epub,
 )
@@ -116,7 +116,7 @@ transform_epub(
     epub_path="output.epub",
     analysing_path="temp",  # Optional: specify temporary folder
     ocr_size="gundam",  # Optional: tiny, small, base, large, gundam
-    ocr=LocalDeepSeekOCRConfig(models_cache_path="models"),
+    ocr=DeepSeekOCRLocalConfig(models_cache_path="models"),
     dpi=300,  # Optional: DPI for rendering PDF pages (default: 300)
     max_page_image_file_size=None,  # Optional: max image file size in bytes, auto-adjust DPI if exceeded
     includes_cover=True,  # Optional: include cover
@@ -141,25 +141,31 @@ transform_epub(
 
 ### OCR Configuration
 
-pdf-craft supports three OCR configurations:
+pdf-craft supports every OCR backend exposed by `doc-page-extractor`:
 
-- `LocalDeepSeekOCRConfig`: local DeepSeek-OCR model. Real conversion requires CUDA.
-- `VendorDeepSeekOCRConfig`: DeepSeek OCR through an OpenAI-compatible endpoint.
-- `VendorUnlimitedOCRConfig`: Baidu Unlimited OCR.
+- `DeepSeekOCRLocalConfig`: local DeepSeek OCR model. Real conversion requires CUDA.
+- `DeepSeekOCR2LocalConfig`: local DeepSeek OCR 2 model. Real conversion requires CUDA.
+- `UnlimitedOCRLocalConfig`: local Unlimited OCR model. Real conversion requires CUDA.
+- `DeepSeekOCRVendorConfig`: DeepSeek OCR through an OpenAI-compatible endpoint.
+- `DeepSeekOCR2VendorConfig`: DeepSeek OCR 2 through an OpenAI-compatible endpoint.
+- `UnlimitedOCRVendorConfig`: Unlimited OCR cloud backend.
 
-Pass one of these configs through the `ocr` parameter:
+Pass one of these configs through the `ocr` parameter. The OCR mode strings are
+`deepseek-ocr-local`, `deepseek-ocr2-local`, `unlimited-ocr-local`,
+`deepseek-ocr-vendor`, `deepseek-ocr2-vendor`, and `unlimited-ocr-vendor`.
 
 ```python
 from pdf_craft import (
-    VendorDeepSeekOCRConfig,
-    VendorUnlimitedOCRConfig,
+    DeepSeekOCR2VendorConfig,
+    DeepSeekOCRVendorConfig,
+    UnlimitedOCRVendorConfig,
     transform_markdown,
 )
 
 transform_markdown(
     pdf_path="input.pdf",
     markdown_path="output.md",
-    ocr=VendorDeepSeekOCRConfig(
+    ocr=DeepSeekOCRVendorConfig(
         base_url="https://example.com",
         api_key="...",
         model="deepseek-ocr",
@@ -169,28 +175,39 @@ transform_markdown(
 transform_markdown(
     pdf_path="input.pdf",
     markdown_path="output.md",
-    ocr=VendorUnlimitedOCRConfig(
+    ocr=DeepSeekOCR2VendorConfig(
+        base_url="https://example.com",
+        api_key="...",
+        model="deepseek-ocr2",
+    ),
+)
+
+transform_markdown(
+    pdf_path="input.pdf",
+    markdown_path="output.md",
+    ocr=UnlimitedOCRVendorConfig(
         ak="...",
         sk="...",
     ),
 )
 ```
 
-The legacy `models_cache_path` and `local_only` parameters are still accepted and map to `LocalDeepSeekOCRConfig`. Do not combine them with `ocr`.
-
 ### Model Management
 
-Local DeepSeek OCR models are automatically downloaded from Hugging Face on first run. You can control model storage and loading behavior through `LocalDeepSeekOCRConfig`.
+Local OCR models are automatically downloaded from Hugging Face on first run.
+You can control model storage and loading behavior through the local OCR
+configs. Unlimited OCR local supports the `base` and `gundam` `ocr_size`
+presets.
 
 #### Pre-download Models
 
 In production environments, it is recommended to download models in advance to avoid downloading on first run:
 
 ```python
-from pdf_craft import LocalDeepSeekOCRConfig, predownload_models
+from pdf_craft import DeepSeekOCRLocalConfig, predownload_models
 
 predownload_models(
-    ocr=LocalDeepSeekOCRConfig(models_cache_path="models"),
+    ocr=DeepSeekOCRLocalConfig(models_cache_path="models"),
     revision=None,  # Optional: specify model version
 )
 ```
@@ -200,12 +217,12 @@ predownload_models(
 By default, models are downloaded to the system's Hugging Face cache directory. You can customize the cache location through the `models_cache_path` parameter:
 
 ```python
-from pdf_craft import LocalDeepSeekOCRConfig, transform_markdown
+from pdf_craft import DeepSeekOCRLocalConfig, transform_markdown
 
 transform_markdown(
     pdf_path="input.pdf",
     markdown_path="output.md",
-    ocr=LocalDeepSeekOCRConfig(models_cache_path="./my_models"),
+    ocr=DeepSeekOCRLocalConfig(models_cache_path="./my_models"),
 )
 ```
 
@@ -214,12 +231,12 @@ transform_markdown(
 If you have pre-downloaded the models, you can use `local_only=True` to disable network downloads and ensure only local models are used:
 
 ```python
-from pdf_craft import LocalDeepSeekOCRConfig, transform_markdown
+from pdf_craft import DeepSeekOCRLocalConfig, transform_markdown
 
 transform_markdown(
     pdf_path="input.pdf",
     markdown_path="output.md",
-    ocr=LocalDeepSeekOCRConfig(
+    ocr=DeepSeekOCRLocalConfig(
         models_cache_path="./my_models",
         local_only=True,
     ),

--- a/README.md
+++ b/README.md
@@ -153,6 +153,9 @@ pdf-craft supports every OCR backend exposed by `doc-page-extractor`:
 Pass one of these configs through the `ocr` parameter. The OCR mode strings are
 `deepseek-ocr-local`, `deepseek-ocr2-local`, `unlimited-ocr-local`,
 `deepseek-ocr-vendor`, `deepseek-ocr2-vendor`, and `unlimited-ocr-vendor`.
+They are used only by this repository's manual scripts through `.env`; the
+library API accepts configuration objects and does not read environment
+variables.
 
 ```python
 from pdf_craft import (
@@ -194,7 +197,11 @@ transform_markdown(
 
 ### Model Management
 
-Local OCR models are automatically downloaded from Hugging Face on first run.
+Local OCR models are automatically downloaded from Hugging Face on first run
+when `local_only=False` (the default for the library configuration objects).
+The repository's manual scripts default `DEEPSEEK_LOCAL_ONLY` and
+`UNLIMITED_LOCAL_ONLY` to `true`, so set the relevant variable to `false` to
+allow a missing model to download.
 You can control model storage and loading behavior through the local OCR
 configs. Unlimited OCR local supports the `base` and `gundam` `ocr_size`
 presets.

--- a/README_zh-CN.md
+++ b/README_zh-CN.md
@@ -39,7 +39,7 @@ pip install torch torchvision --index-url https://download.pytorch.org/whl/cpu
 pip install pdf-craft
 ```
 
-上述命令仅用于快速安装。要真正使用 pdf-craft，你需要**安装 Poppler** 用于 PDF 解析（所有使用场景都需要）以及**配置 CUDA 环境**用于 OCR 识别（实际转换时需要）。详细说明请参考[安装指南](docs/INSTALLATION_zh-CN.md)。
+上述命令仅用于快速安装。要真正使用 pdf-craft，你需要**安装 Poppler** 用于 PDF 解析。本地 OCR 还需要支持 CUDA 的 PyTorch 环境；供应商 OCR 不需要本地 CUDA。详细说明请参考[安装指南](docs/INSTALLATION_zh-CN.md)。
 
 ### 快速开始
 
@@ -79,7 +79,7 @@ transform_epub(
 ### 转换为 Markdown
 
 ```python
-from pdf_craft import LocalDeepSeekOCRConfig, transform_markdown
+from pdf_craft import DeepSeekOCRLocalConfig, transform_markdown
 
 transform_markdown(
     pdf_path="input.pdf",
@@ -87,7 +87,7 @@ transform_markdown(
     markdown_assets_path="images",
     analysing_path="temp",  # 可选：指定临时文件夹
     ocr_size="gundam",  # 可选：tiny, small, base, large, gundam
-    ocr=LocalDeepSeekOCRConfig(models_cache_path="models"),
+    ocr=DeepSeekOCRLocalConfig(models_cache_path="models"),
     dpi=300,  # 可选：渲染 PDF 页面的 DPI（默认：300）
     max_page_image_file_size=None,  # 可选：最大图像文件大小（字节），超出时自动调整 DPI
     includes_cover=False,  # 可选：包含封面
@@ -106,7 +106,7 @@ transform_markdown(
 from pdf_craft import (
     BookMeta,
     LaTeXRender,
-    LocalDeepSeekOCRConfig,
+    DeepSeekOCRLocalConfig,
     TableRender,
     transform_epub,
 )
@@ -116,7 +116,7 @@ transform_epub(
     epub_path="output.epub",
     analysing_path="temp",  # 可选：指定临时文件夹
     ocr_size="gundam",  # 可选：tiny, small, base, large, gundam
-    ocr=LocalDeepSeekOCRConfig(models_cache_path="models"),
+    ocr=DeepSeekOCRLocalConfig(models_cache_path="models"),
     dpi=300,  # 可选：渲染 PDF 页面的 DPI（默认：300）
     max_page_image_file_size=None,  # 可选：最大图像文件大小（字节），超出时自动调整 DPI
     includes_cover=True,  # 可选：包含封面
@@ -141,25 +141,31 @@ transform_epub(
 
 ### OCR 配置
 
-pdf-craft 支持三种 OCR 配置：
+pdf-craft 支持 `doc-page-extractor` 提供的全部 OCR 后端：
 
-- `LocalDeepSeekOCRConfig`：本地 DeepSeek-OCR 模型。真实转换需要 CUDA。
-- `VendorDeepSeekOCRConfig`：通过 OpenAI-compatible endpoint 使用 DeepSeek OCR。
-- `VendorUnlimitedOCRConfig`：百度 Unlimited OCR。
+- `DeepSeekOCRLocalConfig`：本地 DeepSeek OCR 模型。真实转换需要 CUDA。
+- `DeepSeekOCR2LocalConfig`：本地 DeepSeek OCR 2 模型。真实转换需要 CUDA。
+- `UnlimitedOCRLocalConfig`：本地 Unlimited OCR 模型。真实转换需要 CUDA。
+- `DeepSeekOCRVendorConfig`：通过 OpenAI-compatible endpoint 使用 DeepSeek OCR。
+- `DeepSeekOCR2VendorConfig`：通过 OpenAI-compatible endpoint 使用 DeepSeek OCR 2。
+- `UnlimitedOCRVendorConfig`：Unlimited OCR 云端后端。
 
-通过 `ocr` 参数传入其中一种配置：
+通过 `ocr` 参数传入其中一种配置。OCR mode 字符串为
+`deepseek-ocr-local`、`deepseek-ocr2-local`、`unlimited-ocr-local`、
+`deepseek-ocr-vendor`、`deepseek-ocr2-vendor` 和 `unlimited-ocr-vendor`。
 
 ```python
 from pdf_craft import (
-    VendorDeepSeekOCRConfig,
-    VendorUnlimitedOCRConfig,
+    DeepSeekOCR2VendorConfig,
+    DeepSeekOCRVendorConfig,
+    UnlimitedOCRVendorConfig,
     transform_markdown,
 )
 
 transform_markdown(
     pdf_path="input.pdf",
     markdown_path="output.md",
-    ocr=VendorDeepSeekOCRConfig(
+    ocr=DeepSeekOCRVendorConfig(
         base_url="https://example.com",
         api_key="...",
         model="deepseek-ocr",
@@ -169,28 +175,38 @@ transform_markdown(
 transform_markdown(
     pdf_path="input.pdf",
     markdown_path="output.md",
-    ocr=VendorUnlimitedOCRConfig(
+    ocr=DeepSeekOCR2VendorConfig(
+        base_url="https://example.com",
+        api_key="...",
+        model="deepseek-ocr2",
+    ),
+)
+
+transform_markdown(
+    pdf_path="input.pdf",
+    markdown_path="output.md",
+    ocr=UnlimitedOCRVendorConfig(
         ak="...",
         sk="...",
     ),
 )
 ```
 
-旧的 `models_cache_path` 和 `local_only` 参数仍然可用，并映射为 `LocalDeepSeekOCRConfig`。不要把它们和 `ocr` 同时传入。
-
 ### 模型管理
 
-本地 DeepSeek OCR 模型首次运行时会自动从 Hugging Face 下载。你可以通过 `LocalDeepSeekOCRConfig` 控制模型的存储和加载行为。
+本地 OCR 模型首次运行时会自动从 Hugging Face 下载。你可以通过本地 OCR
+配置控制模型的存储和加载行为。Unlimited OCR local 仅支持 `base` 和
+`gundam` 这两个 `ocr_size` preset。
 
 #### 预下载模型
 
 在生产环境中，建议提前下载模型，避免首次运行时下载：
 
 ```python
-from pdf_craft import LocalDeepSeekOCRConfig, predownload_models
+from pdf_craft import DeepSeekOCRLocalConfig, predownload_models
 
 predownload_models(
-    ocr=LocalDeepSeekOCRConfig(models_cache_path="models"),
+    ocr=DeepSeekOCRLocalConfig(models_cache_path="models"),
     revision=None,  # 可选：指定模型版本
 )
 ```
@@ -200,12 +216,12 @@ predownload_models(
 默认情况下，模型会下载到系统的 Hugging Face 缓存目录。你可以通过 `models_cache_path` 参数自定义缓存位置：
 
 ```python
-from pdf_craft import LocalDeepSeekOCRConfig, transform_markdown
+from pdf_craft import DeepSeekOCRLocalConfig, transform_markdown
 
 transform_markdown(
     pdf_path="input.pdf",
     markdown_path="output.md",
-    ocr=LocalDeepSeekOCRConfig(models_cache_path="./my_models"),
+    ocr=DeepSeekOCRLocalConfig(models_cache_path="./my_models"),
 )
 ```
 
@@ -214,12 +230,12 @@ transform_markdown(
 如果你已经预先下载了模型，可以使用 `local_only=True` 禁止网络下载，确保仅使用本地模型：
 
 ```python
-from pdf_craft import LocalDeepSeekOCRConfig, transform_markdown
+from pdf_craft import DeepSeekOCRLocalConfig, transform_markdown
 
 transform_markdown(
     pdf_path="input.pdf",
     markdown_path="output.md",
-    ocr=LocalDeepSeekOCRConfig(
+    ocr=DeepSeekOCRLocalConfig(
         models_cache_path="./my_models",
         local_only=True,
     ),

--- a/README_zh-CN.md
+++ b/README_zh-CN.md
@@ -153,6 +153,8 @@ pdf-craft 支持 `doc-page-extractor` 提供的全部 OCR 后端：
 通过 `ocr` 参数传入其中一种配置。OCR mode 字符串为
 `deepseek-ocr-local`、`deepseek-ocr2-local`、`unlimited-ocr-local`、
 `deepseek-ocr-vendor`、`deepseek-ocr2-vendor` 和 `unlimited-ocr-vendor`。
+这些字符串仅供本仓库的手动脚本通过 `.env` 使用；库 API 接收配置对象，
+不会读取环境变量。
 
 ```python
 from pdf_craft import (
@@ -194,9 +196,11 @@ transform_markdown(
 
 ### 模型管理
 
-本地 OCR 模型首次运行时会自动从 Hugging Face 下载。你可以通过本地 OCR
-配置控制模型的存储和加载行为。Unlimited OCR local 仅支持 `base` 和
-`gundam` 这两个 `ocr_size` preset。
+当 `local_only=False` 时（库配置对象的默认值），本地 OCR 模型首次运行会
+自动从 Hugging Face 下载。本仓库手动脚本中 `DEEPSEEK_LOCAL_ONLY` 和
+`UNLIMITED_LOCAL_ONLY` 默认均为 `true`；要下载缺失模型，请将相应变量设为
+`false`。你可以通过本地 OCR 配置控制模型的存储和加载行为。Unlimited OCR
+local 仅支持 `base` 和 `gundam` 这两个 `ocr_size` preset。
 
 #### 预下载模型
 

--- a/docs/DEVELOPMENT.md
+++ b/docs/DEVELOPMENT.md
@@ -7,10 +7,10 @@ This guide is for human contributors. Agent-facing project routing lives in `AGE
 - Python >= 3.11, < 3.14 (3.11.16 recommended)
 - Poetry 2.x
 - Poppler, only when running PDF rendering or conversion checks
-- PyTorch, installed from the lock file through `doc-page-extractor`
-- CUDA-capable PyTorch and an NVIDIA GPU, only when running real DeepSeek OCR conversion
+- PyTorch, installed through `doc-page-extractor[local]` for local OCR conversion
+- CUDA-capable PyTorch and an NVIDIA GPU, only when running real local OCR conversion
 
-The published `pdf-craft` package does not declare `torch` or `torchvision` directly, but the development lock file currently installs `torch` through `doc-page-extractor`. Override the PyTorch wheel only when you need a specific CPU or CUDA build.
+pdf-craft depends on `doc-page-extractor[local]`, so installs include the upstream local OCR runtime stack. pdf-craft still does not declare `torch` or `torchvision` directly; reinstall or override the PyTorch wheel when you need a specific CPU or CUDA build.
 
 ## Setup For Ordinary Development
 
@@ -33,7 +33,7 @@ poetry run pip install --force-reinstall torch torchvision --index-url https://d
 
 Real PDF conversion can run through either a local CUDA model or vendor OCR.
 
-Local DeepSeek OCR requires CUDA-capable PyTorch. If the default locked wheel is not the CUDA build you need, reinstall the PyTorch build that matches your system before running conversion scripts.
+Local OCR requires CUDA-capable PyTorch. Reinstall the PyTorch build that matches your system before running conversion scripts if the installed wheel does not match your CUDA environment.
 
 Examples:
 
@@ -61,7 +61,7 @@ poetry run python -c "import torch; print(f'PyTorch version: {torch.__version__}
 pdfinfo -v
 ```
 
-Vendor OCR does not require local CUDA. Copy `.env.template` to `.env`, set `PDF_CRAFT_OCR_MODE` to `vendor-deepseek` or `vendor-unlimited`, and fill the matching credentials. Library code does not automatically read `.env`; the manual scripts load it before calling `create_ocr_config_from_env()`.
+Vendor OCR does not require local CUDA. Copy `.env.template` to `.env`, set `OCR_MODE` to `deepseek-ocr-vendor`, `deepseek-ocr2-vendor`, or `unlimited-ocr-vendor`, and fill the matching credentials. Local modes use `DEEPSEEK_LOCAL_MODEL_PATH` and `DEEPSEEK_LOCAL_ONLY` for DeepSeek OCR / DeepSeek OCR 2, and `UNLIMITED_LOCAL_MODEL_PATH` and `UNLIMITED_LOCAL_ONLY` for Unlimited OCR. Library code does not automatically read `.env`; only the manual scripts load it.
 
 ## Validation
 
@@ -88,14 +88,14 @@ poetry build
 
 ## Manual Conversion Checks
 
-The scripts in `scripts/` are manual checks for conversion work. They require Poppler and an OCR configuration from `.env`. `local-deepseek` requires model downloads and CUDA; vendor modes require credentials:
+The scripts in `scripts/` are manual checks for conversion work. They require Poppler and an OCR configuration from `.env`. Local modes require model downloads and CUDA; vendor modes require credentials:
 
 ```shell
 poetry run python scripts/gen_md.py
 poetry run python scripts/gen_epub.py
 ```
 
-They write conversion output under `analysing/` and use `models-cache/` for local model storage when `PDF_CRAFT_OCR_MODE=local-deepseek`.
+They write conversion output under `analysing/` and use the configured local model path from `DEEPSEEK_LOCAL_MODEL_PATH` or `UNLIMITED_LOCAL_MODEL_PATH` when `OCR_MODE` is a local OCR mode.
 
 If `format.json` exists at the repository root, these scripts use it to configure optional LLM-enhanced TOC analysis. The template is `format.template.json`; do not commit local secrets.
 

--- a/docs/DEVELOPMENT_zh-CN.md
+++ b/docs/DEVELOPMENT_zh-CN.md
@@ -7,10 +7,10 @@
 - Python >= 3.11, < 3.14（推荐 3.11.16）
 - Poetry 2.x
 - Poppler，仅在运行 PDF 渲染或转换检查时需要
-- PyTorch，会通过 `doc-page-extractor` 从 lock file 安装
-- 支持 CUDA 的 PyTorch 和 NVIDIA GPU，仅在运行真实 DeepSeek OCR 转换时需要
+- PyTorch，通过 `doc-page-extractor[local]` 安装，用于本地 OCR 转换
+- 支持 CUDA 的 PyTorch 和 NVIDIA GPU，仅在运行真实本地 OCR 转换时需要
 
-发布的 `pdf-craft` 包不会直接声明 `torch` 或 `torchvision`，但开发 lock file 目前会通过 `doc-page-extractor` 安装 `torch`。只有需要指定 CPU 或 CUDA wheel 时，才覆盖安装 PyTorch。
+pdf-craft 依赖 `doc-page-extractor[local]`，因此安装时会包含上游本地 OCR 运行时栈。pdf-craft 仍不会直接声明 `torch` 或 `torchvision`；当你需要指定 CPU 或 CUDA 构建时，再重装或覆盖 PyTorch wheel。
 
 ## 普通开发环境
 
@@ -33,7 +33,7 @@ poetry run pip install --force-reinstall torch torchvision --index-url https://d
 
 真实 PDF 转换可以使用本地 CUDA 模型，也可以使用供应商 OCR。
 
-本地 DeepSeek OCR 需要支持 CUDA 的 PyTorch。如果默认锁定的 wheel 不是你需要的 CUDA 构建，运行转换脚本前请重装与系统匹配的 PyTorch 版本。
+本地 OCR 需要支持 CUDA 的 PyTorch。如果已安装的 wheel 与当前 CUDA 环境不匹配，运行转换脚本前请重装与系统匹配的 PyTorch 版本。
 
 示例：
 
@@ -61,7 +61,7 @@ poetry run python -c "import torch; print(f'PyTorch version: {torch.__version__}
 pdfinfo -v
 ```
 
-供应商 OCR 不需要本地 CUDA。复制 `.env.template` 为 `.env`，把 `PDF_CRAFT_OCR_MODE` 设为 `vendor-deepseek` 或 `vendor-unlimited`，再填写对应密钥。库代码不会自动读取 `.env`；手动脚本会先加载它，再调用 `create_ocr_config_from_env()`。
+供应商 OCR 不需要本地 CUDA。复制 `.env.template` 为 `.env`，把 `OCR_MODE` 设为 `deepseek-ocr-vendor`、`deepseek-ocr2-vendor` 或 `unlimited-ocr-vendor`，再填写对应密钥。本地模式使用 `DEEPSEEK_LOCAL_MODEL_PATH` 和 `DEEPSEEK_LOCAL_ONLY` 作为 DeepSeek OCR / DeepSeek OCR 2 的路径配置，使用 `UNLIMITED_LOCAL_MODEL_PATH` 和 `UNLIMITED_LOCAL_ONLY` 作为 Unlimited OCR 的路径配置。库代码不会自动读取 `.env`；只有手动脚本会加载它。
 
 ## 验证
 
@@ -88,14 +88,14 @@ poetry build
 
 ## 手动转换检查
 
-`scripts/` 中的脚本用于转换联调。它们需要 Poppler，并从 `.env` 读取 OCR 配置。`local-deepseek` 需要模型下载和 CUDA；供应商模式需要对应密钥：
+`scripts/` 中的脚本用于转换联调。它们需要 Poppler，并从 `.env` 读取 OCR 配置。本地模式需要模型下载和 CUDA；供应商模式需要对应密钥：
 
 ```shell
 poetry run python scripts/gen_md.py
 poetry run python scripts/gen_epub.py
 ```
 
-脚本会把转换结果写入 `analysing/`。当 `PDF_CRAFT_OCR_MODE=local-deepseek` 时，脚本使用 `models-cache/` 存放本地模型。
+脚本会把转换结果写入 `analysing/`。当 `OCR_MODE` 是本地 OCR 模式时，脚本使用 `DEEPSEEK_LOCAL_MODEL_PATH` 或 `UNLIMITED_LOCAL_MODEL_PATH` 指定的本地模型路径。
 
 如果仓库根目录存在 `format.json`，脚本会用它配置可选的 LLM 增强目录分析。模板是 `format.template.json`；不要提交本地密钥。
 

--- a/docs/INSTALLATION.md
+++ b/docs/INSTALLATION.md
@@ -4,16 +4,16 @@
 
 - Python >= 3.11, < 3.14 (3.11.16 recommended)
 - Poppler (required for PDF parsing and rendering)
-- NVIDIA GPU with CUDA 11.8 or 12.1 support
-- 16 GB or more VRAM (24 GB or higher recommended, see [DeepSeek OCR Hardware Requirements Discussion](https://huggingface.co/deepseek-ai/DeepSeek-OCR/discussions/31))
+- NVIDIA GPU with CUDA 11.8 or newer support, only when using local OCR
+- 16 GB or more VRAM for local OCR (24 GB or higher recommended for the largest DeepSeek OCR models)
 
 ## Installation Steps
 
-This project uses DeepSeek OCR for document recognition, which **must run in a CUDA environment**. If you need to actually use pdf-craft for PDF conversion, please follow the CUDA environment installation steps below.
+pdf-craft uses `doc-page-extractor` for document recognition. Vendor OCR backends do not require local CUDA; local OCR backends require a CUDA-capable PyTorch environment.
 
 If you only need to develop code, get IDE type hints, or read the source code, you can choose the CPU environment installation as an alternative, but it will not be able to perform actual OCR recognition.
 
-### CUDA Environment Installation (Recommended)
+### CUDA Environment Installation
 
 #### 1. Configure CUDA Environment
 
@@ -82,7 +82,7 @@ pip install torch torchvision --index-url https://download.pytorch.org/whl/cpu
 pip install pdf-craft
 ```
 
-**Note:** Even for development-only setups, you still need to install Poppler following step 4 above if you want to test PDF-related functionality.
+**Note:** Even for development-only setups, you still need to install Poppler following step 4 above if you want to test PDF-related functionality. For vendor OCR conversion, configure one of the vendor OCR configs in code or use `.env.template` with the manual scripts.
 
 ## Troubleshooting
 
@@ -96,7 +96,7 @@ If you encounter an error like "Poppler not found in PATH" when running pdf-craf
 
 ### CUDA Not Available Error
 
-When you try to use pdf-craft, if you see a RuntimeWarning similar to the following:
+When you try to use a local OCR config, if you see a RuntimeWarning similar to the following:
 
 ```
 CUDA is not available! This package requires CUDA to run,
@@ -107,7 +107,7 @@ This indicates that the CUDA environment is not properly configured. Possible re
 
 1. **Installed the CPU version of PyTorch** - Need to reinstall PyTorch with CUDA support following the CUDA environment installation steps above
 2. **NVIDIA driver is outdated or not installed** - Visit [NVIDIA Driver Download Page](https://www.nvidia.com/download/index.aspx) to update drivers
-3. **No CUDA-compatible GPU** - This project must run on NVIDIA GPUs
+3. **No CUDA-compatible GPU** - Local OCR must run on NVIDIA GPUs
 
 You can run the `nvidia-smi` command to check your system's GPU and driver status.
 

--- a/docs/INSTALLATION.md
+++ b/docs/INSTALLATION.md
@@ -11,7 +11,7 @@
 
 pdf-craft uses `doc-page-extractor` for document recognition. Vendor OCR backends do not require local CUDA; local OCR backends require a CUDA-capable PyTorch environment.
 
-If you only need to develop code, get IDE type hints, or read the source code, you can choose the CPU environment installation as an alternative, but it will not be able to perform actual OCR recognition.
+CPU environments cannot run local OCR. They can run vendor OCR when network access, valid credentials, and Poppler are available.
 
 ### CUDA Environment Installation
 
@@ -82,7 +82,7 @@ pip install torch torchvision --index-url https://download.pytorch.org/whl/cpu
 pip install pdf-craft
 ```
 
-**Note:** Even for development-only setups, you still need to install Poppler following step 4 above if you want to test PDF-related functionality. For vendor OCR conversion, configure one of the vendor OCR configs in code or use `.env.template` with the manual scripts.
+**Note:** Even for development-only setups, you still need to install Poppler following step 4 above if you want to test PDF-related functionality. For the repository's manual scripts, copy `.env.template` to `.env`, populate a vendor OCR configuration, and then run the script.
 
 ## Troubleshooting
 

--- a/docs/INSTALLATION_zh-CN.md
+++ b/docs/INSTALLATION_zh-CN.md
@@ -11,7 +11,7 @@
 
 pdf-craft 使用 `doc-page-extractor` 进行文档识别。供应商 OCR 后端不需要本地 CUDA；本地 OCR 后端需要支持 CUDA 的 PyTorch 环境。
 
-如果你仅需进行代码开发、IDE 类型提示或阅读源码，可以选择 CPU 环境安装作为替代方案，但无法执行实际的 OCR 识别。
+CPU 环境无法运行本地 OCR；在具备网络、有效凭据和 Poppler 时，仍可运行供应商 OCR。
 
 ### CUDA 环境安装
 
@@ -82,7 +82,7 @@ pip install torch torchvision --index-url https://download.pytorch.org/whl/cpu
 pip install pdf-craft
 ```
 
-**注意：** 即使是仅用于开发的环境，如果你想测试与 PDF 相关的功能，仍需按照上述步骤 4 安装 Poppler。如需使用供应商 OCR 转换，请在代码中配置供应商 OCR config，或让手动脚本读取 `.env.template` 对应的变量。
+**注意：** 即使是仅用于开发的环境，如果你想测试与 PDF 相关的功能，仍需按照上述步骤 4 安装 Poppler。使用仓库中的手动脚本时，请将 `.env.template` 复制为 `.env`，填写供应商 OCR 配置后再运行脚本。
 
 ## 常见问题
 

--- a/docs/INSTALLATION_zh-CN.md
+++ b/docs/INSTALLATION_zh-CN.md
@@ -4,16 +4,16 @@
 
 - Python >= 3.11, < 3.14（推荐 3.11.16）
 - Poppler（用于 PDF 解析和渲染）
-- NVIDIA GPU，支持 CUDA 11.8 或 12.1
-- 显存 16 GB 以上（推荐 24 GB 或更高，详见 [DeepSeek OCR 硬件需求讨论](https://huggingface.co/deepseek-ai/DeepSeek-OCR/discussions/31)）
+- NVIDIA GPU，支持 CUDA 11.8 或更新版本，仅本地 OCR 需要
+- 本地 OCR 需要 16 GB 以上显存（最大的 DeepSeek OCR 模型推荐 24 GB 或更高）
 
 ## 安装步骤
 
-本项目使用 DeepSeek OCR 进行文档识别，**必须在 CUDA 环境下运行**。如果你需要实际使用 pdf-craft 进行 PDF 转换，请按照下方 CUDA 环境安装步骤操作。
+pdf-craft 使用 `doc-page-extractor` 进行文档识别。供应商 OCR 后端不需要本地 CUDA；本地 OCR 后端需要支持 CUDA 的 PyTorch 环境。
 
 如果你仅需进行代码开发、IDE 类型提示或阅读源码，可以选择 CPU 环境安装作为替代方案，但无法执行实际的 OCR 识别。
 
-### CUDA 环境安装（推荐）
+### CUDA 环境安装
 
 #### 1. 配置 CUDA 环境
 
@@ -82,7 +82,7 @@ pip install torch torchvision --index-url https://download.pytorch.org/whl/cpu
 pip install pdf-craft
 ```
 
-**注意：** 即使是仅用于开发的环境，如果你想测试与 PDF 相关的功能，仍需按照上述步骤 4 安装 Poppler。
+**注意：** 即使是仅用于开发的环境，如果你想测试与 PDF 相关的功能，仍需按照上述步骤 4 安装 Poppler。如需使用供应商 OCR 转换，请在代码中配置供应商 OCR config，或让手动脚本读取 `.env.template` 对应的变量。
 
 ## 常见问题
 
@@ -96,7 +96,7 @@ pip install pdf-craft
 
 ### CUDA 不可用报错
 
-当你尝试使用 pdf-craft 时，如果看到类似以下的 RuntimeWarning：
+当你使用本地 OCR config 时，如果看到类似以下的 RuntimeWarning：
 
 ```
 CUDA is not available! This package requires CUDA to run,
@@ -107,7 +107,7 @@ but torch.cuda.is_available() returned False.
 
 1. **安装了 CPU 版本的 PyTorch** - 需要重新按照上述 CUDA 环境安装步骤，安装支持 CUDA 的 PyTorch 版本
 2. **NVIDIA 驱动过旧或未安装** - 访问 [NVIDIA 驱动下载页](https://www.nvidia.com/download/index.aspx) 更新驱动
-3. **没有 CUDA 兼容的 GPU** - 本项目必须在 NVIDIA GPU 上运行
+3. **没有 CUDA 兼容的 GPU** - 本地 OCR 必须在 NVIDIA GPU 上运行
 
 你可以运行 `nvidia-smi` 命令来检查系统的 GPU 和驱动状态。
 

--- a/pdf_craft/__init__.py
+++ b/pdf_craft/__init__.py
@@ -11,12 +11,16 @@ from .functions import predownload_models, transform_epub, transform_markdown
 from .llm import LLM
 from .metering import AbortedCheck, InterruptedKind, OCRTokensMetering
 from .ocr_config import (
-    LocalDeepSeekOCRConfig,
+    DeepSeekOCR2LocalConfig,
+    DeepSeekOCR2VendorConfig,
+    DeepSeekOCRLocalConfig,
+    DeepSeekOCRVendorConfig,
+    LocalOCRConfig,
     OCRConfig,
-    VendorDeepSeekOCRConfig,
+    OCRMode,
     VendorOCRConfig,
-    VendorUnlimitedOCRConfig,
-    create_ocr_config_from_env,
+    UnlimitedOCRLocalConfig,
+    UnlimitedOCRVendorConfig,
 )
 from .pdf import (
     DeepSeekOCRSize,

--- a/pdf_craft/ocr_config.py
+++ b/pdf_craft/ocr_config.py
@@ -7,7 +7,7 @@ from .to_path import to_path
 
 
 @dataclass(frozen=True)
-class LocalDeepSeekOCRConfig:
+class DeepSeekOCRLocalConfig:
     models_cache_path: Path | None = None
     local_only: bool = False
     enable_devices_numbers: tuple[int, ...] | None = None
@@ -30,25 +30,59 @@ class LocalDeepSeekOCRConfig:
             tuple(enable_devices_numbers) if enable_devices_numbers is not None else None,
         )
 
-    @classmethod
-    def from_env(cls) -> "LocalDeepSeekOCRConfig":
-        import os
 
-        models_cache_path = os.environ.get("PDF_CRAFT_MODELS_CACHE_PATH") or os.environ.get(
-            "DOC_PAGE_EXTRACTOR_MODEL_PATH"
+@dataclass(frozen=True)
+class DeepSeekOCR2LocalConfig:
+    models_cache_path: Path | None = None
+    local_only: bool = False
+    enable_devices_numbers: tuple[int, ...] | None = None
+
+    def __init__(
+        self,
+        models_cache_path: PathLike | str | None = None,
+        local_only: bool = False,
+        enable_devices_numbers: Iterable[int] | None = None,
+    ) -> None:
+        object.__setattr__(
+            self,
+            "models_cache_path",
+            to_path(models_cache_path) if models_cache_path is not None else None,
         )
-        return cls(
-            models_cache_path=models_cache_path.strip() if models_cache_path else None,
-            local_only=_env_bool(
-                "PDF_CRAFT_LOCAL_ONLY",
-                fallback_name="DOC_PAGE_EXTRACTOR_LOCAL_ONLY",
-                default=False,
-            ),
+        object.__setattr__(self, "local_only", local_only)
+        object.__setattr__(
+            self,
+            "enable_devices_numbers",
+            tuple(enable_devices_numbers) if enable_devices_numbers is not None else None,
         )
 
 
 @dataclass(frozen=True)
-class VendorDeepSeekOCRConfig:
+class UnlimitedOCRLocalConfig:
+    models_cache_path: Path | None = None
+    local_only: bool = False
+    enable_devices_numbers: tuple[int, ...] | None = None
+
+    def __init__(
+        self,
+        models_cache_path: PathLike | str | None = None,
+        local_only: bool = False,
+        enable_devices_numbers: Iterable[int] | None = None,
+    ) -> None:
+        object.__setattr__(
+            self,
+            "models_cache_path",
+            to_path(models_cache_path) if models_cache_path is not None else None,
+        )
+        object.__setattr__(self, "local_only", local_only)
+        object.__setattr__(
+            self,
+            "enable_devices_numbers",
+            tuple(enable_devices_numbers) if enable_devices_numbers is not None else None,
+        )
+
+
+@dataclass(frozen=True)
+class DeepSeekOCRVendorConfig:
     base_url: str
     api_key: str = field(repr=False)
     model: str
@@ -57,106 +91,42 @@ class VendorDeepSeekOCRConfig:
     max_tokens: int = 8000
     timeout_seconds: int = 180
 
-    @classmethod
-    def from_env(cls) -> "VendorDeepSeekOCRConfig":
-        return cls(
-            base_url=_required_env(
-                "PDF_CRAFT_DEEPSEEK_BASE_URL",
-                fallback_name="DOC_PAGE_EXTRACTOR_DEEPSEEK_VENDOR_BASE_URL",
-            ),
-            api_key=_required_env(
-                "PDF_CRAFT_DEEPSEEK_API_KEY",
-                fallback_name="DOC_PAGE_EXTRACTOR_DEEPSEEK_VENDOR_API_KEY",
-            ),
-            model=_required_env(
-                "PDF_CRAFT_DEEPSEEK_MODEL",
-                fallback_name="DOC_PAGE_EXTRACTOR_DEEPSEEK_VENDOR_MODEL",
-            ),
-            temperature=_env_optional_float(
-                "PDF_CRAFT_DEEPSEEK_TEMPERATURE",
-                fallback_name="DOC_PAGE_EXTRACTOR_DEEPSEEK_VENDOR_TEMPERATURE",
-            ),
-            top_p=_env_optional_float(
-                "PDF_CRAFT_DEEPSEEK_TOP_P",
-                fallback_name="DOC_PAGE_EXTRACTOR_DEEPSEEK_VENDOR_TOP_P",
-            ),
-            max_tokens=_env_int(
-                "PDF_CRAFT_DEEPSEEK_MAX_TOKENS",
-                fallback_name="DOC_PAGE_EXTRACTOR_DEEPSEEK_VENDOR_MAX_TOKENS",
-                default=8000,
-            ),
-            timeout_seconds=_env_int(
-                "PDF_CRAFT_DEEPSEEK_TIMEOUT_SECONDS",
-                fallback_name="DOC_PAGE_EXTRACTOR_DEEPSEEK_VENDOR_TIMEOUT_SECONDS",
-                default=180,
-            ),
-        )
+
+@dataclass(frozen=True)
+class DeepSeekOCR2VendorConfig:
+    base_url: str
+    api_key: str = field(repr=False)
+    model: str
+    temperature: float | None = None
+    top_p: float | None = None
+    max_tokens: int = 8000
+    timeout_seconds: int = 180
 
 
 @dataclass(frozen=True)
-class VendorUnlimitedOCRConfig:
+class UnlimitedOCRVendorConfig:
     ak: str = field(repr=False)
     sk: str = field(repr=False)
     base_url: str = "https://aip.baidubce.com"
     poll_interval_seconds: float = 2.0
     timeout_seconds: int = 180
 
-    @classmethod
-    def from_env(cls) -> "VendorUnlimitedOCRConfig":
-        return cls(
-            ak=_required_env(
-                "PDF_CRAFT_UNLIMITED_AK",
-                fallback_name="DOC_PAGE_EXTRACTOR_BAIDU_AK",
-            ),
-            sk=_required_env(
-                "PDF_CRAFT_UNLIMITED_SK",
-                fallback_name="DOC_PAGE_EXTRACTOR_BAIDU_SK",
-            ),
-            base_url=_env_str(
-                "PDF_CRAFT_UNLIMITED_BASE_URL",
-                fallback_name="DOC_PAGE_EXTRACTOR_BAIDU_BASE_URL",
-                default="https://aip.baidubce.com",
-            ),
-            poll_interval_seconds=_env_float(
-                "PDF_CRAFT_UNLIMITED_POLL_INTERVAL_SECONDS",
-                fallback_name="DOC_PAGE_EXTRACTOR_BAIDU_POLL_INTERVAL_SECONDS",
-                default=2.0,
-            ),
-            timeout_seconds=_env_int(
-                "PDF_CRAFT_UNLIMITED_TIMEOUT_SECONDS",
-                fallback_name="DOC_PAGE_EXTRACTOR_BAIDU_TIMEOUT_SECONDS",
-                default=180,
-            ),
-        )
 
-
-VendorOCRConfig: TypeAlias = VendorDeepSeekOCRConfig | VendorUnlimitedOCRConfig
-OCRConfig: TypeAlias = LocalDeepSeekOCRConfig | VendorOCRConfig
-OCRMode: TypeAlias = Literal["local-deepseek", "vendor-deepseek", "vendor-unlimited"]
-
-
-def create_ocr_config_from_env() -> OCRConfig:
-    mode = _env_str("PDF_CRAFT_OCR_MODE")
-    if not mode:
-        legacy_mode = _env_str("DOC_PAGE_EXTRACTOR_BACKEND")
-        if legacy_mode == "vendor":
-            mode = "vendor-deepseek"
-        elif legacy_mode == "baidu":
-            mode = "vendor-unlimited"
-        elif legacy_mode in {"local", "cuda"}:
-            mode = "local-deepseek"
-        else:
-            mode = "local-deepseek"
-    if mode == "local-deepseek":
-        return LocalDeepSeekOCRConfig.from_env()
-    if mode == "vendor-deepseek":
-        return VendorDeepSeekOCRConfig.from_env()
-    if mode == "vendor-unlimited":
-        return VendorUnlimitedOCRConfig.from_env()
-    raise SystemExit(
-        "PDF_CRAFT_OCR_MODE must be one of: "
-        "local-deepseek, vendor-deepseek, vendor-unlimited"
-    )
+LocalOCRConfig: TypeAlias = (
+    DeepSeekOCRLocalConfig | DeepSeekOCR2LocalConfig | UnlimitedOCRLocalConfig
+)
+VendorOCRConfig: TypeAlias = (
+    DeepSeekOCRVendorConfig | DeepSeekOCR2VendorConfig | UnlimitedOCRVendorConfig
+)
+OCRConfig: TypeAlias = LocalOCRConfig | VendorOCRConfig
+OCRMode: TypeAlias = Literal[
+    "deepseek-ocr-local",
+    "deepseek-ocr2-local",
+    "unlimited-ocr-local",
+    "deepseek-ocr-vendor",
+    "deepseek-ocr2-vendor",
+    "unlimited-ocr-vendor",
+]
 
 
 def ensure_ocr_config(
@@ -170,103 +140,7 @@ def ensure_ocr_config(
                 "ocr cannot be combined with models_cache_path or local_only."
             )
         return ocr
-    return LocalDeepSeekOCRConfig(
+    return DeepSeekOCRLocalConfig(
         models_cache_path=models_cache_path,
         local_only=local_only,
     )
-
-
-def _env_name(name: str, fallback_name: str | None = None) -> str:
-    import os
-
-    if os.environ.get(name, "").strip():
-        return name
-    if fallback_name and os.environ.get(fallback_name, "").strip():
-        return fallback_name
-    return name
-
-
-def _env_str(
-    name: str,
-    fallback_name: str | None = None,
-    default: str | None = None,
-) -> str:
-    import os
-
-    actual_name = _env_name(name, fallback_name)
-    value = os.environ.get(actual_name, "").strip()
-    if value:
-        return value
-    if default is not None:
-        return default
-    return ""
-
-
-def _required_env(name: str, fallback_name: str | None = None) -> str:
-    actual_name = _env_name(name, fallback_name)
-    value = _env_str(actual_name)
-    if not value:
-        raise SystemExit(f"Missing required environment variable: {actual_name}")
-    return value
-
-
-def _env_bool(
-    name: str,
-    fallback_name: str | None = None,
-    default: bool = False,
-) -> bool:
-    value = _env_str(name, fallback_name=fallback_name)
-    if not value:
-        return default
-    if value.lower() in {"1", "true", "yes", "on"}:
-        return True
-    if value.lower() in {"0", "false", "no", "off"}:
-        return False
-    raise SystemExit(f"{_env_name(name, fallback_name)} must be a boolean, got {value!r}")
-
-
-def _env_int(
-    name: str,
-    fallback_name: str | None = None,
-    default: int = 0,
-) -> int:
-    value = _env_str(name, fallback_name=fallback_name)
-    if not value:
-        return default
-    try:
-        return int(value)
-    except ValueError as exc:
-        raise SystemExit(
-            f"{_env_name(name, fallback_name)} must be an integer, got {value!r}"
-        ) from exc
-
-
-def _env_float(
-    name: str,
-    fallback_name: str | None = None,
-    default: float = 0.0,
-) -> float:
-    value = _env_str(name, fallback_name=fallback_name)
-    if not value:
-        return default
-    try:
-        return float(value)
-    except ValueError as exc:
-        raise SystemExit(
-            f"{_env_name(name, fallback_name)} must be a float, got {value!r}"
-        ) from exc
-
-
-def _env_optional_float(
-    name: str,
-    fallback_name: str | None = None,
-) -> float | None:
-    value = _env_str(name, fallback_name=fallback_name)
-    if not value:
-        return None
-    try:
-        return float(value)
-    except ValueError as exc:
-        raise SystemExit(
-            f"{_env_name(name, fallback_name)} must be a float, got {value!r}"
-        ) from exc

--- a/pdf_craft/pdf/page_extractor.py
+++ b/pdf_craft/pdf/page_extractor.py
@@ -206,15 +206,16 @@ class PageExtractorNode:
                     structured=page_result.structured,
                     asset_hub=asset_hub,
                     stage_index=step_index,
-                    body_layouts=body_layouts,
-                    footnotes_layouts=footnotes_layouts,
                     includes_footnotes=includes_footnotes,
                 ):
                     if is_footnote:
+                        page_layout.order = len(footnotes_layouts)
                         footnotes_layouts.append(page_layout)
                     elif step_index == 1:
+                        page_layout.order = len(body_layouts)
                         body_layouts.append(page_layout)
                     elif page_layout.ref not in ASSET_TAGS:
+                        page_layout.order = len(footnotes_layouts)
                         footnotes_layouts.append(page_layout)
 
                 check_aborted(aborted)
@@ -243,8 +244,6 @@ class PageExtractorNode:
         structured,
         asset_hub: AssetHub,
         stage_index: int,
-        body_layouts: list[PageLayout],
-        footnotes_layouts: list[PageLayout],
         includes_footnotes: bool,
     ):
         if structured is None:
@@ -276,11 +275,7 @@ class PageExtractorNode:
             ):
                 continue
 
-            if stage_index == 1:
-                order = len(footnotes_layouts) if is_footnote else len(body_layouts)
-            elif ref not in ASSET_TAGS:
-                order = len(footnotes_layouts)
-            else:
+            if stage_index != 1 and ref in ASSET_TAGS:
                 continue
 
             asset_hash: str | None = None
@@ -292,7 +287,7 @@ class PageExtractorNode:
                 det=det,
                 text=text,
                 hash=asset_hash,
-                order=order,
+                order=0,
             ), is_footnote
 
     def _normalize_block_text(self, block) -> str:

--- a/pdf_craft/pdf/page_extractor.py
+++ b/pdf_craft/pdf/page_extractor.py
@@ -8,10 +8,13 @@ from ..common import ASSET_TAGS, AssetHub, remove_surrogates
 from ..error import OCRError
 from ..metering import AbortedCheck, check_aborted
 from ..ocr_config import (
-    LocalDeepSeekOCRConfig,
+    DeepSeekOCR2LocalConfig,
+    DeepSeekOCR2VendorConfig,
+    DeepSeekOCRLocalConfig,
+    DeepSeekOCRVendorConfig,
     OCRConfig,
-    VendorDeepSeekOCRConfig,
-    VendorUnlimitedOCRConfig,
+    UnlimitedOCRLocalConfig,
+    UnlimitedOCRVendorConfig,
 )
 from .ngrams import has_repetitive_ngrams
 from .types import DeepSeekOCRSize, Page, PageLayout
@@ -20,10 +23,20 @@ _LAYOUT_KIND_TO_REF = {
     "text": "text",
     "title": "sub_title",
     "image": "image",
+    "image_caption": "image_caption",
     "table": "table",
+    "table_caption": "table_caption",
     "equation": "equation",
+    "equation_caption": "equation_caption",
     "footnote": "text",
+    "aside": "text",
 }
+
+_LOCAL_OCR_CONFIG_TYPES = (
+    DeepSeekOCRLocalConfig,
+    DeepSeekOCR2LocalConfig,
+    UnlimitedOCRLocalConfig,
+)
 
 
 class PageExtractorNode:
@@ -38,20 +51,42 @@ class PageExtractorNode:
 
     def _create_page_extractor(self):
         # 尽可能推迟 doc-page-extractor 的加载时间
-        if isinstance(self._ocr, LocalDeepSeekOCRConfig):
-            from doc_page_extractor.extractor import create_page_extractor
+        if isinstance(self._ocr, DeepSeekOCRLocalConfig):
+            from doc_page_extractor.extractor import create_deepseek_ocr_page_extractor
 
-            return create_page_extractor(
+            return create_deepseek_ocr_page_extractor(
+                ocr_model="deepseek-ocr",
                 model_path=self._ocr.models_cache_path,
                 local_only=self._ocr.local_only,
                 enable_devices_numbers=self._ocr.enable_devices_numbers,
             )
-        if isinstance(self._ocr, VendorDeepSeekOCRConfig):
-            from doc_page_extractor.adapters.deepseek import DeepSeekVendorOCRConfig
-            from doc_page_extractor.extractor import create_deepseek_vendor_page_extractor
+        if isinstance(self._ocr, DeepSeekOCR2LocalConfig):
+            from doc_page_extractor.extractor import create_deepseek_ocr_page_extractor
 
-            return create_deepseek_vendor_page_extractor(
-                DeepSeekVendorOCRConfig(
+            return create_deepseek_ocr_page_extractor(
+                ocr_model="deepseek-ocr2",
+                model_path=self._ocr.models_cache_path,
+                local_only=self._ocr.local_only,
+                enable_devices_numbers=self._ocr.enable_devices_numbers,
+            )
+        if isinstance(self._ocr, UnlimitedOCRLocalConfig):
+            from doc_page_extractor.extractor import create_unlimited_ocr_page_extractor
+
+            return create_unlimited_ocr_page_extractor(
+                model_path=self._ocr.models_cache_path,
+                local_only=self._ocr.local_only,
+                enable_devices_numbers=self._ocr.enable_devices_numbers,
+            )
+        if isinstance(self._ocr, DeepSeekOCRVendorConfig):
+            from doc_page_extractor.adapters.deepseek import (
+                DeepSeekOCRVendorConfig as UpstreamDeepSeekOCRVendorConfig,
+            )
+            from doc_page_extractor.extractor import (
+                create_deepseek_ocr_vendor_page_extractor,
+            )
+
+            return create_deepseek_ocr_vendor_page_extractor(
+                UpstreamDeepSeekOCRVendorConfig(
                     base_url=self._ocr.base_url,
                     api_key=self._ocr.api_key,
                     model=self._ocr.model,
@@ -61,12 +96,35 @@ class PageExtractorNode:
                     timeout_seconds=self._ocr.timeout_seconds,
                 )
             )
-        if isinstance(self._ocr, VendorUnlimitedOCRConfig):
-            from doc_page_extractor.adapters.baidu import BaiduCloudOCRConfig
-            from doc_page_extractor.extractor import create_baidu_page_extractor
+        if isinstance(self._ocr, DeepSeekOCR2VendorConfig):
+            from doc_page_extractor.adapters.deepseek import (
+                DeepSeekOCR2VendorConfig as UpstreamDeepSeekOCR2VendorConfig,
+            )
+            from doc_page_extractor.extractor import (
+                create_deepseek_ocr2_vendor_page_extractor,
+            )
 
-            return create_baidu_page_extractor(
-                BaiduCloudOCRConfig(
+            return create_deepseek_ocr2_vendor_page_extractor(
+                UpstreamDeepSeekOCR2VendorConfig(
+                    base_url=self._ocr.base_url,
+                    api_key=self._ocr.api_key,
+                    model=self._ocr.model,
+                    temperature=self._ocr.temperature,
+                    top_p=self._ocr.top_p,
+                    max_tokens=self._ocr.max_tokens,
+                    timeout_seconds=self._ocr.timeout_seconds,
+                )
+            )
+        if isinstance(self._ocr, UnlimitedOCRVendorConfig):
+            from doc_page_extractor.adapters.unlimited import (
+                UnlimitedOCRVendorConfig as UpstreamUnlimitedOCRVendorConfig,
+            )
+            from doc_page_extractor.extractor import (
+                create_unlimited_ocr_vendor_page_extractor,
+            )
+
+            return create_unlimited_ocr_vendor_page_extractor(
+                UpstreamUnlimitedOCRVendorConfig(
                     ak=self._ocr.ak,
                     sk=self._ocr.sk,
                     base_url=self._ocr.base_url,
@@ -77,14 +135,14 @@ class PageExtractorNode:
         raise TypeError(f"Unsupported OCR config: {type(self._ocr).__name__}")
 
     def download_models(self, revision: str | None) -> None:
-        if not isinstance(self._ocr, LocalDeepSeekOCRConfig):
-            raise RuntimeError("download_models is only available for local DeepSeek OCR.")
-        self._get_page_extractor().download_models(revision)
+        if not isinstance(self._ocr, _LOCAL_OCR_CONFIG_TYPES):
+            raise RuntimeError("download_models is only available for local OCR.")
+        self._get_page_extractor().download_ocr_model(revision)
 
     def load_models(self) -> None:
-        if not isinstance(self._ocr, LocalDeepSeekOCRConfig):
-            raise RuntimeError("load_models is only available for local DeepSeek OCR.")
-        self._get_page_extractor().load_models()
+        if not isinstance(self._ocr, _LOCAL_OCR_CONFIG_TYPES):
+            raise RuntimeError("load_models is only available for local OCR.")
+        self._get_page_extractor().load_ocr_model()
 
     def image2page(
         self,
@@ -143,15 +201,18 @@ class PageExtractorNode:
                         step_index=step_index,
                     ) from error
 
-                for page_layout in self._iter_page_layouts(
+                for page_layout, is_footnote in self._iter_page_layouts(
                     image=image,
                     structured=page_result.structured,
                     asset_hub=asset_hub,
                     stage_index=step_index,
                     body_layouts=body_layouts,
                     footnotes_layouts=footnotes_layouts,
+                    includes_footnotes=includes_footnotes,
                 ):
-                    if step_index == 1:
+                    if is_footnote:
+                        footnotes_layouts.append(page_layout)
+                    elif step_index == 1:
                         body_layouts.append(page_layout)
                     elif page_layout.ref not in ASSET_TAGS:
                         footnotes_layouts.append(page_layout)
@@ -184,13 +245,18 @@ class PageExtractorNode:
         stage_index: int,
         body_layouts: list[PageLayout],
         footnotes_layouts: list[PageLayout],
+        includes_footnotes: bool,
     ):
         if structured is None:
             return
 
         for block in structured.blocks:
-            ref = _LAYOUT_KIND_TO_REF.get(str(block.kind.value), "unknown")
+            kind = str(block.kind.value)
+            ref = _LAYOUT_KIND_TO_REF.get(kind, "unknown")
             if ref == "unknown":
+                continue
+            is_footnote = kind == "footnote"
+            if is_footnote and not includes_footnotes:
                 continue
 
             text = self._normalize_block_text(block)
@@ -211,7 +277,7 @@ class PageExtractorNode:
                 continue
 
             if stage_index == 1:
-                order = len(body_layouts)
+                order = len(footnotes_layouts) if is_footnote else len(body_layouts)
             elif ref not in ASSET_TAGS:
                 order = len(footnotes_layouts)
             else:
@@ -227,7 +293,7 @@ class PageExtractorNode:
                 text=text,
                 hash=asset_hash,
                 order=order,
-            )
+            ), is_footnote
 
     def _normalize_block_text(self, block) -> str:
         parts: list[str] = []

--- a/poetry.lock
+++ b/poetry.lock
@@ -502,25 +502,30 @@ files = [
 
 [[package]]
 name = "doc-page-extractor"
-version = "1.1.1"
-description = "Document page extraction tool with DeepSeek-OCR and Baidu OCR adapters"
+version = "1.2.0"
+description = "Document page extraction tool with local and vendor OCR backends"
 optional = false
 python-versions = "<3.14,>=3.10"
 groups = ["main"]
 files = [
-    {file = "doc_page_extractor-1.1.1-py3-none-any.whl", hash = "sha256:996b396c04fa45df68219c87139c0d1e7d9200073a95cca5c3c6ee0b2e305583"},
-    {file = "doc_page_extractor-1.1.1.tar.gz", hash = "sha256:033f64645c4c2020adac7fb3a7adb7df30e9b3cd5ba71c50c76bb72227cf0313"},
+    {file = "doc_page_extractor-1.2.0-py3-none-any.whl", hash = "sha256:ba52ee8ff2a17222a7127bb0a135f4c896bcf5f023457a7dbb48b5495c1a5057"},
+    {file = "doc_page_extractor-1.2.0.tar.gz", hash = "sha256:06ff711b7ecc71261f966e9db8ddaf88b5ab3ac123611ab513f0e06c6950db89"},
 ]
 
 [package.dependencies]
-accelerate = ">=0.26.0"
-addict = ">=2.4.0"
-easydict = ">=1.13"
-einops = ">=0.8.0"
+accelerate = {version = ">=0.26.0", optional = true, markers = "extra == \"local\""}
+addict = {version = ">=2.4.0", optional = true, markers = "extra == \"local\""}
+easydict = {version = ">=1.13", optional = true, markers = "extra == \"local\""}
+einops = {version = ">=0.8.0", optional = true, markers = "extra == \"local\""}
+hf_transfer = {version = ">=0.1.9,<0.2.0", optional = true, markers = "extra == \"local\""}
+huggingface-hub = {version = ">=0.24.0,<1.0.0", optional = true, markers = "extra == \"local\""}
 Pillow = ">=10.0.1,<=15.0"
-readerwriterlock = ">=1.0.9,<2.0.0"
+readerwriterlock = {version = ">=1.0.9,<2.0.0", optional = true, markers = "extra == \"local\""}
 requests = ">=2.32.0,<3.0.0"
-transformers = ">=4.46.0,<4.48.0"
+transformers = {version = ">=4.46.0,<4.48.0", optional = true, markers = "extra == \"local\""}
+
+[package.extras]
+local = ["accelerate (>=0.26.0)", "addict (>=2.4.0)", "easydict (>=1.13)", "einops (>=0.8.0)", "hf_transfer (>=0.1.9,<0.2.0)", "huggingface-hub (>=0.24.0,<1.0.0)", "readerwriterlock (>=1.0.9,<2.0.0)", "transformers (>=4.46.0,<4.48.0)"]
 
 [[package]]
 name = "easydict"
@@ -706,6 +711,41 @@ groups = ["main"]
 files = [
     {file = "h11-0.16.0-py3-none-any.whl", hash = "sha256:63cf8bbe7522de3bf65932fda1d9c2772064ffb3dae62d55932da54b31cb6c86"},
     {file = "h11-0.16.0.tar.gz", hash = "sha256:4e35b956cf45792e4caa5885e69fba00bdbc6ffafbfa020300e549b208ee5ff1"},
+]
+
+[[package]]
+name = "hf-transfer"
+version = "0.1.9"
+description = "Speed up file transfers with the Hugging Face Hub."
+optional = false
+python-versions = ">=3.7"
+groups = ["main"]
+files = [
+    {file = "hf_transfer-0.1.9-cp313-cp313t-macosx_10_12_x86_64.whl", hash = "sha256:6e94e8822da79573c9b6ae4d6b2f847c59a7a06c5327d7db20751b68538dc4f6"},
+    {file = "hf_transfer-0.1.9-cp313-cp313t-macosx_11_0_arm64.whl", hash = "sha256:3ebc4ab9023414880c8b1d3c38174d1c9989eb5022d37e814fa91a3060123eb0"},
+    {file = "hf_transfer-0.1.9-cp313-cp313t-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:8674026f21ed369aa2a0a4b46000aca850fc44cd2b54af33a172ce5325b4fc82"},
+    {file = "hf_transfer-0.1.9-cp313-cp313t-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:3a736dfbb2c84f5a2c975478ad200c0c8bfcb58a25a35db402678fb87ce17fa4"},
+    {file = "hf_transfer-0.1.9-cp313-cp313t-manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:504b8427fd785dd8546d53b9fafe6e436bd7a3adf76b9dce556507650a7b4567"},
+    {file = "hf_transfer-0.1.9-cp313-cp313t-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:2c7fc1b85f4d0f76e452765d7648c9f4bfd0aedb9ced2ae1ebfece2d8cfaf8e2"},
+    {file = "hf_transfer-0.1.9-cp313-cp313t-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:0d991376f0eac70a60f0cbc95602aa708a6f7c8617f28b4945c1431d67b8e3c8"},
+    {file = "hf_transfer-0.1.9-cp313-cp313t-musllinux_1_2_aarch64.whl", hash = "sha256:e6ac4eddcd99575ed3735ed911ddf9d1697e2bd13aa3f0ad7e3904dd4863842e"},
+    {file = "hf_transfer-0.1.9-cp313-cp313t-musllinux_1_2_armv7l.whl", hash = "sha256:57fd9880da1ee0f47250f735f791fab788f0aa1ee36afc49f761349869c8b4d9"},
+    {file = "hf_transfer-0.1.9-cp313-cp313t-musllinux_1_2_i686.whl", hash = "sha256:5d561f0520f493c66b016d99ceabe69c23289aa90be38dd802d2aef279f15751"},
+    {file = "hf_transfer-0.1.9-cp313-cp313t-musllinux_1_2_x86_64.whl", hash = "sha256:a5b366d34cd449fe9b20ef25941e6eef0460a2f74e7389f02e673e1f88ebd538"},
+    {file = "hf_transfer-0.1.9-cp38-abi3-macosx_10_12_x86_64.whl", hash = "sha256:e66acf91df4a8b72f60223059df3003062a5ae111757187ed1a06750a30e911b"},
+    {file = "hf_transfer-0.1.9-cp38-abi3-macosx_11_0_arm64.whl", hash = "sha256:8669dbcc7a3e2e8d61d42cd24da9c50d57770bd74b445c65123291ca842a7e7a"},
+    {file = "hf_transfer-0.1.9-cp38-abi3-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:8fd0167c4407a3bc4cdd0307e65ada2294ec04f1813d8a69a5243e379b22e9d8"},
+    {file = "hf_transfer-0.1.9-cp38-abi3-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:ee8b10afedcb75f71091bcc197c526a6ebf5c58bbbadb34fdeee6160f55f619f"},
+    {file = "hf_transfer-0.1.9-cp38-abi3-manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:5828057e313de59300dd1abb489444bc452efe3f479d3c55b31a8f680936ba42"},
+    {file = "hf_transfer-0.1.9-cp38-abi3-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:fc6bd19e1cc177c66bdef15ef8636ad3bde79d5a4f608c158021153b4573509d"},
+    {file = "hf_transfer-0.1.9-cp38-abi3-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:cdca9bfb89e6f8f281890cc61a8aff2d3cecaff7e1a4d275574d96ca70098557"},
+    {file = "hf_transfer-0.1.9-cp38-abi3-musllinux_1_2_aarch64.whl", hash = "sha256:89a23f58b7b7effbc047b8ca286f131b17728c99a9f972723323003ffd1bb916"},
+    {file = "hf_transfer-0.1.9-cp38-abi3-musllinux_1_2_armv7l.whl", hash = "sha256:dc7fff1345980d6c0ebb92c811d24afa4b98b3e07ed070c8e38cc91fd80478c5"},
+    {file = "hf_transfer-0.1.9-cp38-abi3-musllinux_1_2_i686.whl", hash = "sha256:1a6bd16c667ebe89a069ca163060127a794fa3a3525292c900b8c8cc47985b0d"},
+    {file = "hf_transfer-0.1.9-cp38-abi3-musllinux_1_2_x86_64.whl", hash = "sha256:d2fde99d502093ade3ab1b53f80da18480e9902aa960dab7f74fb1b9e5bc5746"},
+    {file = "hf_transfer-0.1.9-cp38-abi3-win32.whl", hash = "sha256:435cc3cdc8524ce57b074032b8fd76eed70a4224d2091232fa6a8cef8fd6803e"},
+    {file = "hf_transfer-0.1.9-cp38-abi3-win_amd64.whl", hash = "sha256:16f208fc678911c37e11aa7b586bc66a37d02e636208f18b6bc53d29b5df40ad"},
+    {file = "hf_transfer-0.1.9.tar.gz", hash = "sha256:035572865dab29d17e783fbf1e84cf1cb24f3fcf8f1b17db1cfc7fdf139f02bf"},
 ]
 
 [[package]]
@@ -3048,4 +3088,4 @@ zstd = ["zstandard (>=0.18.0)"]
 [metadata]
 lock-version = "2.1"
 python-versions = ">=3.11,<3.14"
-content-hash = "82f9f2cef28682d41a57ee150b210645f1480779e372c14034004e3e5daf988c"
+content-hash = "184d46ab13eadbb8120153ceaddb1b49d5534425de88aa9c3f6234bc08f8fb33"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -36,7 +36,7 @@ tiktoken = ">=0.12.0,<1.0.0"
 openai = ">=2.14.0,<3.0.0"
 json-repair = ">=0.55.0,<0.56.0"
 pydantic = ">=2.12.5,<3.0.0"
-doc-page-extractor = "1.1.1"
+doc-page-extractor = {version = "1.2.0", extras = ["local"]}
 epub-generator = "==0.1.7"
 pylatexenc = "^2.10"
 pyahocorasick = "^2.2.0"

--- a/references/architecture.md
+++ b/references/architecture.md
@@ -13,13 +13,14 @@
 - `predownload_models`
 - `Transform`
 - `LLM`
-- `LocalDeepSeekOCRConfig`、`VendorDeepSeekOCRConfig`、`VendorUnlimitedOCRConfig`
+- `DeepSeekOCRLocalConfig`、`DeepSeekOCR2LocalConfig`、`UnlimitedOCRLocalConfig`
+- `DeepSeekOCRVendorConfig`、`DeepSeekOCR2VendorConfig`、`UnlimitedOCRVendorConfig`
 - `PDFHandler`、`PDFDocument`、`DefaultPDFHandler`、`DefaultPDFDocument`
 - `BookMeta`、`TableRender`、`LaTeXRender`
 
 ## 模块归属
 
-- `pdf_craft/pdf/` 负责 PDF 元数据、渲染、页引用、通过 `doc-page-extractor` 接入 DeepSeek OCR，以及 OCR 页 XML 数据。
+- `pdf_craft/pdf/` 负责 PDF 元数据、渲染、页引用、通过 `doc-page-extractor` 接入 OCR 后端，以及 OCR 页 XML 数据。
 - `pdf_craft/toc/` 负责目录页检测和标题层级分析，包括可选的 LLM 辅助分析。
 - `pdf_craft/sequence/` 负责根据 OCR 页 XML 和 TOC 事实生成章节结构。
 - `pdf_craft/markdown/` 负责 Markdown 段落解析和 Markdown 输出渲染。
@@ -33,4 +34,4 @@
 
 pdf-craft 对外只暴露自己的 OCR 配置对象，不暴露 `doc-page-extractor` 的 `PageExtractor`、`OCRAdapter` 或 factory 注入口。需要新增 OCR 后端时，优先在 `doc-page-extractor` 增加官方构造入口，再在 pdf-craft 映射成封闭配置对象。
 
-`torch` 和 `torchvision` 有意不作为本包运行时依赖，因为用户必须按自己的环境选择 CPU 或 CUDA wheel。不要轻易把它们加入运行时依赖。
+本包通过 `doc-page-extractor[local]` 获得上游本地 OCR 运行时栈，但不要把 `torch` 或 `torchvision` 作为 pdf-craft 的直接运行时依赖；用户仍可能需要按自己的环境覆盖安装 CPU 或 CUDA wheel。

--- a/references/conversion-pipeline.md
+++ b/references/conversion-pipeline.md
@@ -33,9 +33,9 @@
 
 `PageExtractorNode` 会延迟导入 `doc-page-extractor`，并且只在需要 OCR 时根据 pdf-craft 的 OCR 配置创建上游 extractor。除非任务明确要求 eager loading，否则应保持这种延迟加载行为。
 
-OCR 配置是封闭公共面：`LocalDeepSeekOCRConfig`、`VendorDeepSeekOCRConfig`、`VendorUnlimitedOCRConfig`。不要把 `doc-page-extractor` 的 `PageExtractor`、`OCRAdapter` 或 factory 作为 pdf-craft 公共注入口。
+OCR 配置是封闭公共面：`DeepSeekOCRLocalConfig`、`DeepSeekOCR2LocalConfig`、`UnlimitedOCRLocalConfig`、`DeepSeekOCRVendorConfig`、`DeepSeekOCR2VendorConfig`、`UnlimitedOCRVendorConfig`。不要把 `doc-page-extractor` 的 `PageExtractor`、`OCRAdapter` 或 factory 作为 pdf-craft 公共注入口。
 
-本地 DeepSeek OCR 可能需要 Poppler、支持 CUDA 的 PyTorch、大型模型下载和较高显存；供应商 OCR 不需要本地 CUDA，但需要网络和密钥。普通单元测试应保持不依赖这些资源也能运行。
+本地 OCR 可能需要 Poppler、支持 CUDA 的 PyTorch、大型模型下载和较高显存；供应商 OCR 不需要本地 CUDA，但需要网络和密钥。普通单元测试应保持不依赖这些资源也能运行。
 
 ## 错误与恢复语义
 

--- a/references/development-and-worktrees.md
+++ b/references/development-and-worktrees.md
@@ -13,15 +13,18 @@ poetry config virtualenvs.in-project true
 poetry install --with dev
 ```
 
-开发 lock file 当前会通过 `doc-page-extractor` 安装 `torch`。只有当任务需要指定 CPU 或 CUDA wheel 时，才按当前环境覆盖安装 `torch` 和 `torchvision`。
+本包通过 `doc-page-extractor[local]` 获得上游本地 OCR 运行时栈，但不直接声明 `torch` 或 `torchvision`。只有当任务需要指定 CPU 或 CUDA wheel 时，才按当前环境覆盖安装 `torch` 和 `torchvision`。
 
-真实 OCR 有三种配置入口：
+真实 OCR 有六种配置入口：
 
-- `LocalDeepSeekOCRConfig`：本地 DeepSeek-OCR，真实转换需要 CUDA。
-- `VendorDeepSeekOCRConfig`：DeepSeek OCR 供应商模式。
-- `VendorUnlimitedOCRConfig`：百度 Unlimited OCR 供应商模式。
+- `DeepSeekOCRLocalConfig`：本地 DeepSeek OCR，真实转换需要 CUDA。
+- `DeepSeekOCR2LocalConfig`：本地 DeepSeek OCR 2，真实转换需要 CUDA。
+- `UnlimitedOCRLocalConfig`：本地 Unlimited OCR，真实转换需要 CUDA。
+- `DeepSeekOCRVendorConfig`：DeepSeek OCR 供应商模式。
+- `DeepSeekOCR2VendorConfig`：DeepSeek OCR 2 供应商模式。
+- `UnlimitedOCRVendorConfig`：Unlimited OCR 供应商模式。
 
-库代码不得自动读取 `.env`。手动脚本可以加载 `.env` 后调用 `create_ocr_config_from_env()`。
+库代码不得自动读取 `.env`。手动脚本可以加载 `.env` 后调用脚本内的 `create_ocr_config_from_env()`；脚本会读取 `DEEPSEEK_LOCAL_MODEL_PATH`、`DEEPSEEK_LOCAL_ONLY`、`UNLIMITED_LOCAL_MODEL_PATH`、`UNLIMITED_LOCAL_ONLY`、`DEEPSEEK_OCR_*`、`DEEPSEEK_OCR2_*` 和 `UNLIMITED_OCR_*`。
 
 ## 默认验证
 

--- a/scripts/env_loader.py
+++ b/scripts/env_loader.py
@@ -1,5 +1,6 @@
 import os
 from pathlib import Path
+from typing import cast
 
 from pdf_craft import (
     DeepSeekOCR2LocalConfig,
@@ -7,6 +8,7 @@ from pdf_craft import (
     DeepSeekOCRLocalConfig,
     DeepSeekOCRVendorConfig,
     OCRConfig,
+    OCRMode,
     UnlimitedOCRLocalConfig,
     UnlimitedOCRVendorConfig,
 )
@@ -25,7 +27,7 @@ def load_env(path: Path) -> None:
 
 
 def create_ocr_config_from_env() -> OCRConfig:
-    mode = _env_str("OCR_MODE", default="deepseek-ocr-local")
+    mode = cast(OCRMode, _env_str("OCR_MODE", default="deepseek-ocr-local"))
     if mode == "deepseek-ocr-local":
         return DeepSeekOCRLocalConfig(
             models_cache_path=_env_str(

--- a/scripts/env_loader.py
+++ b/scripts/env_loader.py
@@ -1,6 +1,16 @@
 import os
 from pathlib import Path
 
+from pdf_craft import (
+    DeepSeekOCR2LocalConfig,
+    DeepSeekOCR2VendorConfig,
+    DeepSeekOCRLocalConfig,
+    DeepSeekOCRVendorConfig,
+    OCRConfig,
+    UnlimitedOCRLocalConfig,
+    UnlimitedOCRVendorConfig,
+)
+
 
 def load_env(path: Path) -> None:
     if not path.exists():
@@ -12,3 +22,127 @@ def load_env(path: Path) -> None:
                 continue
             name, value = line.split("=", 1)
             os.environ.setdefault(name.strip(), value.strip().strip("\"'"))
+
+
+def create_ocr_config_from_env() -> OCRConfig:
+    mode = _env_str("OCR_MODE", default="deepseek-ocr-local")
+    if mode == "deepseek-ocr-local":
+        return DeepSeekOCRLocalConfig(
+            models_cache_path=_env_str(
+                "DEEPSEEK_LOCAL_MODEL_PATH",
+                default="models-cache",
+            ),
+            local_only=_env_bool("DEEPSEEK_LOCAL_ONLY", default=True),
+        )
+    if mode == "deepseek-ocr2-local":
+        return DeepSeekOCR2LocalConfig(
+            models_cache_path=_env_str(
+                "DEEPSEEK_LOCAL_MODEL_PATH",
+                default="models-cache",
+            ),
+            local_only=_env_bool("DEEPSEEK_LOCAL_ONLY", default=True),
+        )
+    if mode == "unlimited-ocr-local":
+        return UnlimitedOCRLocalConfig(
+            models_cache_path=_env_str(
+                "UNLIMITED_LOCAL_MODEL_PATH",
+                default="models-cache",
+            ),
+            local_only=_env_bool("UNLIMITED_LOCAL_ONLY", default=True),
+        )
+    if mode == "deepseek-ocr-vendor":
+        return DeepSeekOCRVendorConfig(
+            base_url=_required_env("DEEPSEEK_OCR_BASE_URL"),
+            api_key=_required_env("DEEPSEEK_OCR_API_KEY"),
+            model=_required_env("DEEPSEEK_OCR_MODEL"),
+            temperature=_env_optional_float("DEEPSEEK_OCR_TEMPERATURE"),
+            top_p=_env_optional_float("DEEPSEEK_OCR_TOP_P"),
+            max_tokens=_env_int("DEEPSEEK_OCR_MAX_TOKENS", default=8000),
+            timeout_seconds=_env_int("DEEPSEEK_OCR_TIMEOUT_SECONDS", default=180),
+        )
+    if mode == "deepseek-ocr2-vendor":
+        return DeepSeekOCR2VendorConfig(
+            base_url=_required_env("DEEPSEEK_OCR2_BASE_URL"),
+            api_key=_required_env("DEEPSEEK_OCR2_API_KEY"),
+            model=_required_env("DEEPSEEK_OCR2_MODEL"),
+            temperature=_env_optional_float("DEEPSEEK_OCR2_TEMPERATURE"),
+            top_p=_env_optional_float("DEEPSEEK_OCR2_TOP_P"),
+            max_tokens=_env_int("DEEPSEEK_OCR2_MAX_TOKENS", default=8000),
+            timeout_seconds=_env_int("DEEPSEEK_OCR2_TIMEOUT_SECONDS", default=180),
+        )
+    if mode == "unlimited-ocr-vendor":
+        return UnlimitedOCRVendorConfig(
+            ak=_required_env("UNLIMITED_OCR_ACCESS_KEY"),
+            sk=_required_env("UNLIMITED_OCR_SECRET_KEY"),
+            base_url=_env_str(
+                "UNLIMITED_OCR_BASE_URL",
+                default="https://aip.baidubce.com",
+            ),
+            poll_interval_seconds=_env_float(
+                "UNLIMITED_OCR_POLL_INTERVAL_SECONDS",
+                default=2.0,
+            ),
+            timeout_seconds=_env_int("UNLIMITED_OCR_TIMEOUT_SECONDS", default=180),
+        )
+    raise SystemExit(
+        "OCR_MODE must be one of: "
+        "deepseek-ocr-local, deepseek-ocr2-local, unlimited-ocr-local, "
+        "deepseek-ocr-vendor, deepseek-ocr2-vendor, unlimited-ocr-vendor"
+    )
+
+
+def _env_str(name: str, default: str | None = None) -> str:
+    value = os.environ.get(name, "").strip()
+    if value:
+        return value
+    if default is not None:
+        return default
+    return ""
+
+
+def _required_env(name: str) -> str:
+    value = _env_str(name)
+    if not value:
+        raise SystemExit(f"Missing required environment variable: {name}")
+    return value
+
+
+def _env_bool(name: str, default: bool = False) -> bool:
+    value = _env_str(name)
+    if not value:
+        return default
+    if value.lower() in {"1", "true", "yes", "on"}:
+        return True
+    if value.lower() in {"0", "false", "no", "off"}:
+        return False
+    raise SystemExit(f"{name} must be a boolean, got {value!r}")
+
+
+def _env_int(name: str, default: int = 0) -> int:
+    value = _env_str(name)
+    if not value:
+        return default
+    try:
+        return int(value)
+    except ValueError as exc:
+        raise SystemExit(f"{name} must be an integer, got {value!r}") from exc
+
+
+def _env_float(name: str, default: float = 0.0) -> float:
+    value = _env_str(name)
+    if not value:
+        return default
+    try:
+        return float(value)
+    except ValueError as exc:
+        raise SystemExit(f"{name} must be a float, got {value!r}") from exc
+
+
+def _env_optional_float(name: str) -> float | None:
+    value = _env_str(name)
+    if not value:
+        return None
+    try:
+        return float(value)
+    except ValueError as exc:
+        raise SystemExit(f"{name} must be a float, got {value!r}") from exc

--- a/scripts/gen_epub.py
+++ b/scripts/gen_epub.py
@@ -9,9 +9,9 @@ from pdf_craft import (
     transform_epub,
 )
 
-try:
+if __package__:
     from .env_loader import create_ocr_config_from_env, load_env
-except ImportError:
+else:
     from env_loader import create_ocr_config_from_env, load_env
 
 _IMAGE_STEM = "newton"

--- a/scripts/gen_epub.py
+++ b/scripts/gen_epub.py
@@ -6,11 +6,10 @@ from pdf_craft import (
     LaTeXRender,
     OCREventKind,
     TableRender,
-    create_ocr_config_from_env,
     transform_epub,
 )
 
-from env_loader import load_env
+from env_loader import create_ocr_config_from_env, load_env
 
 _IMAGE_STEM = "newton"
 

--- a/scripts/gen_epub.py
+++ b/scripts/gen_epub.py
@@ -9,7 +9,10 @@ from pdf_craft import (
     transform_epub,
 )
 
-from env_loader import create_ocr_config_from_env, load_env
+try:
+    from .env_loader import create_ocr_config_from_env, load_env
+except ImportError:
+    from env_loader import create_ocr_config_from_env, load_env
 
 _IMAGE_STEM = "newton"
 

--- a/scripts/gen_md.py
+++ b/scripts/gen_md.py
@@ -3,7 +3,10 @@ from pathlib import Path
 
 from pdf_craft import LLM, OCREventKind, transform_markdown
 
-from env_loader import create_ocr_config_from_env, load_env
+try:
+    from .env_loader import create_ocr_config_from_env, load_env
+except ImportError:
+    from env_loader import create_ocr_config_from_env, load_env
 
 _IMAGE_STEM = "newton"
 

--- a/scripts/gen_md.py
+++ b/scripts/gen_md.py
@@ -3,9 +3,9 @@ from pathlib import Path
 
 from pdf_craft import LLM, OCREventKind, transform_markdown
 
-try:
+if __package__:
     from .env_loader import create_ocr_config_from_env, load_env
-except ImportError:
+else:
     from env_loader import create_ocr_config_from_env, load_env
 
 _IMAGE_STEM = "newton"

--- a/scripts/gen_md.py
+++ b/scripts/gen_md.py
@@ -1,9 +1,9 @@
 import json
 from pathlib import Path
 
-from pdf_craft import LLM, OCREventKind, create_ocr_config_from_env, transform_markdown
+from pdf_craft import LLM, OCREventKind, transform_markdown
 
-from env_loader import load_env
+from env_loader import create_ocr_config_from_env, load_env
 
 _IMAGE_STEM = "newton"
 

--- a/tests/test_functions.py
+++ b/tests/test_functions.py
@@ -1,7 +1,7 @@
 import unittest
 from unittest.mock import patch
 
-from pdf_craft import LocalDeepSeekOCRConfig
+from pdf_craft import DeepSeekOCRLocalConfig
 from pdf_craft import functions
 
 
@@ -17,7 +17,7 @@ class TestConvenienceFunctions(unittest.TestCase):
         _, kwargs = transform_cls.return_value.transform_markdown.call_args
         self.assertFalse(kwargs["toc_assumed"])
 
-    def test_transform_markdown_preserves_legacy_positional_parameters(self):
+    def test_transform_markdown_preserves_positional_parameters(self):
         with patch.object(functions, "Transform") as transform_cls:
             functions.transform_markdown(
                 "input.pdf",
@@ -37,7 +37,7 @@ class TestConvenienceFunctions(unittest.TestCase):
         self.assertEqual(method_kwargs["dpi"], 300)
 
     def test_transform_markdown_accepts_ocr_as_last_keyword(self):
-        config = LocalDeepSeekOCRConfig()
+        config = DeepSeekOCRLocalConfig()
         with patch.object(functions, "Transform") as transform_cls:
             functions.transform_markdown(
                 pdf_path="input.pdf",
@@ -59,7 +59,7 @@ class TestConvenienceFunctions(unittest.TestCase):
         _, kwargs = transform_cls.return_value.transform_epub.call_args
         self.assertTrue(kwargs["toc_assumed"])
 
-    def test_transform_epub_preserves_legacy_positional_parameters(self):
+    def test_transform_epub_preserves_positional_parameters(self):
         with patch.object(functions, "Transform") as transform_cls:
             functions.transform_epub(
                 "input.pdf",

--- a/tests/test_ocr_config.py
+++ b/tests/test_ocr_config.py
@@ -3,51 +3,69 @@ import unittest
 from pathlib import Path
 from unittest.mock import Mock, patch
 
+import pdf_craft
 from pdf_craft import (
-    LocalDeepSeekOCRConfig,
-    VendorDeepSeekOCRConfig,
-    VendorUnlimitedOCRConfig,
-    create_ocr_config_from_env,
+    DeepSeekOCR2LocalConfig,
+    DeepSeekOCR2VendorConfig,
+    DeepSeekOCRLocalConfig,
+    DeepSeekOCRVendorConfig,
+    UnlimitedOCRLocalConfig,
+    UnlimitedOCRVendorConfig,
 )
 from pdf_craft.functions import predownload_models
 from pdf_craft.ocr_config import ensure_ocr_config
 from pdf_craft.pdf.page_extractor import PageExtractorNode
 from pdf_craft.transform import Transform
+from scripts.env_loader import create_ocr_config_from_env
 
 
 class TestOCRConfig(unittest.TestCase):
-    def test_legacy_options_create_local_deepseek_config(self):
+    def test_options_create_deepseek_ocr_local_config(self):
         config = ensure_ocr_config(None, "models", True)
 
-        self.assertIsInstance(config, LocalDeepSeekOCRConfig)
-        assert isinstance(config, LocalDeepSeekOCRConfig)
+        self.assertIsInstance(config, DeepSeekOCRLocalConfig)
+        assert isinstance(config, DeepSeekOCRLocalConfig)
         self.assertEqual(config.models_cache_path, (Path.cwd() / "models").resolve())
         self.assertTrue(config.local_only)
 
-    def test_local_deepseek_device_numbers_are_immutable_tuple(self):
+    def test_local_device_numbers_are_immutable_tuple(self):
         devices = [0, 1]
-        config = LocalDeepSeekOCRConfig(enable_devices_numbers=devices)
-        devices.append(2)
+        for config_cls in (
+            DeepSeekOCRLocalConfig,
+            DeepSeekOCR2LocalConfig,
+            UnlimitedOCRLocalConfig,
+        ):
+            with self.subTest(config_cls=config_cls.__name__):
+                config = config_cls(enable_devices_numbers=devices)
+                self.assertEqual(config.enable_devices_numbers, (0, 1))
 
-        self.assertEqual(config.enable_devices_numbers, (0, 1))
+        devices.append(2)
+        config = DeepSeekOCRLocalConfig(enable_devices_numbers=devices)
+        self.assertEqual(config.enable_devices_numbers, (0, 1, 2))
 
     def test_vendor_config_repr_hides_credentials(self):
-        deepseek = VendorDeepSeekOCRConfig(
+        deepseek = DeepSeekOCRVendorConfig(
             base_url="https://example.com",
             api_key="secret-key",
             model="model",
         )
-        unlimited = VendorUnlimitedOCRConfig(
+        deepseek2 = DeepSeekOCR2VendorConfig(
+            base_url="https://example.com",
+            api_key="secret-key-2",
+            model="model",
+        )
+        unlimited = UnlimitedOCRVendorConfig(
             ak="secret-ak",
             sk="secret-sk",
         )
 
         self.assertNotIn("secret-key", repr(deepseek))
+        self.assertNotIn("secret-key-2", repr(deepseek2))
         self.assertNotIn("secret-ak", repr(unlimited))
         self.assertNotIn("secret-sk", repr(unlimited))
 
-    def test_ocr_config_cannot_mix_with_legacy_options(self):
-        config = VendorDeepSeekOCRConfig(
+    def test_ocr_config_cannot_mix_with_models_cache_options(self):
+        config = DeepSeekOCRVendorConfig(
             base_url="https://example.com",
             api_key="key",
             model="model",
@@ -59,14 +77,14 @@ class TestOCRConfig(unittest.TestCase):
                 ocr=config,
             )
 
-    def test_local_deepseek_uses_doc_page_extractor_local_factory(self):
+    def test_local_deepseek_ocr_uses_doc_page_extractor_factory(self):
         extractor = Mock()
         with patch(
-            "doc_page_extractor.extractor.create_page_extractor",
+            "doc_page_extractor.extractor.create_deepseek_ocr_page_extractor",
             return_value=extractor,
         ) as factory:
             node = PageExtractorNode(
-                LocalDeepSeekOCRConfig(
+                DeepSeekOCRLocalConfig(
                     models_cache_path="models",
                     local_only=True,
                     enable_devices_numbers=[0],
@@ -75,20 +93,66 @@ class TestOCRConfig(unittest.TestCase):
             node.load_models()
 
         factory.assert_called_once_with(
+            ocr_model="deepseek-ocr",
             model_path=(Path.cwd() / "models").resolve(),
             local_only=True,
             enable_devices_numbers=(0,),
         )
-        extractor.load_models.assert_called_once_with()
+        extractor.load_ocr_model.assert_called_once_with()
 
-    def test_vendor_deepseek_uses_doc_page_extractor_vendor_factory(self):
+    def test_local_deepseek_ocr2_uses_doc_page_extractor_factory(self):
         extractor = Mock()
         with patch(
-            "doc_page_extractor.extractor.create_deepseek_vendor_page_extractor",
+            "doc_page_extractor.extractor.create_deepseek_ocr_page_extractor",
             return_value=extractor,
         ) as factory:
             node = PageExtractorNode(
-                VendorDeepSeekOCRConfig(
+                DeepSeekOCR2LocalConfig(
+                    models_cache_path="models",
+                    local_only=True,
+                    enable_devices_numbers=[1],
+                )
+            )
+            node.load_models()
+
+        factory.assert_called_once_with(
+            ocr_model="deepseek-ocr2",
+            model_path=(Path.cwd() / "models").resolve(),
+            local_only=True,
+            enable_devices_numbers=(1,),
+        )
+        extractor.load_ocr_model.assert_called_once_with()
+
+    def test_local_unlimited_ocr_uses_doc_page_extractor_factory(self):
+        extractor = Mock()
+        with patch(
+            "doc_page_extractor.extractor.create_unlimited_ocr_page_extractor",
+            return_value=extractor,
+        ) as factory:
+            node = PageExtractorNode(
+                UnlimitedOCRLocalConfig(
+                    models_cache_path="models",
+                    local_only=True,
+                    enable_devices_numbers=[0, 1],
+                )
+            )
+            node.load_models()
+
+        factory.assert_called_once_with(
+            model_path=(Path.cwd() / "models").resolve(),
+            local_only=True,
+            enable_devices_numbers=(0, 1),
+        )
+        extractor.load_ocr_model.assert_called_once_with()
+
+    def test_vendor_deepseek_ocr_uses_doc_page_extractor_factory(self):
+        extractor = Mock()
+        with patch(
+            "doc_page_extractor.extractor.create_deepseek_ocr_vendor_page_extractor",
+            return_value=extractor,
+        ) as factory:
+            node = PageExtractorNode(
+                DeepSeekOCRVendorConfig(
                     base_url="https://example.com",
                     api_key="key",
                     model="model",
@@ -111,17 +175,47 @@ class TestOCRConfig(unittest.TestCase):
         self.assertEqual(upstream_config.max_tokens, 123)
         self.assertEqual(upstream_config.timeout_seconds, 45)
 
-    def test_vendor_unlimited_uses_doc_page_extractor_baidu_factory(self):
+    def test_vendor_deepseek_ocr2_uses_doc_page_extractor_factory(self):
         extractor = Mock()
         with patch(
-            "doc_page_extractor.extractor.create_baidu_page_extractor",
+            "doc_page_extractor.extractor.create_deepseek_ocr2_vendor_page_extractor",
             return_value=extractor,
         ) as factory:
             node = PageExtractorNode(
-                VendorUnlimitedOCRConfig(
+                DeepSeekOCR2VendorConfig(
+                    base_url="https://example.com",
+                    api_key="key",
+                    model="model",
+                    temperature=0.1,
+                    top_p=0.9,
+                    max_tokens=123,
+                    timeout_seconds=45,
+                )
+            )
+            # pylint: disable=protected-access
+            self.assertIs(node._get_page_extractor(), extractor)
+
+        factory.assert_called_once()
+        upstream_config = factory.call_args.args[0]
+        self.assertEqual(upstream_config.base_url, "https://example.com")
+        self.assertEqual(upstream_config.api_key, "key")
+        self.assertEqual(upstream_config.model, "model")
+        self.assertEqual(upstream_config.temperature, 0.1)
+        self.assertEqual(upstream_config.top_p, 0.9)
+        self.assertEqual(upstream_config.max_tokens, 123)
+        self.assertEqual(upstream_config.timeout_seconds, 45)
+
+    def test_vendor_unlimited_ocr_uses_doc_page_extractor_factory(self):
+        extractor = Mock()
+        with patch(
+            "doc_page_extractor.extractor.create_unlimited_ocr_vendor_page_extractor",
+            return_value=extractor,
+        ) as factory:
+            node = PageExtractorNode(
+                UnlimitedOCRVendorConfig(
                     ak="ak",
                     sk="sk",
-                    base_url="https://baidu.example.com",
+                    base_url="https://unlimited.example.com",
                     poll_interval_seconds=1.5,
                     timeout_seconds=60,
                 )
@@ -133,50 +227,83 @@ class TestOCRConfig(unittest.TestCase):
         upstream_config = factory.call_args.args[0]
         self.assertEqual(upstream_config.ak, "ak")
         self.assertEqual(upstream_config.sk, "sk")
-        self.assertEqual(upstream_config.base_url, "https://baidu.example.com")
+        self.assertEqual(upstream_config.base_url, "https://unlimited.example.com")
         self.assertEqual(upstream_config.poll_interval_seconds, 1.5)
         self.assertEqual(upstream_config.timeout_seconds, 60)
 
     def test_vendor_config_cannot_download_or_load_models(self):
         node = PageExtractorNode(
-            VendorUnlimitedOCRConfig(
+            UnlimitedOCRVendorConfig(
                 ak="ak",
                 sk="sk",
             )
         )
 
-        with self.assertRaisesRegex(RuntimeError, "local DeepSeek OCR"):
+        with self.assertRaisesRegex(RuntimeError, "local OCR"):
             node.download_models(None)
-        with self.assertRaisesRegex(RuntimeError, "local DeepSeek OCR"):
+        with self.assertRaisesRegex(RuntimeError, "local OCR"):
             node.load_models()
 
     def test_predownload_models_accepts_local_config(self):
         extractor = Mock()
         with patch(
-            "doc_page_extractor.extractor.create_page_extractor",
+            "doc_page_extractor.extractor.create_deepseek_ocr_page_extractor",
             return_value=extractor,
         ):
             predownload_models(
-                ocr=LocalDeepSeekOCRConfig(models_cache_path="models"),
+                ocr=DeepSeekOCRLocalConfig(models_cache_path="models"),
                 revision="rev",
             )
 
-        extractor.download_models.assert_called_once_with("rev")
+        extractor.download_ocr_model.assert_called_once_with("rev")
 
-    def test_create_ocr_config_from_env_deepseek(self):
+    def test_pdf_craft_package_does_not_export_env_loader(self):
+        self.assertFalse(hasattr(pdf_craft, "create_ocr_config_from_env"))
+        self.assertTrue(hasattr(pdf_craft, "OCRMode"))
+
+    def test_script_env_loader_defaults_to_deepseek_ocr_local(self):
+        with patch.dict(os.environ, {}, clear=True):
+            config = create_ocr_config_from_env()
+
+        self.assertEqual(
+            config,
+            DeepSeekOCRLocalConfig(
+                models_cache_path="models-cache",
+                local_only=True,
+            ),
+        )
+
+    def test_script_env_loader_creates_deepseek_ocr2_local_config(self):
         env = {
-            "PDF_CRAFT_OCR_MODE": "vendor-deepseek",
-            "PDF_CRAFT_DEEPSEEK_BASE_URL": "https://example.com",
-            "PDF_CRAFT_DEEPSEEK_API_KEY": "key",
-            "PDF_CRAFT_DEEPSEEK_MODEL": "model",
-            "PDF_CRAFT_DEEPSEEK_MAX_TOKENS": "123",
+            "OCR_MODE": "deepseek-ocr2-local",
+            "DEEPSEEK_LOCAL_MODEL_PATH": "models",
+            "DEEPSEEK_LOCAL_ONLY": "false",
         }
         with patch.dict(os.environ, env, clear=True):
             config = create_ocr_config_from_env()
 
         self.assertEqual(
             config,
-            VendorDeepSeekOCRConfig(
+            DeepSeekOCR2LocalConfig(
+                models_cache_path="models",
+                local_only=False,
+            ),
+        )
+
+    def test_script_env_loader_creates_deepseek_ocr_vendor_config(self):
+        env = {
+            "OCR_MODE": "deepseek-ocr-vendor",
+            "DEEPSEEK_OCR_BASE_URL": "https://example.com",
+            "DEEPSEEK_OCR_API_KEY": "key",
+            "DEEPSEEK_OCR_MODEL": "model",
+            "DEEPSEEK_OCR_MAX_TOKENS": "123",
+        }
+        with patch.dict(os.environ, env, clear=True):
+            config = create_ocr_config_from_env()
+
+        self.assertEqual(
+            config,
+            DeepSeekOCRVendorConfig(
                 base_url="https://example.com",
                 api_key="key",
                 model="model",
@@ -184,58 +311,64 @@ class TestOCRConfig(unittest.TestCase):
             ),
         )
 
-    def test_create_ocr_config_from_env_unlimited(self):
+    def test_script_env_loader_creates_deepseek_ocr2_vendor_config(self):
         env = {
-            "PDF_CRAFT_OCR_MODE": "vendor-unlimited",
-            "PDF_CRAFT_UNLIMITED_AK": "ak",
-            "PDF_CRAFT_UNLIMITED_SK": "sk",
-            "PDF_CRAFT_UNLIMITED_POLL_INTERVAL_SECONDS": "1.5",
+            "OCR_MODE": "deepseek-ocr2-vendor",
+            "DEEPSEEK_OCR2_BASE_URL": "https://example.com",
+            "DEEPSEEK_OCR2_API_KEY": "key",
+            "DEEPSEEK_OCR2_MODEL": "model",
+            "DEEPSEEK_OCR2_TEMPERATURE": "0.1",
+            "DEEPSEEK_OCR2_TOP_P": "0.9",
         }
         with patch.dict(os.environ, env, clear=True):
             config = create_ocr_config_from_env()
 
         self.assertEqual(
             config,
-            VendorUnlimitedOCRConfig(
-                ak="ak",
-                sk="sk",
-                poll_interval_seconds=1.5,
-            ),
-        )
-
-    def test_create_ocr_config_from_upstream_legacy_vendor_env(self):
-        env = {
-            "DOC_PAGE_EXTRACTOR_BACKEND": "vendor",
-            "DOC_PAGE_EXTRACTOR_DEEPSEEK_VENDOR_BASE_URL": "https://example.com",
-            "DOC_PAGE_EXTRACTOR_DEEPSEEK_VENDOR_API_KEY": "key",
-            "DOC_PAGE_EXTRACTOR_DEEPSEEK_VENDOR_MODEL": "model",
-        }
-        with patch.dict(os.environ, env, clear=True):
-            config = create_ocr_config_from_env()
-
-        self.assertEqual(
-            config,
-            VendorDeepSeekOCRConfig(
+            DeepSeekOCR2VendorConfig(
                 base_url="https://example.com",
                 api_key="key",
                 model="model",
+                temperature=0.1,
+                top_p=0.9,
             ),
         )
 
-    def test_create_ocr_config_from_upstream_legacy_baidu_env(self):
+    def test_script_env_loader_creates_unlimited_ocr_local_config(self):
         env = {
-            "DOC_PAGE_EXTRACTOR_BACKEND": "baidu",
-            "DOC_PAGE_EXTRACTOR_BAIDU_AK": "ak",
-            "DOC_PAGE_EXTRACTOR_BAIDU_SK": "sk",
+            "OCR_MODE": "unlimited-ocr-local",
+            "UNLIMITED_LOCAL_MODEL_PATH": "models",
+            "UNLIMITED_LOCAL_ONLY": "true",
         }
         with patch.dict(os.environ, env, clear=True):
             config = create_ocr_config_from_env()
 
         self.assertEqual(
             config,
-            VendorUnlimitedOCRConfig(
+            UnlimitedOCRLocalConfig(
+                models_cache_path="models",
+                local_only=True,
+            ),
+        )
+
+    def test_script_env_loader_creates_unlimited_ocr_vendor_config(self):
+        env = {
+            "OCR_MODE": "unlimited-ocr-vendor",
+            "UNLIMITED_OCR_ACCESS_KEY": "ak",
+            "UNLIMITED_OCR_SECRET_KEY": "sk",
+            "UNLIMITED_OCR_BASE_URL": "https://unlimited.example.com",
+            "UNLIMITED_OCR_POLL_INTERVAL_SECONDS": "1.5",
+        }
+        with patch.dict(os.environ, env, clear=True):
+            config = create_ocr_config_from_env()
+
+        self.assertEqual(
+            config,
+            UnlimitedOCRVendorConfig(
                 ak="ak",
                 sk="sk",
+                base_url="https://unlimited.example.com",
+                poll_interval_seconds=1.5,
             ),
         )
 

--- a/tests/test_page_extractor_structured.py
+++ b/tests/test_page_extractor_structured.py
@@ -6,7 +6,7 @@ from PIL import Image
 
 from pdf_craft.common import AssetHub
 from pdf_craft.pdf.page_extractor import PageExtractorNode
-from pdf_craft.ocr_config import LocalDeepSeekOCRConfig
+from pdf_craft.ocr_config import DeepSeekOCRLocalConfig
 
 
 class _Kind:
@@ -37,7 +37,7 @@ class _Structured:
 
 class TestStructuredPageMapping(unittest.TestCase):
     def test_asset_block_includes_structured_caption(self):
-        node = PageExtractorNode(LocalDeepSeekOCRConfig())
+        node = PageExtractorNode(DeepSeekOCRLocalConfig())
         image = Image.new("RGB", (100, 100), "white")
         structured = _Structured(
             blocks=[
@@ -66,8 +66,10 @@ class TestStructuredPageMapping(unittest.TestCase):
                     stage_index=1,
                     body_layouts=[],
                     footnotes_layouts=[],
+                    includes_footnotes=False,
                 )
             )
+            layouts = [layout for layout, _ in layouts]
 
             self.assertEqual(len(layouts), 1)
             self.assertEqual(layouts[0].ref, "image")
@@ -79,7 +81,7 @@ class TestStructuredPageMapping(unittest.TestCase):
             self.assertEqual(files[0].stem, layouts[0].hash)
 
     def test_stage_two_asset_does_not_create_asset_file(self):
-        node = PageExtractorNode(LocalDeepSeekOCRConfig())
+        node = PageExtractorNode(DeepSeekOCRLocalConfig())
         image = Image.new("RGB", (100, 100), "white")
         structured = _Structured(
             blocks=[
@@ -101,11 +103,104 @@ class TestStructuredPageMapping(unittest.TestCase):
                     stage_index=2,
                     body_layouts=[],
                     footnotes_layouts=[],
+                    includes_footnotes=False,
                 )
             )
 
             self.assertEqual(layouts, [])
             self.assertEqual(list(asset_path.iterdir()), [])
+
+    def test_caption_kind_preserves_asset_caption_ref(self):
+        node = PageExtractorNode(DeepSeekOCRLocalConfig())
+        image = Image.new("RGB", (100, 100), "white")
+        structured = _Structured(
+            blocks=[
+                _Block(
+                    kind="table_caption",
+                    det=(10, 82, 80, 94),
+                    text="Table 1: Caption",
+                )
+            ]
+        )
+
+        with TemporaryDirectory() as temp_dir:
+            layouts = list(
+                node._iter_page_layouts(  # pylint: disable=protected-access
+                    image=image,
+                    structured=structured,
+                    asset_hub=AssetHub(Path(temp_dir)),
+                    stage_index=1,
+                    body_layouts=[],
+                    footnotes_layouts=[],
+                    includes_footnotes=False,
+                )
+            )
+
+        self.assertEqual(len(layouts), 1)
+        layout, is_footnote = layouts[0]
+        self.assertEqual(layout.ref, "table_caption")
+        self.assertEqual(layout.text, "Table 1: Caption")
+        self.assertFalse(is_footnote)
+
+    def test_footnote_kind_is_excluded_when_footnotes_are_disabled(self):
+        node = PageExtractorNode(DeepSeekOCRLocalConfig())
+        image = Image.new("RGB", (100, 100), "white")
+        structured = _Structured(
+            blocks=[
+                _Block(
+                    kind="footnote",
+                    det=(10, 82, 80, 94),
+                    text="1. Footnote",
+                )
+            ]
+        )
+
+        with TemporaryDirectory() as temp_dir:
+            layouts = list(
+                node._iter_page_layouts(  # pylint: disable=protected-access
+                    image=image,
+                    structured=structured,
+                    asset_hub=AssetHub(Path(temp_dir)),
+                    stage_index=1,
+                    body_layouts=[],
+                    footnotes_layouts=[],
+                    includes_footnotes=False,
+                )
+            )
+
+        self.assertEqual(layouts, [])
+
+    def test_footnote_kind_uses_footnote_bucket_when_enabled(self):
+        node = PageExtractorNode(DeepSeekOCRLocalConfig())
+        image = Image.new("RGB", (100, 100), "white")
+        structured = _Structured(
+            blocks=[
+                _Block(
+                    kind="footnote",
+                    det=(10, 82, 80, 94),
+                    text="1. Footnote",
+                )
+            ]
+        )
+
+        with TemporaryDirectory() as temp_dir:
+            layouts = list(
+                node._iter_page_layouts(  # pylint: disable=protected-access
+                    image=image,
+                    structured=structured,
+                    asset_hub=AssetHub(Path(temp_dir)),
+                    stage_index=1,
+                    body_layouts=[],
+                    footnotes_layouts=[],
+                    includes_footnotes=True,
+                )
+            )
+
+        self.assertEqual(len(layouts), 1)
+        layout, is_footnote = layouts[0]
+        self.assertEqual(layout.ref, "text")
+        self.assertEqual(layout.text, "1. Footnote")
+        self.assertTrue(is_footnote)
 
 
 if __name__ == "__main__":

--- a/tests/test_page_extractor_structured.py
+++ b/tests/test_page_extractor_structured.py
@@ -64,8 +64,6 @@ class TestStructuredPageMapping(unittest.TestCase):
                     structured=structured,
                     asset_hub=AssetHub(asset_path),
                     stage_index=1,
-                    body_layouts=[],
-                    footnotes_layouts=[],
                     includes_footnotes=False,
                 )
             )
@@ -101,8 +99,6 @@ class TestStructuredPageMapping(unittest.TestCase):
                     structured=structured,
                     asset_hub=AssetHub(asset_path),
                     stage_index=2,
-                    body_layouts=[],
-                    footnotes_layouts=[],
                     includes_footnotes=False,
                 )
             )
@@ -130,8 +126,6 @@ class TestStructuredPageMapping(unittest.TestCase):
                     structured=structured,
                     asset_hub=AssetHub(Path(temp_dir)),
                     stage_index=1,
-                    body_layouts=[],
-                    footnotes_layouts=[],
                     includes_footnotes=False,
                 )
             )
@@ -162,15 +156,13 @@ class TestStructuredPageMapping(unittest.TestCase):
                     structured=structured,
                     asset_hub=AssetHub(Path(temp_dir)),
                     stage_index=1,
-                    body_layouts=[],
-                    footnotes_layouts=[],
                     includes_footnotes=False,
                 )
             )
 
         self.assertEqual(layouts, [])
 
-    def test_footnote_kind_uses_footnote_bucket_when_enabled(self):
+    def test_footnote_kind_is_marked_when_enabled(self):
         node = PageExtractorNode(DeepSeekOCRLocalConfig())
         image = Image.new("RGB", (100, 100), "white")
         structured = _Structured(
@@ -190,8 +182,6 @@ class TestStructuredPageMapping(unittest.TestCase):
                     structured=structured,
                     asset_hub=AssetHub(Path(temp_dir)),
                     stage_index=1,
-                    body_layouts=[],
-                    footnotes_layouts=[],
                     includes_footnotes=True,
                 )
             )


### PR DESCRIPTION
## Summary

- upgrade doc-page-extractor to 1.2.0 with local OCR support
- expose aligned DeepSeek OCR, DeepSeek OCR 2, and Unlimited OCR local/vendor configurations
- move environment parsing to scripts so the library never reads environment variables
- update documentation and tests for the six supported OCR modes

## Validation

- poetry run pyright pdf_craft tests
- poetry run pylint pdf_craft tests
- poetry run python test.py
- local CUDA Markdown smoke conversion for DeepSeek OCR, DeepSeek OCR 2, and Unlimited OCR
- vendor Markdown smoke conversion for DeepSeek OCR, DeepSeek OCR 2, and Unlimited OCR