### PR TITLE
Model translation as package transformation steps

### DIFF
--- a/pdf_craft/__init__.py
+++ b/pdf_craft/__init__.py
@@ -8,7 +8,7 @@ from .error import (
     PDFError,
 )
 from .functions import predownload_models, transform_epub, transform_markdown
-from .craft import ExtractionOptions, PDFCraft, PDFOptions
+from .craft import ExtractionOptions, PDFCraft, PDFOptions, TranslationStep
 from .pipeline.epub import translate_epub
 from .pipeline.pdf import PDFPatcher, PDFReplacement, PDFTranslationPipeline
 from .transformer import FillFailedEvent, SubmitKind, XMLTranslator

--- a/pdf_craft/craft.py
+++ b/pdf_craft/craft.py
@@ -4,7 +4,7 @@ from collections.abc import Callable, Container, Sequence
 from dataclasses import dataclass
 from os import PathLike
 from pathlib import Path
-from typing import Literal
+from typing import Literal, cast
 
 from epub_generator import BookMeta, LaTeXRender, TableRender
 
@@ -141,7 +141,8 @@ class PDFCraft:
         *, steps: Sequence[TranslationStep | PackageTransformer] = (),
     ) -> None:
         for step in steps:
-            if isinstance(step, TranslationStep) and step.mode == SubmitKind.APPEND_BLOCK:
+            mode = step.mode if isinstance(step, TranslationStep) else getattr(step, "mode", None)
+            if mode == SubmitKind.APPEND_BLOCK:
                 raise ValueError("PDF output does not support APPEND_BLOCK")
         package = self._apply_steps(package, steps)
         PDFTranslationPipeline(
@@ -205,7 +206,7 @@ class PDFCraft:
                     transformer.chapter_transformer, mode=step.mode
                 )
             return transformer
-        return ChapterPackageTransformer(transformer, mode=step.mode)
+        return ChapterPackageTransformer(cast(ChapterTransformer, transformer), mode=step.mode)
 
     def _pdf_engine(self):
         if self._engine is not None:

--- a/pdf_craft/craft.py
+++ b/pdf_craft/craft.py
@@ -1,6 +1,6 @@
 """Public facade that composes pdf-craft's independent components."""
 
-from collections.abc import Callable, Container
+from collections.abc import Callable, Container, Sequence
 from dataclasses import dataclass
 from os import PathLike
 from pathlib import Path
@@ -18,7 +18,15 @@ from .pdf import DeepSeekOCRSize, OCREvent, PDFHandler
 from .pipeline.epub import translate_epub as run_epub_translation
 from .pipeline.pdf import PDFTranslationPipeline
 from .renderer import EpubRenderer, MarkdownRenderer
-from .transformer import ChapterTransformer, SubmitKind
+from .transformer import ChapterTransformer, PackageTransformer, SubmitKind
+
+
+@dataclass(frozen=True)
+class TranslationStep:
+    """A user-requested content transformation inserted before rendering."""
+
+    transformer: PackageTransformer
+    mode: SubmitKind = SubmitKind.REPLACE
 
 
 @dataclass(frozen=True)
@@ -104,6 +112,19 @@ class PDFCraft:
                                   Path(assets_path) if assets_path is not None else None,
                                   aborted=aborted)
 
+    def transform_package(
+        self, package: DocumentPackage, output_path: PathLike | str,
+        steps: Sequence[TranslationStep | PackageTransformer],
+    ) -> DocumentPackage:
+        current = package
+        for step in steps:
+            transformer = step.transformer if isinstance(step, TranslationStep) else step
+            if isinstance(step, TranslationStep) and step.mode != SubmitKind.REPLACE and hasattr(transformer, "with_mode"):
+                transformer = transformer.with_mode(step.mode)
+            current = transformer.transform(current, Path(output_path))
+            output_path = Path(output_path).with_name(Path(output_path).name + ".next")
+        return current
+
     def render_epub(
         self, package: DocumentPackage, output: PathLike | str, *,
         book_meta: BookMeta | None = None, lan: Literal["zh", "en"] = "zh",
@@ -119,7 +140,12 @@ class PDFCraft:
     def translate_pdf(
         self, source: PathLike | str, package: DocumentPackage,
         output: PathLike | str, transformer: ChapterTransformer | Callable[[str], str],
+        *, steps: Sequence[TranslationStep | PackageTransformer] = (),
     ) -> None:
+        for step in steps:
+            if isinstance(step, TranslationStep) and step.mode == SubmitKind.APPEND_BLOCK:
+                raise ValueError("PDF output does not support APPEND_BLOCK")
+        package = self._apply_steps(package, steps)
         PDFTranslationPipeline(
             pdf_handler=self._pdf.pdf_handler if self._pdf else None
         ).translate(Path(source), Path(output), package, transformer)
@@ -133,8 +159,10 @@ class PDFCraft:
         self, source: PathLike | str, output: PathLike | str, *,
         package_path: PathLike | str, extraction: ExtractionOptions | None = None,
         assets_path: PathLike | str | None = None,
+        steps: Sequence[TranslationStep | PackageTransformer] = (),
     ) -> OCRTokensMetering:
         package, metering = self.extract_pdf_with_metering(source, package_path, extraction)
+        package = self._apply_steps(package, steps)
         self.render_markdown(package, output, assets_path, aborted=(extraction or ExtractionOptions()).aborted)
         return metering
 
@@ -145,15 +173,30 @@ class PDFCraft:
         table_render: TableRender = TableRender.HTML,
         latex_render: LaTeXRender = LaTeXRender.MATHML,
         inline_latex: bool = True,
