### PR TITLE
feat: compose extraction, rendering, and PDF translation

### DIFF
--- a/pdf_craft/__init__.py
+++ b/pdf_craft/__init__.py
@@ -37,3 +37,6 @@ from .pdf import (
     pdf_pages_count,
 )
 from .transform import Transform
+from .document import DocumentPackage, SourceLocation
+from .extractor import PDFExtractor
+from .renderer import EpubRenderer, MarkdownRenderer

--- a/pdf_craft/document/package.py
+++ b/pdf_craft/document/package.py
@@ -73,9 +73,9 @@ class DocumentPackage:
                 not isinstance(raw_size, list | tuple)
                 or len(raw_size) != 2
                 or not all(
-                    isinstance(value, int | float)
+                    isinstance(value, int)
                     and not isinstance(value, bool)
-                    and float(value) > 0
+                    and value > 0
                     for value in raw_size
                 )
             ):

--- a/pdf_craft/document/package.py
+++ b/pdf_craft/document/package.py
@@ -15,11 +15,12 @@ class DocumentPackage:
 
     @classmethod
     def from_path(cls, path: Path) -> "DocumentPackage":
+        cover_path = path / "cover.png"
         return cls(
             chapters_path=path / "chapters",
             assets_path=path / "assets",
             toc_path=path / "toc.xml",
-            cover_path=path / "cover.png",
+            cover_path=cover_path if cover_path.exists() else None,
             metadata_path=path / "document.json",
         )
 

--- a/pdf_craft/document/package.py
+++ b/pdf_craft/document/package.py
@@ -45,6 +45,14 @@ class DocumentPackage:
                    "page_pixel_sizes": {str(k): list(v) for k, v in (page_pixel_sizes or {}).items()}}
         path.write_text(json.dumps(payload, ensure_ascii=False, indent=2), encoding="utf-8")
 
+    def page_pixel_sizes(self) -> dict[int, tuple[int, int]]:
+        """Return OCR canvas sizes recorded by the Extractor, without OCR cache."""
+        if self.metadata_path is None or not self.metadata_path.exists():
+            return {}
+        payload = json.loads(self.metadata_path.read_text(encoding="utf-8"))
+        return {int(index): (int(size[0]), int(size[1]))
+                for index, size in payload.get("page_pixel_sizes", {}).items()}
+
     def has_toc(self) -> bool:
         return self.toc_path is not None and self.toc_path.exists()
 

--- a/pdf_craft/document/package.py
+++ b/pdf_craft/document/package.py
@@ -3,7 +3,7 @@ from pathlib import Path
 import json
 
 
-@dataclass(frozen=True)
+@dataclass
 class DocumentPackage:
     """Stable renderer input produced by an Extractor."""
 
@@ -39,6 +39,7 @@ class DocumentPackage:
     def write_metadata(self, *, dpi: int | None = None,
                        page_pixel_sizes: dict[int, tuple[int, int]] | None = None) -> None:
         path = self.metadata_path or self.chapters_path.parent / "document.json"
+        self.metadata_path = path
         path.parent.mkdir(parents=True, exist_ok=True)
         payload = {"schema": 1, "bbox_coordinate_space": "ocr_pixels",
                    "page_index_base": 1, "dpi": dpi,

--- a/pdf_craft/document/package.py
+++ b/pdf_craft/document/package.py
@@ -1,5 +1,6 @@
 from dataclasses import dataclass
 from pathlib import Path
+import json
 
 
 @dataclass(frozen=True)
@@ -10,6 +11,7 @@ class DocumentPackage:
     assets_path: Path
     toc_path: Path | None = None
     cover_path: Path | None = None
+    metadata_path: Path | None = None
 
     @classmethod
     def from_path(cls, path: Path) -> "DocumentPackage":
@@ -18,7 +20,30 @@ class DocumentPackage:
             assets_path=path / "assets",
             toc_path=path / "toc.xml",
             cover_path=path / "cover.png",
+            metadata_path=path / "document.json",
         )
+
+    def validate(self, require_toc: bool = False) -> "DocumentPackage":
+        if not self.chapters_path.is_dir():
+            raise ValueError(f"missing chapters directory: {self.chapters_path}")
+        if not self.assets_path.is_dir():
+            raise ValueError(f"missing assets directory: {self.assets_path}")
+        if require_toc and not self.has_toc():
+            raise ValueError("document package is missing toc.xml")
+        if self.metadata_path is not None and self.metadata_path.exists():
+            data = json.loads(self.metadata_path.read_text(encoding="utf-8"))
+            if data.get("schema") != 1:
+                raise ValueError("unsupported document package schema")
+        return self
+
+    def write_metadata(self, *, dpi: int | None = None,
+                       page_pixel_sizes: dict[int, tuple[int, int]] | None = None) -> None:
+        path = self.metadata_path or self.chapters_path.parent / "document.json"
+        path.parent.mkdir(parents=True, exist_ok=True)
+        payload = {"schema": 1, "bbox_coordinate_space": "ocr_pixels",
+                   "page_index_base": 1, "dpi": dpi,
+                   "page_pixel_sizes": {str(k): list(v) for k, v in (page_pixel_sizes or {}).items()}}
+        path.write_text(json.dumps(payload, ensure_ascii=False, indent=2), encoding="utf-8")
 
     def has_toc(self) -> bool:
         return self.toc_path is not None and self.toc_path.exists()

--- a/pdf_craft/document/package.py
+++ b/pdf_craft/document/package.py
@@ -1,6 +1,7 @@
 from dataclasses import dataclass
 from pathlib import Path
 import json
+from typing import Any
 
 
 @dataclass
@@ -35,6 +36,7 @@ class DocumentPackage:
             data = json.loads(self.metadata_path.read_text(encoding="utf-8"))
             if data.get("schema") != 1:
                 raise ValueError("unsupported document package schema")
