### PR TITLE
fix: harden package translation workflows

### DIFF
--- a/pdf_craft/__init__.py
+++ b/pdf_craft/__init__.py
@@ -11,7 +11,13 @@ from .functions import predownload_models, transform_epub, transform_markdown
 from .craft import ExtractionOptions, PDFCraft, PDFOptions, TranslationStep
 from .pipeline.epub import translate_epub
 from .pipeline.pdf import PDFPatcher, PDFReplacement, PDFTranslationPipeline
-from .transformer import FillFailedEvent, SubmitKind, XMLTranslator
+from .transformer import (
+    ChapterPackageTransformer,
+    FillFailedEvent,
+    PackageTransformer,
+    SubmitKind,
+    XMLTranslator,
+)
 from .llm import LLM
 from .metering import AbortedCheck, InterruptedKind, OCRTokensMetering
 from .ocr_config import (

--- a/pdf_craft/craft.py
+++ b/pdf_craft/craft.py
@@ -229,11 +229,18 @@ class PDFCraft:
 
 
 def _accepts_package(transformer: ChapterTransformer | PackageTransformer) -> bool:
-    """Distinguish the two public transformer contracts by their bound method."""
+    """Recognise the public PackageTransformer method shape explicitly."""
     try:
-        return len(signature(transformer.transform).parameters) >= 2
+        parameters = list(signature(transformer.transform).parameters.values())
     except (TypeError, ValueError):
         return False
+    positional = [
+        parameter for parameter in parameters
+        if parameter.kind in (parameter.POSITIONAL_ONLY, parameter.POSITIONAL_OR_KEYWORD)
+    ]
+    return len(positional) == 2 and [parameter.name for parameter in positional] == [
+        "package", "output_path"
+    ]
 
 
 def _step_mode(step: TranslationStep | PackageTransformer, transformer: PackageTransformer) -> SubmitKind | None:

--- a/pdf_craft/craft.py
+++ b/pdf_craft/craft.py
@@ -2,6 +2,7 @@
 
 from collections.abc import Callable, Container, Sequence
 from dataclasses import dataclass
+from inspect import signature
 from os import PathLike
 from pathlib import Path
 from typing import Literal, cast
@@ -141,7 +142,7 @@ class PDFCraft:
         *, steps: Sequence[TranslationStep | PackageTransformer] = (),
     ) -> None:
         for step in steps:
-            mode = step.mode if isinstance(step, TranslationStep) else getattr(step, "mode", None)
+            mode = _step_mode(step, self._as_package_transformer(step))
             if mode == SubmitKind.APPEND_BLOCK:
                 raise ValueError("PDF output does not support APPEND_BLOCK")
         package = self._apply_steps(package, steps)
@@ -196,7 +197,7 @@ class PDFCraft:
         return current
 
     @staticmethod
-    def _as_package_transformer(step: TranslationStep | PackageTransformer):
+    def _as_package_transformer(step: TranslationStep | PackageTransformer) -> PackageTransformer:
         if not isinstance(step, TranslationStep):
             return step
         transformer = step.transformer
@@ -206,6 +207,8 @@ class PDFCraft:
                     transformer.chapter_transformer, mode=step.mode
                 )
             return transformer
+        if _accepts_package(transformer):
+            return cast(PackageTransformer, transformer)
         return ChapterPackageTransformer(cast(ChapterTransformer, transformer), mode=step.mode)
 
     def _pdf_engine(self):
@@ -223,3 +226,17 @@ class PDFCraft:
         engine = self._pdf_engine()
         extract = getattr(engine, "_extract_book_meta", None)
         return extract(source) if extract is not None else None
+
+
+def _accepts_package(transformer: ChapterTransformer | PackageTransformer) -> bool:
+    """Distinguish the two public transformer contracts by their bound method."""
+    try:
+        return len(signature(transformer.transform).parameters) >= 2
+    except (TypeError, ValueError):
+        return False
+
+
+def _step_mode(step: TranslationStep | PackageTransformer, transformer: PackageTransformer) -> SubmitKind | None:
+    if isinstance(step, TranslationStep):
+        return step.mode if step.mode != SubmitKind.REPLACE else getattr(transformer, "mode", step.mode)
+    return getattr(transformer, "mode", None)