+        steps: Sequence[TranslationStep | PackageTransformer] = (),
     ) -> OCRTokensMetering:
         extraction = extraction or ExtractionOptions()
         package, metering = self.extract_pdf_with_metering(source, package_path, extraction)
+        package = self._apply_steps(package, steps)
         if book_meta is None:
             book_meta = self._extract_book_meta(Path(source))
         self.render_epub(package, output, book_meta=book_meta, lan=lan,
                          table_render=table_render, latex_render=latex_render,
                          inline_latex=inline_latex, aborted=extraction.aborted)
         return metering
+
+    def _apply_steps(
+        self, package: DocumentPackage,
+        steps: Sequence[TranslationStep | PackageTransformer],
+    ) -> DocumentPackage:
+        current = package
+        for index, step in enumerate(steps):
+            transformer = step.transformer if isinstance(step, TranslationStep) else step
+            if isinstance(step, TranslationStep) and step.mode != SubmitKind.REPLACE and hasattr(transformer, "with_mode"):
+                transformer = transformer.with_mode(step.mode)
+            output = package.chapters_path.parent / f"transformed-{index}"
+            current = transformer.transform(current, output)
+        return current
 
     def _pdf_engine(self):
         if self._engine is not None:

--- a/pdf_craft/craft.py
+++ b/pdf_craft/craft.py
@@ -18,14 +18,14 @@ from .pdf import DeepSeekOCRSize, OCREvent, PDFHandler
 from .pipeline.epub import translate_epub as run_epub_translation
 from .pipeline.pdf import PDFTranslationPipeline
 from .renderer import EpubRenderer, MarkdownRenderer
-from .transformer import ChapterTransformer, PackageTransformer, SubmitKind
+from .transformer import ChapterPackageTransformer, ChapterTransformer, PackageTransformer, SubmitKind
 
 
 @dataclass(frozen=True)
 class TranslationStep:
     """A user-requested content transformation inserted before rendering."""
 
-    transformer: PackageTransformer
+    transformer: ChapterTransformer | PackageTransformer
     mode: SubmitKind = SubmitKind.REPLACE
 
 
@@ -118,9 +118,7 @@ class PDFCraft:
     ) -> DocumentPackage:
         current = package
         for step in steps:
-            transformer = step.transformer if isinstance(step, TranslationStep) else step
-            if isinstance(step, TranslationStep) and step.mode != SubmitKind.REPLACE and hasattr(transformer, "with_mode"):
-                transformer = transformer.with_mode(step.mode)
+            transformer = self._as_package_transformer(step)
             current = transformer.transform(current, Path(output_path))
             output_path = Path(output_path).with_name(Path(output_path).name + ".next")
         return current
@@ -191,12 +189,23 @@ class PDFCraft:
     ) -> DocumentPackage:
         current = package
         for index, step in enumerate(steps):
-            transformer = step.transformer if isinstance(step, TranslationStep) else step
-            if isinstance(step, TranslationStep) and step.mode != SubmitKind.REPLACE and hasattr(transformer, "with_mode"):
-                transformer = transformer.with_mode(step.mode)
+            transformer = self._as_package_transformer(step)
             output = package.chapters_path.parent / f"transformed-{index}"
             current = transformer.transform(current, output)
         return current
+
+    @staticmethod
+    def _as_package_transformer(step: TranslationStep | PackageTransformer):
+        if not isinstance(step, TranslationStep):
+            return step
+        transformer = step.transformer
+        if isinstance(transformer, ChapterPackageTransformer):
+            if step.mode != SubmitKind.REPLACE and transformer.mode != step.mode:
+                return ChapterPackageTransformer(
+                    transformer.chapter_transformer, mode=step.mode
+                )
+            return transformer
+        return ChapterPackageTransformer(transformer, mode=step.mode)
 
     def _pdf_engine(self):
         if self._engine is not None:

--- a/pdf_craft/functions.py
+++ b/pdf_craft/functions.py
@@ -1,4 +1,5 @@
 from os import PathLike
+from collections.abc import Sequence
 from typing import Callable, Literal
 
 from epub_generator import BookMeta, LaTeXRender, TableRender
@@ -9,6 +10,8 @@ from .metering import AbortedCheck, OCRTokensMetering
 from .ocr_config import OCRConfig, ensure_ocr_config
 from .pdf import OCR, DeepSeekOCRSize, OCREvent, PDFHandler
 from .transform import Transform