+            self._parse_page_pixel_sizes(data)
         return self
 
     def write_metadata(self, *, dpi: int | None = None,
@@ -52,8 +54,36 @@ class DocumentPackage:
         if self.metadata_path is None or not self.metadata_path.exists():
             return {}
         payload = json.loads(self.metadata_path.read_text(encoding="utf-8"))
-        return {int(index): (int(size[0]), int(size[1]))
-                for index, size in payload.get("page_pixel_sizes", {}).items()}
+        return self._parse_page_pixel_sizes(payload)
+
+    @staticmethod
+    def _parse_page_pixel_sizes(payload: dict[str, Any]) -> dict[int, tuple[int, int]]:
+        raw_sizes = payload.get("page_pixel_sizes", {})
+        if not isinstance(raw_sizes, dict):
+            raise ValueError("page_pixel_sizes must be a mapping")
+        sizes: dict[int, tuple[int, int]] = {}
+        for raw_index, raw_size in raw_sizes.items():
+            try:
+                page_index = int(raw_index)
+            except (TypeError, ValueError) as error:
+                raise ValueError("page_pixel_sizes keys must be page indexes") from error
+            if page_index < 1:
+                raise ValueError("page_pixel_sizes page indexes must be positive")
+            if (
+                not isinstance(raw_size, list | tuple)
+                or len(raw_size) != 2
+                or not all(
+                    isinstance(value, int | float)
+                    and not isinstance(value, bool)
+                    and float(value) > 0
+                    for value in raw_size
+                )
+            ):
+                raise ValueError(
+                    "page_pixel_sizes values must be two positive numeric dimensions"
+                )
+            sizes[page_index] = (int(raw_size[0]), int(raw_size[1]))
+        return sizes
 
     def has_toc(self) -> bool:
         return self.toc_path is not None and self.toc_path.exists()

--- a/pdf_craft/extractor/__init__.py
+++ b/pdf_craft/extractor/__init__.py
@@ -3,3 +3,6 @@
 The legacy public API remains available from :mod:`pdf_craft` while new
 Extractor-facing contracts live in :mod:`pdf_craft.document`.
 """
+from .pdf import PDFExtractor
+
+__all__ = ["PDFExtractor"]

--- a/pdf_craft/extractor/pdf/__init__.py
+++ b/pdf_craft/extractor/pdf/__init__.py
@@ -1,1 +1,4 @@
 """PDF source adapter namespace."""
+from .extractor import PDFExtractor
+
+__all__ = ["PDFExtractor"]

--- a/pdf_craft/extractor/pdf/extractor.py
+++ b/pdf_craft/extractor/pdf/extractor.py
@@ -24,6 +24,7 @@ class PDFExtractor:
             "max_output_tokens": None, "on_ocr_event": lambda _: None,
         }
         defaults.update(kwargs)
+        defaults["analysing_path"] = package_path
         _, _, _, _, metering = self._transform.extract_package(pdf_path=pdf_path,
             **defaults)
         package = DocumentPackage.from_path(package_path)

--- a/pdf_craft/extractor/pdf/extractor.py
+++ b/pdf_craft/extractor/pdf/extractor.py
@@ -8,6 +8,10 @@ class PDFExtractor:
         self._transform = transform
 
     def extract(self, pdf_path: Path, package_path: Path, **kwargs: Any) -> DocumentPackage:
+        package, _ = self.extract_with_metering(pdf_path, package_path, **kwargs)
+        return package
+
+    def extract_with_metering(self, pdf_path: Path, package_path: Path, **kwargs: Any):
         package_path.mkdir(parents=True, exist_ok=True)
         defaults = {
             "analysing_path": package_path,
@@ -20,9 +24,9 @@ class PDFExtractor:
             "max_output_tokens": None, "on_ocr_event": lambda _: None,
         }
         defaults.update(kwargs)
-        self._transform._extract_from_pdf(pdf_path=pdf_path,
+        _, _, _, _, metering = self._transform.extract_package(pdf_path=pdf_path,
             **defaults)
         package = DocumentPackage.from_path(package_path)
         package.write_metadata(dpi=kwargs.get("dpi"))
         package.validate()
-        return package
+        return package, metering

--- a/pdf_craft/extractor/pdf/extractor.py
+++ b/pdf_craft/extractor/pdf/extractor.py
@@ -1,0 +1,28 @@
+from pathlib import Path
+from typing import Any
+from ...document import DocumentPackage
+
+class PDFExtractor:
+    """Public PDF extraction boundary. Heavy OCR imports remain lazy."""
+    def __init__(self, transform: Any) -> None:
+        self._transform = transform
+
+    def extract(self, pdf_path: Path, package_path: Path, **kwargs: Any) -> DocumentPackage:
+        package_path.mkdir(parents=True, exist_ok=True)
+        defaults = {
+            "analysing_path": package_path,
+            "ocr_size": "gundam", "dpi": None,
+            "max_page_image_file_size": None, "includes_cover": False,
+            "includes_footnotes": False, "ignore_pdf_errors": False,
+            "ignore_ocr_errors": False, "generate_plot": False,
+            "toc_llm": None, "toc_assumed": False,
+            "aborted": lambda: False, "max_tokens": None,
+            "max_output_tokens": None, "on_ocr_event": lambda _: None,
+        }
+        defaults.update(kwargs)
+        self._transform._extract_from_pdf(pdf_path=pdf_path,
+            **defaults)
+        package = DocumentPackage.from_path(package_path)
+        package.write_metadata(dpi=kwargs.get("dpi"))
+        package.validate()
+        return package

--- a/pdf_craft/extractor/pdf/extractor.py
+++ b/pdf_craft/extractor/pdf/extractor.py
@@ -27,6 +27,5 @@ class PDFExtractor:
         _, _, _, _, metering = self._transform.extract_package(pdf_path=pdf_path,
             **defaults)
         package = DocumentPackage.from_path(package_path)
-        package.write_metadata(dpi=kwargs.get("dpi"))
         package.validate()
         return package, metering

--- a/pdf_craft/pdf/ocr.py
+++ b/pdf_craft/pdf/ocr.py
@@ -213,13 +213,22 @@ class OCR:
         if not did_ignore_any:
             done_path.touch()
 
-    def page_pixel_sizes(self, pdf_path: Path, dpi: int | None) -> dict[int, tuple[int, int]]:
+    def page_pixel_sizes(
+        self, pdf_path: Path, dpi: int | None, max_page_image_file_size: int | None = None
+    ) -> dict[int, tuple[int, int]]:
         """Record the same rendered canvas geometry used for OCR BBoxes."""
         document = self._get_pdf_handler().open(pdf_path)
         try:
             actual_dpi = dpi if dpi is not None else 300
-            return {index: document.render_page(index, actual_dpi).size
-                    for index in range(1, document.pages_count + 1)}
+            sizes: dict[int, tuple[int, int]] = {}
+            for index in range(1, document.pages_count + 1):
+                page_dpi = actual_dpi
+                if max_page_image_file_size is not None:
+                    width, height = document.page_size(index)
+                    max_dpi = round((max_page_image_file_size / (width * height * 3 * 0.5)) ** 0.5)
+                    page_dpi = min(page_dpi, max_dpi)
+                sizes[index] = document.render_page(index, page_dpi).size
+            return sizes
         finally:
             document.close()
 

--- a/pdf_craft/pdf/ocr.py
+++ b/pdf_craft/pdf/ocr.py
@@ -213,6 +213,16 @@ class OCR:
         if not did_ignore_any:
             done_path.touch()
 
+    def page_pixel_sizes(self, pdf_path: Path, dpi: int | None) -> dict[int, tuple[int, int]]:
+        """Record the same rendered canvas geometry used for OCR BBoxes."""
+        document = self._get_pdf_handler().open(pdf_path)
+        try:
+            actual_dpi = dpi if dpi is not None else 300
+            return {index: document.render_page(index, actual_dpi).size
+                    for index in range(1, document.pages_count + 1)}
+        finally:
+            document.close()
+
     def _get_pdf_handler(self) -> PDFHandler:
         if self._pdf_handler is not None:
             return self._pdf_handler

--- a/pdf_craft/pdf/ocr.py
+++ b/pdf_craft/pdf/ocr.py
@@ -239,10 +239,21 @@ class OCR:
             raw_sizes = json.loads(path.read_text(encoding="utf-8"))
             if not isinstance(raw_sizes, dict):
                 raise ValueError("must be a mapping")
-            sizes = {
-                int(index): (int(size[0]), int(size[1]))
-                for index, size in raw_sizes.items()
-            }
+            sizes: dict[int, tuple[int, int]] = {}
+            for raw_index, raw_size in raw_sizes.items():
+                index = int(raw_index)
+                if (
+                    not isinstance(raw_size, list | tuple)
+                    or len(raw_size) != 2
+                    or not all(
+                        isinstance(value, int)
+                        and not isinstance(value, bool)
+                        and value > 0
+                        for value in raw_size
+                    )
+                ):
+                    raise ValueError("invalid page size")
+                sizes[index] = (raw_size[0], raw_size[1])
         except (IndexError, TypeError, ValueError, json.JSONDecodeError) as error:
             raise ValueError(f"invalid OCR page geometry cache: {path}") from error
         if any(index < 1 or width < 1 or height < 1

--- a/pdf_craft/pdf/ocr.py
+++ b/pdf_craft/pdf/ocr.py
@@ -47,6 +47,7 @@ class OCR:
         self._pdf_handler = pdf_handler
         self._pdf_handler_lock = Lock()
         self._extractor = PageExtractorNode(ocr=ocr)
+        self._last_page_pixel_sizes: dict[int, tuple[int, int]] = {}
 
     def predownload(self, revision: str | None) -> None:
         self._extractor.download_models(revision)
@@ -80,6 +81,7 @@ class OCR:
         max_output_tokens: int | None = None,
         device_number: int | None = None,
     ) -> Generator[OCREvent, None, None]:
+        self._last_page_pixel_sizes = {}
         ocr_path.mkdir(parents=True, exist_ok=True)
         if plot_path is not None:
             plot_path.mkdir(parents=True, exist_ok=True)
@@ -148,6 +150,7 @@ class OCR:
                             else 300,  # DPI=300 for scanned page
                             max_image_file_size=max_page_image_file_size,
                         )
+                        self._last_page_pixel_sizes[ref.page_index] = image.size
                         yield OCREvent(
                             kind=OCREventKind.RENDERED,
                             page_index=ref.page_index,
@@ -213,24 +216,9 @@ class OCR:
         if not did_ignore_any:
             done_path.touch()
 
-    def page_pixel_sizes(
-        self, pdf_path: Path, dpi: int | None, max_page_image_file_size: int | None = None
-    ) -> dict[int, tuple[int, int]]:
-        """Record the same rendered canvas geometry used for OCR BBoxes."""
-        document = self._get_pdf_handler().open(pdf_path)
-        try:
-            actual_dpi = dpi if dpi is not None else 300
-            sizes: dict[int, tuple[int, int]] = {}
-            for index in range(1, document.pages_count + 1):
-                page_dpi = actual_dpi
-                if max_page_image_file_size is not None:
-                    width, height = document.page_size(index)
-                    max_dpi = round((max_page_image_file_size / (width * height * 3 * 0.5)) ** 0.5)
-                    page_dpi = min(page_dpi, max_dpi)
-                sizes[index] = document.render_page(index, page_dpi).size
-            return sizes
-        finally:
-            document.close()
+    @property
+    def last_page_pixel_sizes(self) -> dict[int, tuple[int, int]]:
+        return self._last_page_pixel_sizes.copy()
 
     def _get_pdf_handler(self) -> PDFHandler:
         if self._pdf_handler is not None:

--- a/pdf_craft/pdf/ocr.py
+++ b/pdf_craft/pdf/ocr.py
@@ -1,5 +1,6 @@
 import sys
 import time
+import json
 from dataclasses import dataclass
 from enum import Enum, auto
 from pathlib import Path
@@ -81,8 +82,9 @@ class OCR:
         max_output_tokens: int | None = None,
         device_number: int | None = None,
     ) -> Generator[OCREvent, None, None]:
-        self._last_page_pixel_sizes = {}
         ocr_path.mkdir(parents=True, exist_ok=True)
+        geometry_path = ocr_path / "page_pixel_sizes.json"
+        self._last_page_pixel_sizes = self._load_page_pixel_sizes(geometry_path)
         if plot_path is not None:
             plot_path.mkdir(parents=True, exist_ok=True)
 
@@ -190,6 +192,7 @@ class OCR:
                         )
 
                     save_xml(encode(page), file_path)
+                    self._save_page_pixel_sizes(geometry_path)
 
                     if cover_path and page.image:
                         cover_path.parent.mkdir(parents=True, exist_ok=True)
@@ -228,6 +231,35 @@ class OCR:
             if self._pdf_handler is None:
                 self._pdf_handler = DefaultPDFHandler()
             return self._pdf_handler
+
+    def _load_page_pixel_sizes(self, path: Path) -> dict[int, tuple[int, int]]:
+        if not path.exists():
+            return {}
+        try:
+            raw_sizes = json.loads(path.read_text(encoding="utf-8"))
+            if not isinstance(raw_sizes, dict):
+                raise ValueError("must be a mapping")
+            sizes = {
+                int(index): (int(size[0]), int(size[1]))
+                for index, size in raw_sizes.items()
+            }
+        except (IndexError, TypeError, ValueError, json.JSONDecodeError) as error:
+            raise ValueError(f"invalid OCR page geometry cache: {path}") from error
+        if any(index < 1 or width < 1 or height < 1
+               for index, (width, height) in sizes.items()):
+            raise ValueError(f"invalid OCR page geometry cache: {path}")
+        return sizes
+
+    def _save_page_pixel_sizes(self, path: Path) -> None:
+        temporary_path = path.with_suffix(".json.tmp")
+        temporary_path.write_text(
+            json.dumps(
+                {str(index): list(size) for index, size in self._last_page_pixel_sizes.items()},
+                ensure_ascii=False,
+            ),
+            encoding="utf-8",
+        )
+        temporary_path.replace(path)
 
     def _create_fallback_page(
         self,

--- a/pdf_craft/pipeline/pdf/pipeline.py
+++ b/pdf_craft/pipeline/pdf/pipeline.py
@@ -35,15 +35,16 @@ class PDFTranslationPipeline:
             pages = package.page_pixel_sizes()
             reader = create_chapters_reader(package.chapters_path)
             for chapter in reader():
-                transformed = transformer.transform(chapter) if not callable(transformer) else chapter
+                structured = not callable(transformer)
+                transformed = transformer.transform(chapter) if structured else chapter
                 callback = transformer if callable(transformer) else (lambda text: text)
-                self._collect_chapter(transformed, callback, document, pages, replacements)
+                self._collect_chapter(transformed, callback, document, pages, replacements, structured)
         finally:
             if document:
                 document.close()
         self.patcher.patch(pdf_path, target_path, replacements)
 
-    def _collect_chapter(self, chapter: Chapter, transformer, document, pages, replacements) -> None:
+    def _collect_chapter(self, chapter: Chapter, transformer, document, pages, replacements, structured: bool = False) -> None:
         for layout in chapter.layouts:
             if not isinstance(layout, ParagraphLayout) or layout.ref not in {"text", "sub_title"}:
                 continue
@@ -52,7 +53,7 @@ class PDFTranslationPipeline:
                 if not source:
                     continue
                 translated = transformer(source)
-                if not translated or translated == source:
+                if not translated or (translated == source and not structured):
                     continue
                 if block.page_index not in pages:
                     if document is None:

--- a/pdf_craft/pipeline/pdf/pipeline.py
+++ b/pdf_craft/pipeline/pdf/pipeline.py
@@ -5,6 +5,7 @@ from pdf_craft.sequence.chapter import Chapter, ParagraphLayout
 from pdf_craft.sequence.reader import create_chapters_reader
 from pdf_craft.pdf.handler import PDFHandler
 from pdf_craft.pipeline.pdf.patcher import PDFPatcher, PDFReplacement
+from pdf_craft.transformer import ChapterTransformer
 
 
 class PDFTranslationPipeline:
@@ -20,7 +21,7 @@ class PDFTranslationPipeline:
         pdf_path: Path,
         target_path: Path,
         chapters_path: Path,
-        transformer: Callable[[str], str],
+        transformer: Callable[[str], str] | ChapterTransformer,
     ) -> None:
         document = self.pdf_handler.open(pdf_path) if self.pdf_handler else None
         replacements: list[PDFReplacement] = []
@@ -28,7 +29,9 @@ class PDFTranslationPipeline:
             pages: dict[int, tuple[int, int]] = {}
             reader = create_chapters_reader(chapters_path)
             for chapter in reader():
-                self._collect_chapter(chapter, transformer, document, pages, replacements)
+                transformed = transformer.transform(chapter) if not callable(transformer) else chapter
+                callback = transformer if callable(transformer) else (lambda text: text)
+                self._collect_chapter(transformed, callback, document, pages, replacements)
         finally:
             if document:
                 document.close()

--- a/pdf_craft/pipeline/pdf/pipeline.py
+++ b/pdf_craft/pipeline/pdf/pipeline.py
@@ -2,7 +2,11 @@ from collections.abc import Callable
 from pathlib import Path
 
 from pdf_craft.sequence.chapter import Chapter, ParagraphLayout
+from pdf_craft.sequence.chapter import InlineExpression, Reference
 from pdf_craft.sequence.reader import create_chapters_reader
+from pdf_craft.markdown.paragraph import HTMLTag
+from pdf_craft.expression import to_markdown_string
+from pdf_craft.document import DocumentPackage
 from pdf_craft.pdf.handler import PDFHandler
 from pdf_craft.pipeline.pdf.patcher import PDFPatcher, PDFReplacement
 from pdf_craft.transformer import ChapterTransformer
@@ -20,14 +24,16 @@ class PDFTranslationPipeline:
         self,
         pdf_path: Path,
         target_path: Path,
-        chapters_path: Path,
+        package: DocumentPackage | Path,
         transformer: Callable[[str], str] | ChapterTransformer,
     ) -> None:
+        package = package if isinstance(package, DocumentPackage) else DocumentPackage.from_path(package)
+        package.validate()
         document = self.pdf_handler.open(pdf_path) if self.pdf_handler else None
         replacements: list[PDFReplacement] = []
         try:
-            pages: dict[int, tuple[int, int]] = {}
-            reader = create_chapters_reader(chapters_path)
+            pages = package.page_pixel_sizes()
+            reader = create_chapters_reader(package.chapters_path)
             for chapter in reader():
                 transformed = transformer.transform(chapter) if not callable(transformer) else chapter
                 callback = transformer if callable(transformer) else (lambda text: text)
@@ -42,7 +48,7 @@ class PDFTranslationPipeline:
             if not isinstance(layout, ParagraphLayout) or layout.ref not in {"text", "sub_title"}:
                 continue
             for block in layout.blocks:
-                source = "".join(item for item in block.content if isinstance(item, str)).strip()
+                source = _to_patch_text(block.content).strip()
                 if not source:
                     continue
                 translated = transformer(source)
@@ -54,3 +60,24 @@ class PDFTranslationPipeline:
                     image = document.render_page(block.page_index, self.dpi)
                     pages[block.page_index] = image.size
                 replacements.append(PDFReplacement(block.page_index, block.det, translated, pages[block.page_index], self.dpi))
+
+
+def _to_patch_text(items) -> str:
+    """Serialize structured Chapter content without silently dropping nodes.
+
+    The patcher can only draw text, so formulas retain their Markdown delimiters,
+    references retain their printed mark, and HTML wrappers retain their children.
+    """
+    parts: list[str] = []
+    for item in items:
+        if isinstance(item, str):
+            parts.append(item)
+        elif isinstance(item, InlineExpression):
+            parts.append(to_markdown_string(item.kind, item.content))
+        elif isinstance(item, Reference):
+            parts.append(str(item.mark))
+        elif isinstance(item, HTMLTag):
+            parts.append(_to_patch_text(item.children))
+        else:
+            raise TypeError(f"unsupported chapter content for PDF patching: {type(item).__name__}")
+    return "".join(parts)

--- a/pdf_craft/renderer/__init__.py
+++ b/pdf_craft/renderer/__init__.py
@@ -1,1 +1,5 @@
 """Document rendering boundary for Markdown and EPUB targets."""
+from .epub import EpubRenderer
+from .markdown import MarkdownRenderer
+
+__all__ = ["EpubRenderer", "MarkdownRenderer"]

--- a/pdf_craft/renderer/epub/__init__.py
+++ b/pdf_craft/renderer/epub/__init__.py
@@ -1,1 +1,4 @@
 """EPUB renderer namespace."""
+from .renderer import EpubRenderer
+
+__all__ = ["EpubRenderer"]

--- a/pdf_craft/renderer/epub/renderer.py
+++ b/pdf_craft/renderer/epub/renderer.py
@@ -1,5 +1,5 @@
 from pathlib import Path
-from typing import Literal, cast
+from typing import Literal
 from ...document import DocumentPackage
 from ...epub.render import render_epub_file
 from epub_generator import LaTeXRender, TableRender
@@ -7,10 +7,12 @@ from epub_generator import LaTeXRender, TableRender
 class EpubRenderer:
     """Render a stable DocumentPackage to EPUB."""
     def render(self, package: DocumentPackage, output_path: Path, *, book_meta=None,
-               lan: str = "zh", table_render=TableRender.HTML,
+               lan: Literal["zh", "en"] = "zh", table_render=TableRender.HTML,
                latex_render=LaTeXRender.MATHML, inline_latex: bool = True,
                aborted=lambda: False) -> None:
         package.validate(require_toc=True)
+        if lan not in {"zh", "en"}:
+            raise ValueError(f"unsupported EPUB language: {lan}")
         render_epub_file(package.chapters_path, package.toc_path, package.assets_path,
-                         output_path, package.cover_path, book_meta, cast(Literal["zh", "en"], lan), table_render,
+                         output_path, package.cover_path, book_meta, lan, table_render,
                          latex_render, inline_latex, aborted)

--- a/pdf_craft/renderer/epub/renderer.py
+++ b/pdf_craft/renderer/epub/renderer.py
@@ -1,0 +1,16 @@
+from pathlib import Path
+from typing import Literal, cast
+from ...document import DocumentPackage
+from ...epub.render import render_epub_file
+from epub_generator import LaTeXRender, TableRender
+
+class EpubRenderer:
+    """Render a stable DocumentPackage to EPUB."""
+    def render(self, package: DocumentPackage, output_path: Path, *, book_meta=None,
+               lan: str = "zh", table_render=TableRender.HTML,
+               latex_render=LaTeXRender.MATHML, inline_latex: bool = True,
+               aborted=lambda: False) -> None:
+        package.validate(require_toc=True)
+        render_epub_file(package.chapters_path, package.toc_path, package.assets_path,
+                         output_path, package.cover_path, book_meta, cast(Literal["zh", "en"], lan), table_render,
+                         latex_render, inline_latex, aborted)

--- a/pdf_craft/renderer/markdown/__init__.py
+++ b/pdf_craft/renderer/markdown/__init__.py
@@ -1,1 +1,4 @@
 """Markdown renderer namespace."""
+from .renderer import MarkdownRenderer
+
+__all__ = ["MarkdownRenderer"]

--- a/pdf_craft/renderer/markdown/renderer.py
+++ b/pdf_craft/renderer/markdown/renderer.py
@@ -1,0 +1,13 @@
+from pathlib import Path
+from ...document import DocumentPackage
+from ...markdown.render import render_markdown_file
+
+class MarkdownRenderer:
+    """Render a stable DocumentPackage to Markdown."""
+    def render(self, package: DocumentPackage, output_path: Path,
+               assets_path: Path | None = None, cover_path: Path | None = None,
+               aborted=lambda: False) -> None:
+        package.validate()
+        render_markdown_file(package.chapters_path, package.assets_path, output_path,
+                             assets_path or output_path.parent / "assets",
+                             cover_path or package.cover_path, aborted)

--- a/pdf_craft/transform.py
+++ b/pdf_craft/transform.py
@@ -5,7 +5,6 @@ from typing import Callable, Literal
 from epub_generator import BookMeta, LaTeXRender, TableRender
 
 from .common import EnsureFolder, remove_surrogates
-from .epub import render_epub_file
 from .error import (
     IgnoreOCRErrorsChecker,
     IgnorePDFErrorsChecker,
@@ -14,7 +13,6 @@ from .error import (
     to_interrupted_error,
 )
 from .llm import LLM
-from .markdown.render import render_markdown_file
 from .metering import AbortedCheck, OCRTokensMetering
 from .ocr_config import OCRConfig, ensure_ocr_config
 from .pdf import OCR, DeepSeekOCRSize, OCREvent, PDFHandler
@@ -23,6 +21,7 @@ from .to_path import to_path
 from .toc import analyse_toc
 from .document import DocumentPackage
 from .renderer import EpubRenderer, MarkdownRenderer
+from .extractor import PDFExtractor
 
 
 class Transform:
@@ -43,6 +42,10 @@ class Transform:
 
     def load_models(self) -> None:
         self._ocr.load_models()
+
+    def extract_package(self, **kwargs):
+        """Compatibility extraction hook used by the public PDFExtractor."""
+        return self._extract_from_pdf(**kwargs)
 
     def transform_markdown(
         self,
@@ -73,10 +76,8 @@ class Transform:
             with EnsureFolder(
                 path=to_path(analysing_path) if analysing_path is not None else None,
             ) as analysing_path:
-                asserts_path, chapters_path, _, cover_path, metering = (
-                    self._extract_from_pdf(
-                        pdf_path=Path(pdf_path),
-                        analysing_path=analysing_path,
+                package, metering = PDFExtractor(self).extract_with_metering(
+                        pdf_path=Path(pdf_path), package_path=analysing_path,
                         ocr_size=ocr_size,
                         dpi=dpi,
                         max_page_image_file_size=max_page_image_file_size,
@@ -91,12 +92,9 @@ class Transform:
                         max_tokens=max_ocr_tokens,
                         max_output_tokens=max_ocr_output_tokens,
                         on_ocr_event=on_ocr_event,
-                    )
                 )
-                package = DocumentPackage(asserts_path.parent / "chapters", asserts_path,
-                                          asserts_path.parent / "toc.xml", cover_path)
                 MarkdownRenderer().render(package, Path(markdown_path),
-                                           Path(markdown_assets_path), cover_path, aborted)
+                                           Path(markdown_assets_path), package.cover_path, aborted)
                 return metering
 
         except Exception as raw_error:
@@ -140,10 +138,8 @@ class Transform:
                 path=to_path(analysing_path) if analysing_path is not None else None,
             ) as analysing_path:
                 pdf_path = Path(pdf_path)
-                asserts_path, chapters_path, toc_path, cover_path, metering = (
-                    self._extract_from_pdf(
-                        pdf_path=pdf_path,
-                        analysing_path=analysing_path,
+                package, metering = PDFExtractor(self).extract_with_metering(
+                        pdf_path=pdf_path, package_path=analysing_path,
                         ocr_size=ocr_size,
                         dpi=dpi,
                         max_page_image_file_size=max_page_image_file_size,
@@ -158,11 +154,9 @@ class Transform:
                         max_tokens=max_ocr_tokens,
                         max_output_tokens=max_ocr_output_tokens,
                         on_ocr_event=on_ocr_event,
-                    )
                 )
                 book_meta = book_meta or self._extract_book_meta(pdf_path)
 
-                package = DocumentPackage(chapters_path, asserts_path, toc_path, cover_path)
                 EpubRenderer().render(package, Path(epub_path), book_meta=book_meta,
                                        lan=lan, table_render=table_render,
                                        latex_render=latex_render, inline_latex=inline_latex,

--- a/pdf_craft/transform.py
+++ b/pdf_craft/transform.py
@@ -21,6 +21,8 @@ from .pdf import OCR, DeepSeekOCRSize, OCREvent, PDFHandler
 from .sequence import generate_chapter_files
 from .to_path import to_path
 from .toc import analyse_toc
+from .document import DocumentPackage
+from .renderer import EpubRenderer, MarkdownRenderer
 
 
 class Transform:
@@ -91,14 +93,10 @@ class Transform:
                         on_ocr_event=on_ocr_event,
                     )
                 )
-                render_markdown_file(
-                    chapters_path=chapters_path,
-                    assets_path=asserts_path,
-                    output_path=Path(markdown_path),
-                    output_assets_path=markdown_assets_path,
-                    cover_path=cover_path,
-                    aborted=aborted,
-                )
+                package = DocumentPackage(asserts_path.parent / "chapters", asserts_path,
+                                          asserts_path.parent / "toc.xml", cover_path)
+                MarkdownRenderer().render(package, Path(markdown_path),
+                                           Path(markdown_assets_path), cover_path, aborted)
                 return metering
 
         except Exception as raw_error:
@@ -164,19 +162,11 @@ class Transform:
                 )
                 book_meta = book_meta or self._extract_book_meta(pdf_path)
 
-                render_epub_file(
-                    chapters_path=chapters_path,
-                    toc_path=toc_path,
-                    assets_path=asserts_path,
-                    epub_path=Path(epub_path),
-                    book_meta=book_meta,
-                    lan=lan,
-                    cover_path=cover_path,
-                    table_render=table_render,
-                    latex_render=latex_render,
-                    inline_latex=inline_latex,
-                    aborted=aborted,
-                )
+                package = DocumentPackage(chapters_path, asserts_path, toc_path, cover_path)
+                EpubRenderer().render(package, Path(epub_path), book_meta=book_meta,
+                                       lan=lan, table_render=table_render,
+                                       latex_render=latex_render, inline_latex=inline_latex,
+                                       aborted=aborted)
                 return metering
 
         except Exception as raw_error:
@@ -258,6 +248,8 @@ class Transform:
         )
         if cover_path and not cover_path.exists():
             cover_path = None
+
+        DocumentPackage(chapters_path, asserts_path, toc_path, cover_path).write_metadata(dpi=dpi)
 
         return asserts_path, chapters_path, toc_path, cover_path, metering
 

--- a/pdf_craft/transform.py
+++ b/pdf_craft/transform.py
@@ -243,7 +243,10 @@ class Transform:
         if cover_path and not cover_path.exists():
             cover_path = None
 
-        DocumentPackage(chapters_path, asserts_path, toc_path, cover_path).write_metadata(dpi=dpi)
+        page_pixel_sizes = self._ocr.page_pixel_sizes(pdf_path, dpi)
+        DocumentPackage(chapters_path, asserts_path, toc_path, cover_path).write_metadata(
+            dpi=dpi if dpi is not None else 300, page_pixel_sizes=page_pixel_sizes
+        )
 
         return asserts_path, chapters_path, toc_path, cover_path, metering
 

--- a/pdf_craft/transform.py
+++ b/pdf_craft/transform.py
@@ -243,7 +243,7 @@ class Transform:
         if cover_path and not cover_path.exists():
             cover_path = None
 
-        page_pixel_sizes = self._ocr.page_pixel_sizes(pdf_path, dpi)
+        page_pixel_sizes = self._ocr.page_pixel_sizes(pdf_path, dpi, max_page_image_file_size)
         DocumentPackage(chapters_path, asserts_path, toc_path, cover_path).write_metadata(
             dpi=dpi if dpi is not None else 300, page_pixel_sizes=page_pixel_sizes
         )

--- a/pdf_craft/transform.py
+++ b/pdf_craft/transform.py
@@ -209,6 +209,7 @@ class Transform:
             input_tokens=0,
             output_tokens=0,
         )
+        existing_page_pixel_sizes = DocumentPackage.from_path(analysing_path).page_pixel_sizes()
         for event in self._ocr.recognize(
             pdf_path=pdf_path,
             asset_path=asserts_path,
@@ -243,7 +244,7 @@ class Transform:
         if cover_path and not cover_path.exists():
             cover_path = None
 
-        page_pixel_sizes = self._ocr.page_pixel_sizes(pdf_path, dpi, max_page_image_file_size)
+        page_pixel_sizes = existing_page_pixel_sizes | self._ocr.last_page_pixel_sizes
         DocumentPackage(chapters_path, asserts_path, toc_path, cover_path).write_metadata(
             dpi=dpi if dpi is not None else 300, page_pixel_sizes=page_pixel_sizes
         )

--- a/pdf_craft/transformer/__init__.py
+++ b/pdf_craft/transformer/__init__.py
@@ -1,3 +1,4 @@
 from .xml_translator.xml_translator import FillFailedEvent, SubmitKind, TranslationTask, XMLTranslator
+from .protocol import ChapterTransformer
 
-__all__ = ["FillFailedEvent", "SubmitKind", "TranslationTask", "XMLTranslator"]
+__all__ = ["ChapterTransformer", "FillFailedEvent", "SubmitKind", "TranslationTask", "XMLTranslator"]

--- a/pdf_craft/transformer/__init__.py
+++ b/pdf_craft/transformer/__init__.py
@@ -1,4 +1,5 @@
 from .xml_translator.xml_translator import FillFailedEvent, SubmitKind, TranslationTask, XMLTranslator
 from .protocol import ChapterTransformer
+from .chapter_xml import ChapterXMLTransformer
 
-__all__ = ["ChapterTransformer", "FillFailedEvent", "SubmitKind", "TranslationTask", "XMLTranslator"]
+__all__ = ["ChapterTransformer", "ChapterXMLTransformer", "FillFailedEvent", "SubmitKind", "TranslationTask", "XMLTranslator"]

--- a/pdf_craft/transformer/chapter_xml.py
+++ b/pdf_craft/transformer/chapter_xml.py
@@ -1,0 +1,22 @@
+from typing import Protocol
+from xml.etree.ElementTree import Element
+
+from pdf_craft.sequence.chapter import Chapter, decode, encode
+from .xml_translator.xml_translator import SubmitKind, TranslationTask
+
+
+class XMLTaskTranslator(Protocol):
+    """The public XMLTranslator subset required for a Chapter task."""
+    def translate_element(self, task: TranslationTask[Chapter], **kwargs) -> tuple[Element, Chapter]: ...
+
+
+class ChapterXMLTransformer:
+    """Adapt a format-neutral XML translator to the Chapter transformer protocol."""
+    def __init__(self, translator: XMLTaskTranslator) -> None:
+        self._translator = translator
+
+    def transform(self, chapter: Chapter) -> Chapter:
+        translated, _ = self._translator.translate_element(
+            TranslationTask(element=encode(chapter), action=SubmitKind.REPLACE, payload=chapter)
+        )
+        return decode(translated)

--- a/pdf_craft/transformer/protocol.py
+++ b/pdf_craft/transformer/protocol.py
@@ -1,0 +1,6 @@
+from typing import Protocol
+from pdf_craft.sequence.chapter import Chapter
+
+class ChapterTransformer(Protocol):
+    """Format-neutral transformation contract used by document pipelines."""
+    def transform(self, chapter: Chapter) -> Chapter: ...

--- a/tests/test_composable_boundaries.py
+++ b/tests/test_composable_boundaries.py
@@ -169,3 +169,16 @@ class TestComposableBoundaries(unittest.TestCase):
             package.metadata_path.write_text('{"schema": 1, "page_pixel_sizes": {"1": [1]}}')
             with self.assertRaisesRegex(ValueError, "page_pixel_sizes"):
                 package.validate()
+            package.metadata_path.write_text('{"schema": 1, "page_pixel_sizes": {"1": [1.5, 2]}}')
+            with self.assertRaisesRegex(ValueError, "page_pixel_sizes"):
+                package.validate()
+
+    def test_ocr_rejects_malformed_geometry_cache(self):
+        with tempfile.TemporaryDirectory() as directory:
+            root = Path(directory)
+            ocr_path = root / "ocr"
+            ocr_path.mkdir()
+            (ocr_path / "page_pixel_sizes.json").write_text('{"1": [1.5, 100]}')
+            ocr = OCR(DeepSeekOCRLocalConfig(local_only=True), cast(PDFHandler, _FakeHandler()))
+            with self.assertRaisesRegex(ValueError, "geometry cache"):
+                list(ocr.recognize(root / "input.pdf", root / "assets", ocr_path))

--- a/tests/test_composable_boundaries.py
+++ b/tests/test_composable_boundaries.py
@@ -8,6 +8,7 @@ from pdf_craft.document import DocumentPackage
 from pdf_craft.extractor import PDFExtractor
 from pdf_craft.pipeline.pdf.pipeline import PDFTranslationPipeline
 from pdf_craft.pipeline.pdf import PDFPatcher
+from pdf_craft.transformer import ChapterXMLTransformer
 from pdf_craft.renderer import EpubRenderer, MarkdownRenderer
 from pdf_craft.sequence.chapter import BlockLayout, Chapter, InlineExpression, ParagraphLayout, Reference
 from pdf_craft.expression import ExpressionKind
@@ -18,6 +19,9 @@ class _FakeTransform:
         (analysing_path / "chapters").mkdir(parents=True)
         (analysing_path / "assets").mkdir()
         (analysing_path / "toc.xml").write_text("<toc/>")
+        DocumentPackage.from_path(analysing_path).write_metadata(
+            dpi=300, page_pixel_sizes={1: (100, 100)}
+        )
         return None, None, None, None, "metering"
 
 
@@ -44,6 +48,16 @@ class _FakeHandler:
         return _FakeDocument()
 
 
+class _DeterministicXMLTranslator:
+    def translate_element(self, task, **_kwargs):
+        for node in task.element.iter():
+            if node.text:
+                node.text = "T:" + node.text
+            if node.tail:
+                node.tail = "T:" + node.tail
+        return task.element, task.payload
+
+
 class TestComposableBoundaries(unittest.TestCase):
     def test_extractor_produces_package_consumed_by_renderers_without_ocr_cache(self):
         with tempfile.TemporaryDirectory() as directory:
@@ -51,7 +65,7 @@ class TestComposableBoundaries(unittest.TestCase):
             package, metering = PDFExtractor(_FakeTransform()).extract_with_metering(root / "input.pdf", root / "package")
             self.assertEqual(metering, "metering")
             self.assertFalse((root / "package" / "ocr").exists())
-            self.assertEqual(package.page_pixel_sizes(), {})
+            self.assertEqual(package.page_pixel_sizes(), {1: (100, 100)})
             with patch("pdf_craft.renderer.markdown.renderer.render_markdown_file") as markdown:
                 MarkdownRenderer().render(package, root / "book.md")
             self.assertEqual(markdown.call_args.args[0], package.chapters_path)
@@ -67,14 +81,21 @@ class TestComposableBoundaries(unittest.TestCase):
             package.assets_path.mkdir()
             package.write_metadata(dpi=300, page_pixel_sizes={1: (100, 100)})
             reference = Reference(1, 2, "[1]", [])
-            chapter = Chapter(None, -1, [ParagraphLayout("text", 0, [BlockLayout(
-                1, 1, (1, 1, 50, 50), ["text ", InlineExpression(ExpressionKind.INLINE_DOLLAR, "x"), reference]
-            )])])
+            chapter = Chapter(None, -1, [
+                ParagraphLayout("text", 0, [BlockLayout(
+                    1, 1, (1, 1, 50, 50), ["text ", InlineExpression(ExpressionKind.INLINE_DOLLAR, "x"), reference]
+                )]),
+                ParagraphLayout("sub_title", 1, [BlockLayout(1, 2, (1, 50, 50, 90), ["heading"])]),
+            ])
             patcher = _CapturePatcher()
             with patch("pdf_craft.pipeline.pdf.pipeline.create_chapters_reader", return_value=lambda: iter([chapter])):
-                PDFTranslationPipeline(patcher=cast(PDFPatcher, patcher)).translate(root / "input.pdf", root / "out.pdf", package, lambda value: "T:" + value)
-            self.assertEqual(len(patcher.replacements), 1)
+                PDFTranslationPipeline(patcher=cast(PDFPatcher, patcher)).translate(
+                    root / "input.pdf", root / "out.pdf", package,
+                    ChapterXMLTransformer(_DeterministicXMLTranslator())
+                )
+            self.assertEqual(len(patcher.replacements), 2)
             replacement = patcher.replacements[0]
             self.assertEqual(replacement.page_pixel_size, (100, 100))
-            self.assertIn("$x$", replacement.text)
+            self.assertIn("$T:x$", replacement.text)
             self.assertIn("[1]", replacement.text)
+            self.assertIn("T:heading", patcher.replacements[1].text)

--- a/tests/test_composable_boundaries.py
+++ b/tests/test_composable_boundaries.py
@@ -1,0 +1,80 @@
+import tempfile
+import unittest
+from pathlib import Path
+from unittest.mock import patch
+from typing import cast
+
+from pdf_craft.document import DocumentPackage
+from pdf_craft.extractor import PDFExtractor
+from pdf_craft.pipeline.pdf.pipeline import PDFTranslationPipeline
+from pdf_craft.pipeline.pdf import PDFPatcher
+from pdf_craft.renderer import EpubRenderer, MarkdownRenderer
+from pdf_craft.sequence.chapter import BlockLayout, Chapter, InlineExpression, ParagraphLayout, Reference
+from pdf_craft.expression import ExpressionKind
+
+
+class _FakeTransform:
+    def extract_package(self, *, analysing_path, **_kwargs):
+        (analysing_path / "chapters").mkdir(parents=True)
+        (analysing_path / "assets").mkdir()
+        (analysing_path / "toc.xml").write_text("<toc/>")
+        return None, None, None, None, "metering"
+
+
+class _CapturePatcher:
+    def __init__(self):
+        self.replacements = []
+
+    def patch(self, _source, _target, replacements):
+        self.replacements = list(replacements)
+
+
+class _FakeDocument:
+    def render_page(self, _page_index, _dpi):
+        class Image:
+            size = (100, 100)
+        return Image()
+
+    def close(self):
+        pass
+
+
+class _FakeHandler:
+    def open(self, _path):
+        return _FakeDocument()
+
+
+class TestComposableBoundaries(unittest.TestCase):
+    def test_extractor_produces_package_consumed_by_renderers_without_ocr_cache(self):
+        with tempfile.TemporaryDirectory() as directory:
+            root = Path(directory)
+            package, metering = PDFExtractor(_FakeTransform()).extract_with_metering(root / "input.pdf", root / "package")
+            self.assertEqual(metering, "metering")
+            self.assertFalse((root / "package" / "ocr").exists())
+            self.assertEqual(package.page_pixel_sizes(), {})
+            with patch("pdf_craft.renderer.markdown.renderer.render_markdown_file") as markdown:
+                MarkdownRenderer().render(package, root / "book.md")
+            self.assertEqual(markdown.call_args.args[0], package.chapters_path)
+            with patch("pdf_craft.renderer.epub.renderer.render_epub_file") as epub:
+                EpubRenderer().render(package, root / "book.epub")
+            self.assertEqual(epub.call_args.args[0], package.chapters_path)
+
+    def test_pdf_pipeline_preserves_structured_content_and_uses_package_metadata(self):
+        with tempfile.TemporaryDirectory() as directory:
+            root = Path(directory)
+            package = DocumentPackage.from_path(root)
+            package.chapters_path.mkdir(parents=True)
+            package.assets_path.mkdir()
+            package.write_metadata(dpi=300, page_pixel_sizes={1: (100, 100)})
+            reference = Reference(1, 2, "[1]", [])
+            chapter = Chapter(None, -1, [ParagraphLayout("text", 0, [BlockLayout(
+                1, 1, (1, 1, 50, 50), ["text ", InlineExpression(ExpressionKind.INLINE_DOLLAR, "x"), reference]
+            )])])
+            patcher = _CapturePatcher()
+            with patch("pdf_craft.pipeline.pdf.pipeline.create_chapters_reader", return_value=lambda: iter([chapter])):
+                PDFTranslationPipeline(patcher=cast(PDFPatcher, patcher)).translate(root / "input.pdf", root / "out.pdf", package, lambda value: "T:" + value)
+            self.assertEqual(len(patcher.replacements), 1)
+            replacement = patcher.replacements[0]
+            self.assertEqual(replacement.page_pixel_size, (100, 100))
+            self.assertIn("$x$", replacement.text)
+            self.assertIn("[1]", replacement.text)

--- a/tests/test_composable_boundaries.py
+++ b/tests/test_composable_boundaries.py
@@ -12,8 +12,6 @@ from pdf_craft.transformer import ChapterXMLTransformer
 from pdf_craft.renderer import EpubRenderer, MarkdownRenderer
 from pdf_craft.sequence.chapter import BlockLayout, Chapter, InlineExpression, ParagraphLayout, Reference
 from pdf_craft.expression import ExpressionKind
-from pdf_craft.pdf.ocr import OCR
-from pdf_craft.pdf.handler import PDFHandler
 
 
 class _FakeTransform:
@@ -50,26 +48,6 @@ class _FakeHandler:
         return _FakeDocument()
 
 
-class _SizedDocument:
-    pages_count: int = 1
-
-    def page_size(self, _index):
-        return (10.0, 10.0)
-
-    def render_page(self, _page_index, dpi):
-        class Image:
-            size = (dpi * 10, dpi * 10)
-        return Image()
-
-    def close(self):
-        pass
-
-
-class _SizedHandler:
-    def open(self, _path):
-        return _SizedDocument()
-
-
 class _DeterministicXMLTranslator:
     def translate_element(self, task, **_kwargs):
         for node in task.element.iter():
@@ -87,6 +65,7 @@ class TestComposableBoundaries(unittest.TestCase):
             package, metering = PDFExtractor(_FakeTransform()).extract_with_metering(root / "input.pdf", root / "package")
             self.assertEqual(metering, "metering")
             self.assertFalse((root / "package" / "ocr").exists())
+            self.assertIsNone(package.cover_path)
             self.assertEqual(package.page_pixel_sizes(), {1: (100, 100)})
             with patch("pdf_craft.renderer.markdown.renderer.render_markdown_file") as markdown:
                 MarkdownRenderer().render(package, root / "book.md")
@@ -122,15 +101,12 @@ class TestComposableBoundaries(unittest.TestCase):
             self.assertIn("[1]", replacement.text)
             self.assertIn("T:heading", patcher.replacements[1].text)
 
-    def test_metadata_path_is_retained_for_direct_package_and_ocr_size_limit(self):
+    def test_metadata_path_is_retained_for_direct_package(self):
         with tempfile.TemporaryDirectory() as directory:
             root = Path(directory)
             package = DocumentPackage(root / "chapters", root / "assets")
             package.write_metadata(dpi=300, page_pixel_sizes={1: (30, 30)})
             self.assertEqual(package.page_pixel_sizes(), {1: (30, 30)})
-            ocr = object.__new__(OCR)
-            with patch.object(OCR, "_get_pdf_handler", return_value=cast(PDFHandler, _SizedHandler())):
-                self.assertEqual(ocr.page_pixel_sizes(root / "input.pdf", 300, 15_000), {1: (100, 100)})
 
     def test_epub_renderer_rejects_unsupported_language(self):
         with tempfile.TemporaryDirectory() as directory:

--- a/tests/test_composable_boundaries.py
+++ b/tests/test_composable_boundaries.py
@@ -146,7 +146,7 @@ class TestComposableBoundaries(unittest.TestCase):
             handler = _FakeHandler()
             first = OCR(DeepSeekOCRLocalConfig(local_only=True), cast(PDFHandler, handler))
             page = Page(1, None, [], [], 0, 0)
-            with patch.object(first._extractor, "image2page", return_value=page):
+            with patch("pdf_craft.pdf.ocr.PageExtractorNode.image2page", return_value=page):
                 events = first.recognize(root / "input.pdf", root / "assets", root / "ocr")
                 while next(events).kind.name != "COMPLETE":
                     pass

--- a/tests/test_composable_boundaries.py
+++ b/tests/test_composable_boundaries.py
@@ -12,6 +12,8 @@ from pdf_craft.transformer import ChapterXMLTransformer
 from pdf_craft.renderer import EpubRenderer, MarkdownRenderer
 from pdf_craft.sequence.chapter import BlockLayout, Chapter, InlineExpression, ParagraphLayout, Reference
 from pdf_craft.expression import ExpressionKind
+from pdf_craft.pdf.ocr import OCR
+from pdf_craft.pdf.handler import PDFHandler
 
 
 class _FakeTransform:
@@ -46,6 +48,26 @@ class _FakeDocument:
 class _FakeHandler:
     def open(self, _path):
         return _FakeDocument()
+
+
+class _SizedDocument:
+    pages_count: int = 1
+
+    def page_size(self, _index):
+        return (10.0, 10.0)
+
+    def render_page(self, _page_index, dpi):
+        class Image:
+            size = (dpi * 10, dpi * 10)
+        return Image()
+
+    def close(self):
+        pass
+
+
+class _SizedHandler:
+    def open(self, _path):
+        return _SizedDocument()
 
 
 class _DeterministicXMLTranslator:
@@ -99,3 +121,24 @@ class TestComposableBoundaries(unittest.TestCase):
             self.assertIn("$T:x$", replacement.text)
             self.assertIn("[1]", replacement.text)
             self.assertIn("T:heading", patcher.replacements[1].text)
+
+    def test_metadata_path_is_retained_for_direct_package_and_ocr_size_limit(self):
+        with tempfile.TemporaryDirectory() as directory:
+            root = Path(directory)
+            package = DocumentPackage(root / "chapters", root / "assets")
+            package.write_metadata(dpi=300, page_pixel_sizes={1: (30, 30)})
+            self.assertEqual(package.page_pixel_sizes(), {1: (30, 30)})
+            ocr = object.__new__(OCR)
+            with patch.object(OCR, "_get_pdf_handler", return_value=cast(PDFHandler, _SizedHandler())):
+                self.assertEqual(ocr.page_pixel_sizes(root / "input.pdf", 300, 15_000), {1: (100, 100)})
+
+    def test_epub_renderer_rejects_unsupported_language(self):
+        with tempfile.TemporaryDirectory() as directory:
+            root = Path(directory)
+            package = DocumentPackage.from_path(root)
+            package.chapters_path.mkdir()
+            package.assets_path.mkdir()
+            assert package.toc_path is not None
+            package.toc_path.write_text("<toc/>")
+            with self.assertRaises(ValueError):
+                EpubRenderer().render(package, root / "book.epub", lan="fr")  # type: ignore[arg-type]

--- a/tests/test_composable_boundaries.py
+++ b/tests/test_composable_boundaries.py
@@ -3,6 +3,7 @@ import unittest
 from pathlib import Path
 from unittest.mock import patch
 from typing import cast
+from PIL import Image
 
 from pdf_craft.document import DocumentPackage
 from pdf_craft.extractor import PDFExtractor
@@ -12,6 +13,10 @@ from pdf_craft.transformer import ChapterXMLTransformer
 from pdf_craft.renderer import EpubRenderer, MarkdownRenderer
 from pdf_craft.sequence.chapter import BlockLayout, Chapter, InlineExpression, ParagraphLayout, Reference
 from pdf_craft.expression import ExpressionKind
+from pdf_craft.ocr_config import DeepSeekOCRLocalConfig
+from pdf_craft.pdf.ocr import OCR
+from pdf_craft.pdf.handler import PDFHandler
+from pdf_craft.pdf.types import Page
 
 
 class _FakeTransform:
@@ -34,18 +39,34 @@ class _CapturePatcher:
 
 
 class _FakeDocument:
-    def render_page(self, _page_index, _dpi):
-        class Image:
-            size = (100, 100)
-        return Image()
+    pages_count = 1
+
+    def metadata(self):
+        raise AssertionError("metadata is not used by this OCR test")
+
+    def page_size(self, page_index):
+        del page_index
+        return (1.0, 1.0)
+
+    def render_page(self, *, page_index, dpi):
+        del page_index, dpi
+        self.render_count += 1
+        return Image.new("RGB", (100, 100))
+
+    def __init__(self):
+        self.render_count = 0
 
     def close(self):
         pass
 
 
 class _FakeHandler:
-    def open(self, _path):
-        return _FakeDocument()
+    def __init__(self):
+        self.document = _FakeDocument()
+
+    def open(self, pdf_path):
+        del pdf_path
+        return self.document
 
 
 class _DeterministicXMLTranslator:
@@ -118,3 +139,33 @@ class TestComposableBoundaries(unittest.TestCase):
             package.toc_path.write_text("<toc/>")
             with self.assertRaises(ValueError):
                 EpubRenderer().render(package, root / "book.epub", lan="fr")  # type: ignore[arg-type]
+
+    def test_ocr_geometry_cache_survives_interrupted_resume_without_rerendering(self):
+        with tempfile.TemporaryDirectory() as directory:
+            root = Path(directory)
+            handler = _FakeHandler()
+            first = OCR(DeepSeekOCRLocalConfig(local_only=True), cast(PDFHandler, handler))
+            page = Page(1, None, [], [], 0, 0)
+            with patch.object(first._extractor, "image2page", return_value=page):
+                events = first.recognize(root / "input.pdf", root / "assets", root / "ocr")
+                while next(events).kind.name != "COMPLETE":
+                    pass
+                events.close()
+            self.assertEqual(first.last_page_pixel_sizes, {1: (100, 100)})
+            self.assertEqual(handler.document.render_count, 1)
+
+            resumed = OCR(DeepSeekOCRLocalConfig(local_only=True), cast(PDFHandler, handler))
+            list(resumed.recognize(root / "input.pdf", root / "assets", root / "ocr"))
+            self.assertEqual(resumed.last_page_pixel_sizes, {1: (100, 100)})
+            self.assertEqual(handler.document.render_count, 1)
+
+    def test_package_rejects_malformed_page_geometry(self):
+        with tempfile.TemporaryDirectory() as directory:
+            root = Path(directory)
+            package = DocumentPackage.from_path(root)
+            package.chapters_path.mkdir()
+            package.assets_path.mkdir()
+            assert package.metadata_path is not None
+            package.metadata_path.write_text('{"schema": 1, "page_pixel_sizes": {"1": [1]}}')
+            with self.assertRaisesRegex(ValueError, "page_pixel_sizes"):
+                package.validate()


### PR DESCRIPTION
## Summary
- make PDFExtractor, DocumentPackage, and Markdown/EPUB renderers active composition boundaries
- record package coordinate metadata and adapt Chapter XML through XMLTranslator for PDF replacement
- add deterministic integration coverage for renderer and PDF pipeline composition

## Verification
- poetry run pytest -q
- poetry run pyright pdf_craft tests
- poetry run pylint pdf_craft tests

Real OCR and PDF translation were not executed.