--- a/pdf_craft/smoke/runner.py
+++ b/pdf_craft/smoke/runner.py
@@ -3,6 +3,7 @@ import platform
 import shutil
 import traceback
 import uuid
+import zipfile
 from copy import deepcopy
 from dataclasses import asdict, dataclass
 from datetime import UTC, datetime
@@ -170,7 +171,7 @@ def _run_pdf(
         craft.render_markdown(package, markdown, markdown_assets)
         errors.extend(check_markdown(markdown, markdown_assets))
         marker = (run.translation or {}).get("package_marker")
-        if isinstance(marker, str) and marker not in markdown.read_text(encoding="utf-8"):
+        if isinstance(marker, str) and markdown.is_file() and marker not in markdown.read_text(encoding="utf-8"):
             errors.append(f"Package translation marker missing from Markdown: {marker}")
         details["outputs"] = [str(markdown)]
         status, errors = _result_from_errors(errors)
@@ -182,6 +183,9 @@ def _run_pdf(
             package = craft.transform_package(package, run_path / "translated", steps)
         craft.render_epub(package, epub)
         errors.extend(check_epub(epub))
+        marker = (run.translation or {}).get("package_marker")
+        if isinstance(marker, str) and not _epub_contains_marker(epub, marker):
+            errors.append(f"Package translation marker missing from EPUB: {marker}")
         details["outputs"] = [str(epub)]
         status, errors = _result_from_errors(errors)
         return status, errors, details
@@ -206,6 +210,18 @@ def _unavailable_ocr_reason(error: Exception) -> str | None:
             return "OCR backend unavailable: local OCR requires CUDA, but no CUDA device is available"
         current = current.__cause__ or current.__context__
     return None
+
+
+def _epub_contains_marker(epub: Path, marker: str) -> bool:
+    if not zipfile.is_zipfile(epub):
+        return False
+    encoded_marker = marker.encode("utf-8")
+    with zipfile.ZipFile(epub) as archive:
+        return any(
+            encoded_marker in archive.read(name)
+            for name in archive.namelist()
+            if name.lower().endswith((".xhtml", ".html"))
+        )
 
 
 class _DeterministicChapterTransformer:

--- a/tests/test_craft.py
+++ b/tests/test_craft.py
@@ -121,6 +121,16 @@ class TestPDFCraft(unittest.TestCase):
                 steps=[TranslationStep(CustomPackageTransformer(), SubmitKind.APPEND_BLOCK)],
             )
 
+    def test_optional_chapter_transformer_is_not_treated_as_package_transformer(self):
+        class OptionalChapterTransformer:
+            def transform(self, chapter: Chapter, *, trace: bool = False) -> Chapter:
+                del trace
+                return chapter
+
+        step = TranslationStep(OptionalChapterTransformer())
+        transformer = getattr(PDFCraft, "_as_package_transformer")(step)
+        self.assertIsInstance(transformer, ChapterPackageTransformer)
+
     def test_epub_only_facade_needs_no_pdf_options(self):
         craft = PDFCraft()
         with patch("pdf_craft.craft.run_epub_translation") as translate:

--- a/tests/test_craft.py
+++ b/tests/test_craft.py
@@ -107,6 +107,20 @@ class TestPDFCraft(unittest.TestCase):
                 "out.pdf", lambda text: text, steps=[transformer]
             )
 
+    def test_pdf_rejects_append_block_custom_package_step(self):
+        class CustomPackageTransformer:
+            def transform(self, package: DocumentPackage, output_path: Path) -> DocumentPackage:
+                del output_path
+                return package
+
+        craft = PDFCraft.from_engine(_Engine())
+        with self.assertRaisesRegex(ValueError, "APPEND_BLOCK"):
+            craft.translate_pdf(
+                "source.pdf", DocumentPackage(Path("chapters"), Path("assets")),
+                "out.pdf", lambda text: text,
+                steps=[TranslationStep(CustomPackageTransformer(), SubmitKind.APPEND_BLOCK)],
+            )
+
     def test_epub_only_facade_needs_no_pdf_options(self):
         craft = PDFCraft()
         with patch("pdf_craft.craft.run_epub_translation") as translate:

--- a/tests/test_smoke.py
+++ b/tests/test_smoke.py
@@ -13,7 +13,14 @@ from pdf_craft.ocr_config import OCRConfig
 from pdf_craft.smoke.assets import discover_assets
 from pdf_craft.smoke.checks import check_epub
 from pdf_craft.smoke.checks import check_pdf_patch_geometry
-from pdf_craft.smoke.runner import SmokeAsset, SmokeRun, _run_pdf, expand_matrix, run_smoke
+from pdf_craft.smoke.runner import (
+    SmokeAsset,
+    SmokeRun,
+    _epub_contains_marker,
+    _run_pdf,
+    expand_matrix,
+    run_smoke,
+)
 from pdf_craft.common.xml import save_xml
 from pdf_craft.sequence.chapter import BlockLayout, Chapter, ParagraphLayout
 from pdf_craft.sequence.chapter import encode as encode_chapter
@@ -73,6 +80,11 @@ class TestSmokeMatrix(unittest.TestCase):
 
     def test_epub_check_validates_epub3_navigation_fixture(self):
         self.assertEqual(check_epub(Path("tests/assets/epub/DeepSeek OCR.epub")), [])
+
+    def test_epub_marker_check_rejects_renderer_output_without_translation(self):
+        with tempfile.TemporaryDirectory() as directory:
+            path = _write_epub(Path(directory), {"chapter.xhtml": "<p>original</p>"})
+            self.assertFalse(_epub_contains_marker(path, "[translated]"))
 
     def test_epub_check_rejects_malformed_container(self):
         with tempfile.TemporaryDirectory() as directory:

--- a/tests/test_smoke.py
+++ b/tests/test_smoke.py
@@ -86,6 +86,14 @@ class TestSmokeMatrix(unittest.TestCase):
             path = _write_epub(Path(directory), {"chapter.xhtml": "<p>original</p>"})
             self.assertFalse(_epub_contains_marker(path, "[translated]"))
 
+    def test_epub_marker_check_accepts_xhtml_and_html_content(self):
+        with tempfile.TemporaryDirectory() as directory:
+            path = _write_epub(Path(directory), {
+                "chapter.xhtml": "<p>[translated]</p>",
+                "appendix.html": "<p>[translated]</p>",
+            })
+            self.assertTrue(_epub_contains_marker(path, "[translated]"))
+
     def test_epub_check_rejects_malformed_container(self):
         with tempfile.TemporaryDirectory() as directory:
             path = _write_epub(Path(directory), {"META-INF/container.xml": "<container>"})

--- a/tests/test_smoke.py
+++ b/tests/test_smoke.py
@@ -88,11 +88,11 @@ class TestSmokeMatrix(unittest.TestCase):
 
     def test_epub_marker_check_accepts_xhtml_and_html_content(self):
         with tempfile.TemporaryDirectory() as directory:
-            path = _write_epub(Path(directory), {
-                "chapter.xhtml": "<p>[translated]</p>",
-                "appendix.html": "<p>[translated]</p>",
-            })
-            self.assertTrue(_epub_contains_marker(path, "[translated]"))
+            root = Path(directory)
+            for name in ("chapter.xhtml", "appendix.html"):
+                with self.subTest(name=name):
+                    path = _write_epub(root, {name: "<p>[translated]</p>"})
+                    self.assertTrue(_epub_contains_marker(path, "[translated]"))
 
     def test_epub_check_rejects_malformed_container(self):
         with tempfile.TemporaryDirectory() as directory:


### PR DESCRIPTION
Follow-up to #384 addressing post-merge automated review findings.\n\nVerification: poetry run python test.py; poetry run pyright; poetry run pylint pdf_craft tests.