+from .transformer import PackageTransformer
+from .craft import TranslationStep
 
 
 def predownload_models(
@@ -47,6 +50,7 @@ def transform_markdown(
     max_ocr_output_tokens: int | None = None,
     on_ocr_event: Callable[[OCREvent], None] = lambda _: None,
     ocr: OCRConfig | None = None,
+    steps: Sequence[TranslationStep | PackageTransformer] = (),
 ) -> OCRTokensMetering:
     return Transform(
         models_cache_path=models_cache_path,
@@ -72,6 +76,7 @@ def transform_markdown(
         max_ocr_tokens=max_ocr_tokens,
         max_ocr_output_tokens=max_ocr_output_tokens,
         on_ocr_event=on_ocr_event,
+        steps=steps,
     )
 
 
@@ -102,6 +107,7 @@ def transform_epub(
     max_ocr_output_tokens: int | None = None,
     on_ocr_event: Callable[[OCREvent], None] = lambda _: None,
     ocr: OCRConfig | None = None,
+    steps: Sequence[TranslationStep | PackageTransformer] = (),
 ) -> OCRTokensMetering:
     return Transform(
         models_cache_path=models_cache_path,
@@ -131,4 +137,5 @@ def transform_epub(
         max_ocr_tokens=max_ocr_tokens,
         max_ocr_output_tokens=max_ocr_output_tokens,
         on_ocr_event=on_ocr_event,
+        steps=steps,
     )

--- a/pdf_craft/smoke/runner.py
+++ b/pdf_craft/smoke/runner.py
@@ -3,6 +3,7 @@ import platform
 import shutil
 import traceback
 import uuid
+from copy import deepcopy
 from dataclasses import asdict, dataclass
 from datetime import UTC, datetime
 from pathlib import Path
@@ -12,7 +13,7 @@ from typing import Any, Literal, cast
 from pdf_craft.craft import ExtractionOptions, PDFCraft, PDFOptions, TranslationStep
 from pdf_craft.ocr_config import OCRConfig, OCRMode
 from pdf_craft.transformer import SubmitKind
-from pdf_craft.sequence.chapter import HTMLTag
+from pdf_craft.sequence.chapter import BlockLayout, BlockMember, Chapter, HTMLTag, ParagraphLayout
 from pdf_craft.llm import LLM
 
 from .assets import SmokeAsset, discover_assets
@@ -194,15 +195,33 @@ def _run_pdf(
 class _DeterministicChapterTransformer:
     def __init__(self, marker: str) -> None:
         self.marker = marker
+        self.mode = SubmitKind.REPLACE
 
-    def transform(self, chapter):
+    def with_mode(self, mode: SubmitKind) -> "_DeterministicChapterTransformer":
+        transformer = _DeterministicChapterTransformer(self.marker)
+        transformer.mode = mode
+        return transformer
+
+    def transform(self, chapter: Chapter) -> Chapter:
         for layout in chapter.layouts:
-            blocks = getattr(layout, "blocks", ())
-            for block in blocks:
-                block.content = [self._transform_item(item) for item in block.content]
+            if not isinstance(layout, ParagraphLayout):
+                continue
+            transformed_blocks: list[BlockLayout] = []
+            for block in layout.blocks:
+                translated = BlockLayout(
+                    page_index=block.page_index,
+                    order=block.order,
+                    det=block.det,
+                    content=[self._transform_item(item) for item in deepcopy(block.content)],
+                )
+                if self.mode == SubmitKind.APPEND_BLOCK:
+                    transformed_blocks.extend((block, translated))
+                else:
+                    transformed_blocks.append(translated)
+            layout.blocks = transformed_blocks
         return chapter
 
-    def _transform_item(self, item):
+    def _transform_item(self, item: str | BlockMember | HTMLTag[BlockMember]):
         if isinstance(item, str):
             return item + self.marker
         if isinstance(item, HTMLTag):

--- a/pdf_craft/smoke/runner.py
+++ b/pdf_craft/smoke/runner.py
@@ -9,9 +9,10 @@ from pathlib import Path
 from time import perf_counter
 from typing import Any, Literal, cast
 
-from pdf_craft.craft import ExtractionOptions, PDFCraft, PDFOptions
+from pdf_craft.craft import ExtractionOptions, PDFCraft, PDFOptions, TranslationStep
 from pdf_craft.ocr_config import OCRConfig, OCRMode
 from pdf_craft.transformer import SubmitKind
+from pdf_craft.sequence.chapter import HTMLTag
 from pdf_craft.llm import LLM
 
 from .assets import SmokeAsset, discover_assets
@@ -156,13 +157,22 @@ def _run_pdf(
     if run.route == "markdown":
         markdown = output_path / "book.md"
         markdown_assets = output_path / "assets"
+        steps = _package_steps(run)
+        if steps:
+            package = craft.transform_package(package, run_path / "translated", steps)
         craft.render_markdown(package, markdown, markdown_assets)
         errors.extend(check_markdown(markdown, markdown_assets))
+        marker = (run.translation or {}).get("package_marker")
+        if isinstance(marker, str) and marker not in markdown.read_text(encoding="utf-8"):
+            errors.append(f"Package translation marker missing from Markdown: {marker}")
         details["outputs"] = [str(markdown)]
         status, errors = _result_from_errors(errors)
         return status, errors, details
     if run.route == "epub":
         epub = output_path / "book.epub"
+        steps = _package_steps(run)
+        if steps:
+            package = craft.transform_package(package, run_path / "translated", steps)
         craft.render_epub(package, epub)
         errors.extend(check_epub(epub))
         details["outputs"] = [str(epub)]
@@ -179,6 +189,35 @@ def _run_pdf(
     details["outputs"] = [str(target)]
     status, errors = _result_from_errors(errors)
     return status, errors, details
+
+
+class _DeterministicChapterTransformer:
+    def __init__(self, marker: str) -> None:
+        self.marker = marker
+
+    def transform(self, chapter):
+        for layout in chapter.layouts:
+            blocks = getattr(layout, "blocks", ())
+            for block in blocks:
+                block.content = [self._transform_item(item) for item in block.content]
+        return chapter
+
+    def _transform_item(self, item):
+        if isinstance(item, str):
+            return item + self.marker
+        if isinstance(item, HTMLTag):
+            item.children = [self._transform_item(child) for child in item.children]
+        return item
+
+
+def _package_steps(run: SmokeRun):
+    translation = run.translation or {}
+    marker = translation.get("package_marker")
+    if not isinstance(marker, str):
+        return ()
+    mode = SubmitKind[translation.get("package_submit", "REPLACE").upper()]
+    from pdf_craft.transformer import ChapterPackageTransformer
+    return (TranslationStep(ChapterPackageTransformer(_DeterministicChapterTransformer(marker)), mode),)
 
 
 def _result_from_errors(errors: list[str]) -> tuple[str, list[str]]:

--- a/pdf_craft/smoke/runner.py
+++ b/pdf_craft/smoke/runner.py
@@ -132,17 +132,23 @@ def _run_pdf(
     package_path = run_path / "package"
     output_path = run_path / "output"
     craft = PDFCraft(pdf=PDFOptions(ocr=ocr))
-    package, metering = craft.extract_pdf_with_metering(
-        asset.path, package_path, ExtractionOptions(
-            page_indexes=run.page_indexes, ocr_size=cast(Any, run.ocr_size), dpi=run.dpi,
-            max_page_image_file_size=run.max_page_image_file_size,
-            max_ocr_tokens=run.max_ocr_tokens,
-            max_ocr_output_tokens=run.max_ocr_output_tokens,
-            includes_cover=run.includes_cover,
-            includes_footnotes=run.includes_footnotes,
-            generate_plot=run.generate_plot, toc_assumed=run.toc_assumed,
+    try:
+        package, metering = craft.extract_pdf_with_metering(
+            asset.path, package_path, ExtractionOptions(
+                page_indexes=run.page_indexes, ocr_size=cast(Any, run.ocr_size), dpi=run.dpi,
+                max_page_image_file_size=run.max_page_image_file_size,
+                max_ocr_tokens=run.max_ocr_tokens,
+                max_ocr_output_tokens=run.max_ocr_output_tokens,
+                includes_cover=run.includes_cover,
+                includes_footnotes=run.includes_footnotes,
+                generate_plot=run.generate_plot, toc_assumed=run.toc_assumed,
+            )
         )
-    )
+    except Exception as error:
+        unavailable = _unavailable_ocr_reason(error)
+        if unavailable is not None:
+            return "skipped", [unavailable], {"package": str(package_path)}
+        raise
     details = {
         "package": str(package_path),
         "metering": {"input_tokens": metering.input_tokens, "output_tokens": metering.output_tokens},
@@ -190,6 +196,16 @@ def _run_pdf(
     details["outputs"] = [str(target)]
     status, errors = _result_from_errors(errors)
     return status, errors, details
+
+
+def _unavailable_ocr_reason(error: Exception) -> str | None:
+    """Recognise infrastructure gaps without hiding extraction failures."""
+    current: BaseException | None = error
+    while current is not None:
+        if "No CUDA devices available" in str(current):
+            return "OCR backend unavailable: local OCR requires CUDA, but no CUDA device is available"
+        current = current.__cause__ or current.__context__
+    return None
 
 
 class _DeterministicChapterTransformer:

--- a/pdf_craft/transform.py
+++ b/pdf_craft/transform.py
@@ -1,5 +1,6 @@
 from os import PathLike
 from pathlib import Path
+from collections.abc import Sequence
 from typing import Callable, Container, Literal, NoReturn
 
 from epub_generator import BookMeta, LaTeXRender, TableRender
@@ -21,6 +22,8 @@ from .sequence import generate_chapter_files
 from .to_path import to_path
 from .toc import analyse_toc
 from .document import DocumentPackage
+from .craft import TranslationStep
+from .transformer import PackageTransformer
 
 
 class Transform:
@@ -66,6 +69,7 @@ class Transform:
         max_ocr_tokens: int | None = None,
         max_ocr_output_tokens: int | None = None,
         on_ocr_event: Callable[[OCREvent], None] = lambda _: None,
+        steps: Sequence[TranslationStep | PackageTransformer] = (),
     ) -> OCRTokensMetering:  # pyright: ignore[reportReturnType]
         # Compatibility wrapper.  PDFCraft owns the production workflow.
         from .craft import ExtractionOptions, PDFCraft
@@ -85,6 +89,7 @@ class Transform:
                         aborted=aborted, max_ocr_tokens=max_ocr_tokens,
                         max_ocr_output_tokens=max_ocr_output_tokens, on_ocr_event=on_ocr_event,
                     ),
+                    steps=steps,
                 )
         except Exception as error:
             self._raise_compatibility_error(error, pdf_path, "markdown")
@@ -113,6 +118,7 @@ class Transform:
         max_ocr_tokens: int | None = None,
         max_ocr_output_tokens: int | None = None,
         on_ocr_event: Callable[[OCREvent], None] = lambda _: None,
+        steps: Sequence[TranslationStep | PackageTransformer] = (),
     ) -> OCRTokensMetering:  # pyright: ignore[reportReturnType]
         from .craft import ExtractionOptions, PDFCraft
         try:
@@ -130,6 +136,7 @@ class Transform:
                         aborted=aborted, max_ocr_tokens=max_ocr_tokens,
                         max_ocr_output_tokens=max_ocr_output_tokens, on_ocr_event=on_ocr_event,
                     ),
+                    steps=steps,
                 )
         except Exception as error:
             self._raise_compatibility_error(error, pdf_path, "epub")

--- a/pdf_craft/transformer/__init__.py
+++ b/pdf_craft/transformer/__init__.py
@@ -1,5 +1,6 @@
 from .xml_translator.xml_translator import FillFailedEvent, SubmitKind, TranslationTask, XMLTranslator
 from .protocol import ChapterTransformer
 from .chapter_xml import ChapterXMLTransformer
+from .package import ChapterPackageTransformer, PackageTransformer
 
-__all__ = ["ChapterTransformer", "ChapterXMLTransformer", "FillFailedEvent", "SubmitKind", "TranslationTask", "XMLTranslator"]
+__all__ = ["ChapterTransformer", "ChapterXMLTransformer", "ChapterPackageTransformer", "PackageTransformer", "FillFailedEvent", "SubmitKind", "TranslationTask", "XMLTranslator"]

--- a/pdf_craft/transformer/chapter_xml.py
+++ b/pdf_craft/transformer/chapter_xml.py
@@ -12,11 +12,20 @@ class XMLTaskTranslator(Protocol):
 
 class ChapterXMLTransformer:
     """Adapt a format-neutral XML translator to the Chapter transformer protocol."""
-    def __init__(self, translator: XMLTaskTranslator) -> None:
+    def __init__(self, translator: XMLTaskTranslator, mode: SubmitKind = SubmitKind.REPLACE) -> None:
         self._translator = translator
+        self._mode = mode
+
+    @property
+    def mode(self) -> SubmitKind:
+        return self._mode
+
+    def with_mode(self, mode: SubmitKind) -> "ChapterXMLTransformer":
+        """Return a transformer using the requested XML submission mode."""
+        return ChapterXMLTransformer(self._translator, mode)
 
     def transform(self, chapter: Chapter) -> Chapter:
         translated, _ = self._translator.translate_element(
-            TranslationTask(element=encode(chapter), action=SubmitKind.REPLACE, payload=chapter)
+            TranslationTask(element=encode(chapter), action=self._mode, payload=chapter)
         )
         return decode(translated)

--- a/pdf_craft/transformer/package.py
+++ b/pdf_craft/transformer/package.py
@@ -9,6 +9,7 @@ from xml.etree.ElementTree import Element
 from pdf_craft.common.xml import read_xml, save_xml
 from pdf_craft.document import DocumentPackage
 from pdf_craft.sequence.chapter import decode, encode
+from pdf_craft.transformer.protocol import ChapterTransformer
 from pdf_craft.transformer.xml_translator.xml_translator import SubmitKind
 
 
@@ -23,13 +24,13 @@ class ChapterPackageTransformer:
 
     def __init__(
         self,
-        chapter_transformer: Callable,
+        chapter_transformer: ChapterTransformer,
         *,
         mode: SubmitKind = SubmitKind.REPLACE,
         toc_transformer: Callable[[Element], Element] | None = None,
     ) -> None:
         if mode != SubmitKind.REPLACE and hasattr(chapter_transformer, "with_mode"):
-            chapter_transformer = chapter_transformer.with_mode(mode)
+            chapter_transformer = getattr(chapter_transformer, "with_mode")(mode)
         self.chapter_transformer = chapter_transformer
         self.mode = mode
         self.toc_transformer = toc_transformer

--- a/pdf_craft/transformer/package.py
+++ b/pdf_craft/transformer/package.py
@@ -1,0 +1,55 @@
+"""Transformers operating on render-ready document packages."""
+
+from collections.abc import Callable
+from pathlib import Path
+from shutil import copy2, copytree
+from typing import Protocol
+from xml.etree.ElementTree import Element
+
+from pdf_craft.common.xml import read_xml, save_xml
+from pdf_craft.document import DocumentPackage
+from pdf_craft.sequence.chapter import decode, encode
+from pdf_craft.transformer.xml_translator.xml_translator import SubmitKind
+
+
+class PackageTransformer(Protocol):
+    """A format-neutral transformation from one package to another."""
+
+    def transform(self, package: DocumentPackage, output_path: Path) -> DocumentPackage: ...
+
+
+class ChapterPackageTransformer:
+    """Copy a package and transform its chapter XML files independently."""
+
+    def __init__(
+        self,
+        chapter_transformer: Callable,
+        *,
+        mode: SubmitKind = SubmitKind.REPLACE,
+        toc_transformer: Callable[[Element], Element] | None = None,
+    ) -> None:
+        if mode != SubmitKind.REPLACE and hasattr(chapter_transformer, "with_mode"):
+            chapter_transformer = chapter_transformer.with_mode(mode)
+        self.chapter_transformer = chapter_transformer
+        self.mode = mode
+        self.toc_transformer = toc_transformer
+
+    def transform(self, package: DocumentPackage, output_path: Path) -> DocumentPackage:
+        package.validate()
+        if output_path.exists():
+            raise FileExistsError(f"output package already exists: {output_path}")
+        output_path.mkdir(parents=True)
+        copytree(package.chapters_path, output_path / "chapters")
+        copytree(package.assets_path, output_path / "assets")
+        for source in (package.toc_path, package.cover_path, package.metadata_path):
+            if source is not None and source.exists():
+                copy2(source, output_path / source.name)
+
+        for path in sorted((output_path / "chapters").glob("chapter*.xml")):
+            chapter = decode(read_xml(path))
+            transformed = self.chapter_transformer.transform(chapter)
+            save_xml(encode(transformed), path)
+
+        if self.toc_transformer is not None and package.toc_path is not None and package.toc_path.exists():
+            save_xml(self.toc_transformer(read_xml(output_path / package.toc_path.name)), output_path / package.toc_path.name)
+        return DocumentPackage.from_path(output_path).validate()

--- a/tests/smoke/minimal.json
+++ b/tests/smoke/minimal.json
@@ -1,0 +1,18 @@
+{
+  "defaults": {
+    "page_indexes": [1],
+    "ocr_size": "tiny",
+    "translation": {
+      "package_marker": "[smoke-translated]",
+      "package_submit": "REPLACE"
+    }
+  },
+  "runs": [
+    {
+      "asset": "double_column.pdf",
+      "route": "markdown",
+      "backend": "deepseek-ocr-local",
+      "ocr": {}
+    }
+  ]
+}

--- a/tests/test_craft.py
+++ b/tests/test_craft.py
@@ -2,13 +2,15 @@ import tempfile
 import unittest
 from pathlib import Path
 from unittest.mock import Mock, patch
+from xml.etree.ElementTree import tostring
 
-from pdf_craft.craft import ExtractionOptions, PDFCraft, PDFOptions
+from pdf_craft.craft import ExtractionOptions, PDFCraft, PDFOptions, TranslationStep
 from pdf_craft.document import DocumentPackage
 from pdf_craft.error import InterruptedError as PDFInterruptedError, PDFError
 from pdf_craft.metering import InterruptedKind, OCRTokensMetering
+from pdf_craft.sequence.chapter import BlockLayout, Chapter, ParagraphLayout, encode
 from pdf_craft.transform import Transform
-from pdf_craft.transformer import SubmitKind
+from pdf_craft.transformer import ChapterPackageTransformer, SubmitKind
 
 
 class _Engine:
@@ -30,6 +32,43 @@ class _Engine:
 
 
 class TestPDFCraft(unittest.TestCase):
+    def test_package_step_creates_independent_package(self):
+        with tempfile.TemporaryDirectory() as directory:
+            root = Path(directory)
+            source = DocumentPackage.from_path(root / "source")
+            source.chapters_path.mkdir(parents=True)
+            source.assets_path.mkdir()
+            source.toc_path.write_text("<toc page_indexes=\"1\" />")
+            source.write_metadata(page_pixel_sizes={1: (10, 10)})
+            chapter = Chapter(
+                None, -1, [ParagraphLayout(
+                    "text", 0, [BlockLayout(1, 1, (1, 1, 5, 5), ["original"])]
+                )]
+            )
+            (source.chapters_path / "chapter_1.xml").write_text(
+                '<?xml version="1.0" encoding="UTF-8"?>\n'
+                + tostring(encode(chapter), encoding="unicode")
+            )
+
+            class Upper:
+                def transform(self, value):
+                    value.layouts[0].blocks[0].content = ["translated"]
+                    return value
+
+            target = ChapterPackageTransformer(Upper()).transform(source, root / "target")
+            self.assertEqual(target.page_pixel_sizes(), {1: (10, 10)})
+            self.assertIn("original", (source.chapters_path / "chapter_1.xml").read_text())
+            self.assertIn("translated", (target.chapters_path / "chapter_1.xml").read_text())
+
+    def test_pdf_rejects_append_block_steps_before_transforming(self):
+        craft = PDFCraft.from_engine(_Engine())
+        step = TranslationStep(Mock(), SubmitKind.APPEND_BLOCK)
+        with self.assertRaisesRegex(ValueError, "APPEND_BLOCK"):
+            craft.translate_pdf(
+                "source.pdf", DocumentPackage(Path("chapters"), Path("assets")),
+                "out.pdf", lambda text: text, steps=[step]
+            )
+
     def test_epub_only_facade_needs_no_pdf_options(self):
         craft = PDFCraft()
         with patch("pdf_craft.craft.run_epub_translation") as translate:

--- a/tests/test_craft.py
+++ b/tests/test_craft.py
@@ -38,6 +38,7 @@ class TestPDFCraft(unittest.TestCase):
             source = DocumentPackage.from_path(root / "source")
             source.chapters_path.mkdir(parents=True)
             source.assets_path.mkdir()
+            assert source.toc_path is not None
             source.toc_path.write_text("<toc page_indexes=\"1\" />")
             source.write_metadata(page_pixel_sizes={1: (10, 10)})
             chapter = Chapter(
@@ -51,14 +52,42 @@ class TestPDFCraft(unittest.TestCase):
             )
 
             class Upper:
-                def transform(self, value):
-                    value.layouts[0].blocks[0].content = ["translated"]
-                    return value
+                def transform(self, chapter: Chapter) -> Chapter:
+                    layout = chapter.layouts[0]
+                    assert isinstance(layout, ParagraphLayout)
+                    layout.blocks[0].content = ["translated"]
+                    return chapter
 
             target = ChapterPackageTransformer(Upper()).transform(source, root / "target")
             self.assertEqual(target.page_pixel_sizes(), {1: (10, 10)})
             self.assertIn("original", (source.chapters_path / "chapter_1.xml").read_text())
             self.assertIn("translated", (target.chapters_path / "chapter_1.xml").read_text())
+            assert target.toc_path is not None
+            self.assertEqual(source.toc_path.read_text(), target.toc_path.read_text())
+
+    def test_package_toc_transform_is_explicit(self):
+        with tempfile.TemporaryDirectory() as directory:
+            root = Path(directory)
+            source = DocumentPackage.from_path(root / "source")
+            source.chapters_path.mkdir(parents=True)
+            source.assets_path.mkdir()
+            assert source.toc_path is not None
+            source.toc_path.write_text('<toc page_indexes="1"><item /></toc>')
+            source.write_metadata(page_pixel_sizes={1: (10, 10)})
+
+            class Identity:
+                def transform(self, chapter: Chapter) -> Chapter:
+                    return chapter
+
+            def translate_toc(element):
+                element.set("translated", "yes")
+                return element
+
+            target = ChapterPackageTransformer(
+                Identity(), toc_transformer=translate_toc
+            ).transform(source, root / "target")
+            assert target.toc_path is not None
+            self.assertIn('translated="yes"', target.toc_path.read_text())
 
     def test_pdf_rejects_append_block_steps_before_transforming(self):
         craft = PDFCraft.from_engine(_Engine())
@@ -67,6 +96,15 @@ class TestPDFCraft(unittest.TestCase):
             craft.translate_pdf(
                 "source.pdf", DocumentPackage(Path("chapters"), Path("assets")),
                 "out.pdf", lambda text: text, steps=[step]
+            )
+
+    def test_pdf_rejects_append_block_package_transformer(self):
+        craft = PDFCraft.from_engine(_Engine())
+        transformer = ChapterPackageTransformer(Mock(), mode=SubmitKind.APPEND_BLOCK)
+        with self.assertRaisesRegex(ValueError, "APPEND_BLOCK"):
+            craft.translate_pdf(
+                "source.pdf", DocumentPackage(Path("chapters"), Path("assets")),
+                "out.pdf", lambda text: text, steps=[transformer]
             )
 
     def test_epub_only_facade_needs_no_pdf_options(self):

--- a/tests/test_functions.py
+++ b/tests/test_functions.py
@@ -1,8 +1,10 @@
 import unittest
-from unittest.mock import patch
+from unittest.mock import MagicMock, patch
 
 from pdf_craft import DeepSeekOCRLocalConfig
 from pdf_craft import functions
+from pdf_craft.craft import TranslationStep
+from pdf_craft.transformer import SubmitKind
 
 
 class TestConvenienceFunctions(unittest.TestCase):
@@ -76,6 +78,20 @@ class TestConvenienceFunctions(unittest.TestCase):
         self.assertIsNone(transform_kwargs["ocr"])
         _, method_kwargs = transform_cls.return_value.transform_epub.call_args
         self.assertEqual(method_kwargs["dpi"], 300)
+
+    def test_transform_markdown_forwards_package_steps(self):
+        step = TranslationStep(transformer=MagicMock(), mode=SubmitKind.REPLACE)
+        with patch.object(functions, "Transform") as transform_cls:
+            functions.transform_markdown("input.pdf", "output.md", steps=[step])
+        _, kwargs = transform_cls.return_value.transform_markdown.call_args
+        self.assertEqual(kwargs["steps"], [step])
+
+    def test_transform_epub_forwards_package_steps(self):
+        step = TranslationStep(transformer=MagicMock(), mode=SubmitKind.APPEND_BLOCK)
+        with patch.object(functions, "Transform") as transform_cls:
+            functions.transform_epub("input.pdf", "output.epub", steps=[step])
+        _, kwargs = transform_cls.return_value.transform_epub.call_args
+        self.assertEqual(kwargs["steps"], [step])
 
 
 if __name__ == "__main__":

--- a/tests/test_smoke.py
+++ b/tests/test_smoke.py
@@ -137,35 +137,23 @@ class TestSmokeMatrix(unittest.TestCase):
             ])])
             save_xml(encode_chapter(chapter), package_path / "chapters" / "chapter_1.xml")
 
-            class FakeCraft:
-                def __init__(self):
-                    self.steps = ()
-
-                def extract_pdf_with_metering(self, *_args, **_kwargs):
-                    return package, OCRTokensMetering(0, 0)
-
-                def transform_package(self, source, output, steps):
-                    self.steps = steps
-                    from pdf_craft.craft import PDFCraft
-                    return PDFCraft().transform_package(source, output, steps)
-
-                def render_markdown(self, transformed, output, _assets):
-                    output.write_text((transformed.chapters_path / "chapter_1.xml").read_text())
-
-            fake = FakeCraft()
             run = SmokeRun(
                 "double_column.pdf", "markdown",
                 translation={"package_marker": "[translated]", "package_submit": "APPEND_BLOCK"},
             )
             asset = SmokeAsset("double_column.pdf", "pdf", Path("source.pdf"))
-            with patch("pdf_craft.smoke.runner.PDFCraft", return_value=fake):
+            from pdf_craft.craft import PDFCraft
+            craft = PDFCraft()
+            with patch("pdf_craft.smoke.runner.PDFCraft", return_value=craft), \
+                    patch.object(craft, "extract_pdf_with_metering", return_value=(
+                        package, OCRTokensMetering(0, 0)
+                    )):
                 status, errors, details = _run_pdf(run, asset, root, cast(OCRConfig, None))
             self.assertEqual(status, "passed", errors)
             rendered = (root / "output" / "book.md").read_text()
             self.assertIn("original", rendered)
             self.assertIn("original[translated]", rendered)
             self.assertEqual(details["outputs"], [str(root / "output" / "book.md")])
-            self.assertEqual(len(fake.steps), 1)
 
 
 def _write_epub(path: Path, files: dict[str, str]) -> Path:

--- a/tests/test_smoke.py
+++ b/tests/test_smoke.py
@@ -154,13 +154,16 @@ class TestSmokeMatrix(unittest.TestCase):
 
             fake = FakeCraft()
             run = SmokeRun(
-                "double_column.pdf", "markdown", translation={"package_marker": "[translated]"}
+                "double_column.pdf", "markdown",
+                translation={"package_marker": "[translated]", "package_submit": "APPEND_BLOCK"},
             )
             asset = SmokeAsset("double_column.pdf", "pdf", Path("source.pdf"))
             with patch("pdf_craft.smoke.runner.PDFCraft", return_value=fake):
                 status, errors, details = _run_pdf(run, asset, root, cast(OCRConfig, None))
             self.assertEqual(status, "passed", errors)
-            self.assertIn("[translated]", (root / "output" / "book.md").read_text())
+            rendered = (root / "output" / "book.md").read_text()
+            self.assertIn("original", rendered)
+            self.assertIn("original[translated]", rendered)
             self.assertEqual(details["outputs"], [str(root / "output" / "book.md")])
             self.assertEqual(len(fake.steps), 1)
 

--- a/tests/test_smoke.py
+++ b/tests/test_smoke.py
@@ -3,15 +3,20 @@ import tempfile
 import unittest
 import zipfile
 from pathlib import Path
+from typing import cast
 from unittest.mock import patch
 
 from pdf_craft.document import DocumentPackage
 from pdf_craft.extractor import PDFExtractor
+from pdf_craft.metering import OCRTokensMetering
+from pdf_craft.ocr_config import OCRConfig
 from pdf_craft.smoke.assets import discover_assets
 from pdf_craft.smoke.checks import check_epub
 from pdf_craft.smoke.checks import check_pdf_patch_geometry
-from pdf_craft.smoke.runner import SmokeRun, expand_matrix, run_smoke
+from pdf_craft.smoke.runner import SmokeAsset, SmokeRun, _run_pdf, expand_matrix, run_smoke
+from pdf_craft.common.xml import save_xml
 from pdf_craft.sequence.chapter import BlockLayout, Chapter, ParagraphLayout
+from pdf_craft.sequence.chapter import encode as encode_chapter
 
 
 class _CaptureTransform:
@@ -116,6 +121,48 @@ class TestSmokeMatrix(unittest.TestCase):
             with patch("pdf_craft.smoke.checks.create_chapters_reader", return_value=lambda: iter([chapter])):
                 errors = check_pdf_patch_geometry(package)
             self.assertEqual(errors, ["PDF patch geometry missing for replacement pages: [2]"])
+
+    def test_markdown_route_inserts_deterministic_package_step(self):
+        with tempfile.TemporaryDirectory() as directory:
+            root = Path(directory)
+            (root / "output").mkdir()
+            package_path = root / "package"
+            package_path.joinpath("chapters").mkdir(parents=True)
+            package_path.joinpath("assets").mkdir()
+            package_path.joinpath("toc.xml").write_text("<toc />")
+            package = DocumentPackage.from_path(package_path)
+            package.write_metadata(page_pixel_sizes={1: (10, 10)})
+            chapter = Chapter(None, -1, [ParagraphLayout("text", 0, [
+                BlockLayout(1, 1, (1, 1, 2, 2), ["original"])
+            ])])
+            save_xml(encode_chapter(chapter), package_path / "chapters" / "chapter_1.xml")
+
+            class FakeCraft:
+                def __init__(self):
+                    self.steps = ()
+
+                def extract_pdf_with_metering(self, *_args, **_kwargs):
+                    return package, OCRTokensMetering(0, 0)
+
+                def transform_package(self, source, output, steps):
+                    self.steps = steps
+                    from pdf_craft.craft import PDFCraft
+                    return PDFCraft().transform_package(source, output, steps)
+
+                def render_markdown(self, transformed, output, _assets):
+                    output.write_text((transformed.chapters_path / "chapter_1.xml").read_text())
+
+            fake = FakeCraft()
+            run = SmokeRun(
+                "double_column.pdf", "markdown", translation={"package_marker": "[translated]"}
+            )
+            asset = SmokeAsset("double_column.pdf", "pdf", Path("source.pdf"))
+            with patch("pdf_craft.smoke.runner.PDFCraft", return_value=fake):
+                status, errors, details = _run_pdf(run, asset, root, cast(OCRConfig, None))
+            self.assertEqual(status, "passed", errors)
+            self.assertIn("[translated]", (root / "output" / "book.md").read_text())
+            self.assertEqual(details["outputs"], [str(root / "output" / "book.md")])
+            self.assertEqual(len(fake.steps), 1)
 
 
 def _write_epub(path: Path, files: dict[str, str]) -> Path:

--- a/tests/test_smoke.py
+++ b/tests/test_smoke.py
@@ -122,6 +122,30 @@ class TestSmokeMatrix(unittest.TestCase):
                 errors = check_pdf_patch_geometry(package)
             self.assertEqual(errors, ["PDF patch geometry missing for replacement pages: [2]"])
 
+    def test_pdf_route_skips_when_local_ocr_has_no_cuda_device(self):
+        with tempfile.TemporaryDirectory() as directory:
+            root = Path(directory)
+            (root / "package").mkdir()
+            (root / "output").mkdir()
+
+            class UnavailableCraft:
+                def extract_pdf_with_metering(self, *_args, **_kwargs):
+                    try:
+                        raise RuntimeError("No CUDA devices available")
+                    except RuntimeError as cause:
+                        raise ValueError("OCR extraction failed") from cause
+
+            run = SmokeRun("double_column.pdf", "markdown")
+            asset = SmokeAsset("double_column.pdf", "pdf", Path("source.pdf"))
+            with patch("pdf_craft.smoke.runner.PDFCraft", return_value=UnavailableCraft()):
+                status, errors, details = _run_pdf(run, asset, root, cast(OCRConfig, None))
+            self.assertEqual(status, "skipped")
+            self.assertEqual(
+                errors,
+                ["OCR backend unavailable: local OCR requires CUDA, but no CUDA device is available"],
+            )
+            self.assertEqual(details["package"], str(root / "package"))
+
     def test_markdown_route_inserts_deterministic_package_step(self):
         with tempfile.TemporaryDirectory() as directory:
             root = Path(directory)


### PR DESCRIPTION
## Summary
- add immutable package transformation steps before PDF Markdown/EPUB rendering
- support replace and append-block semantics while keeping PDF patching replace-only
- route facade, compatibility APIs, and smoke runs through the package step path

## Verification
- poetry run python test.py
- poetry run pyright
- poetry run pylint pdf_craft tests
- git diff --check