### PR TITLE
feat: fit PDF patch text within OCR boxes

### DIFF
--- a/pdf_craft/__init__.py
+++ b/pdf_craft/__init__.py
@@ -10,7 +10,7 @@ from .error import (
 from .functions import predownload_models, transform_epub, transform_markdown
 from .craft import ExtractionOptions, PDFCraft, PDFOptions, TranslationStep
 from .pipeline.epub import translate_epub
-from .pipeline.pdf import PDFPatcher, PDFReplacement, PDFTranslationPipeline
+from .pipeline.pdf import PDFPatcher, PDFReplacement, PDFSkippedReplacement, PDFTranslationPipeline, PatchTextOptions
 from .transformer import (
     ChapterPackageTransformer,
     FillFailedEvent,

--- a/pdf_craft/pipeline/pdf/__init__.py
+++ b/pdf_craft/pipeline/pdf/__init__.py
@@ -1,4 +1,8 @@
-from .patcher import PDFPatcher, PDFReplacement
+from .patcher import PDFPatcher, PDFReplacement, PDFSkippedReplacement
 from .pipeline import PDFTranslationPipeline
+from .text_layout import BoxTextLayout, PatchTextOptions
 
-__all__ = ["PDFPatcher", "PDFReplacement", "PDFTranslationPipeline"]
+__all__ = [
+    "BoxTextLayout", "PatchTextOptions", "PDFPatcher", "PDFReplacement",
+    "PDFSkippedReplacement", "PDFTranslationPipeline",
+]

--- a/pdf_craft/pipeline/pdf/patcher.py
+++ b/pdf_craft/pipeline/pdf/patcher.py
@@ -3,6 +3,8 @@ from pathlib import Path
 from tempfile import NamedTemporaryFile
 from typing import Iterable
 
+from .text_layout import BoxTextLayout, PatchTextOptions
+
 
 @dataclass(frozen=True)
 class PDFReplacement:
@@ -13,6 +15,15 @@ class PDFReplacement:
     dpi: int = 300
 
 
+@dataclass(frozen=True)
+class PDFSkippedReplacement:
+    """An explicitly skipped overflow, retained for callers to inspect."""
+
+    page_index: int
+    bbox: tuple[int, int, int, int]
+    reason: str
+
+
 class PDFPatcher:
     """Replace OCR-backed text regions in a PDF with translated text.
 
@@ -21,9 +32,32 @@ class PDFPatcher:
     not need the patching stack at import time.
     """
 
-    def __init__(self, font_name: str = "Helvetica", font_size: float = 10.0) -> None:
-        self.font_name = font_name
-        self.font_size = font_size
+    def __init__(
+        self,
+        font_name: str | None = None,
+        font_size: float | None = None,
+        options: PatchTextOptions | None = None,
+    ) -> None:
+        """Create a patcher.
+
+        ``font_name`` and ``font_size`` remain accepted for compatibility. A
+        supplied font size is the maximum fitted size, not a forced size.
+        """
+        if options is not None and (font_name is not None or font_size is not None):
+            raise ValueError("pass either options or legacy font_name/font_size arguments")
+        if options is None:
+            defaults = PatchTextOptions()
+            options = PatchTextOptions(
+                font_name=font_name if font_name is not None else defaults.font_name,
+                max_font_size=font_size if font_size is not None else defaults.max_font_size,
+                min_font_size=min(
+                    defaults.min_font_size,
+                    font_size if font_size is not None else defaults.min_font_size,
+                ),
+            )
+        self.options = options
+        self._layout = BoxTextLayout(options)
+        self.skipped_replacements: tuple[PDFSkippedReplacement, ...] = ()
 
     def patch(self, source_path: Path, target_path: Path, replacements: Iterable[PDFReplacement]) -> None:
         try:
@@ -33,29 +67,51 @@ class PDFPatcher:
             raise RuntimeError("PDF patching requires the optional 'reportlab' dependency") from error
 
         reader = pypdf.PdfReader(str(source_path))
-        target_path.parent.mkdir(parents=True, exist_ok=True)
+        skipped: list[PDFSkippedReplacement] = []
         replacements_by_page: dict[int, list[PDFReplacement]] = {}
         for replacement in replacements:
             self.validate(replacement, pages_count=len(reader.pages))
             replacements_by_page.setdefault(replacement.page_index, []).append(replacement)
 
+        # Preflight all pages before drawing any white rectangles or creating a
+        # target file. A failed fit must not masquerade as a successful patch.
+        layouts: dict[int, list[tuple[PDFReplacement, object]]] = {}
+        for index, page in enumerate(reader.pages, 1):
+            width = float(page.mediabox.width)
+            height = float(page.mediabox.height)
+            for replacement in replacements_by_page.get(index, []):
+                try:
+                    fitted = self._fit_replacement(replacement, width, height)
+                except ValueError as error:
+                    if self.options.overflow == "skip":
+                        skipped.append(PDFSkippedReplacement(index, replacement.bbox, str(error)))
+                        continue
+                    raise ValueError(
+                        f"page {index}, bbox {replacement.bbox}: {error}"
+                    ) from error
+                layouts.setdefault(index, []).append((replacement, fitted))
+
         writer = pypdf.PdfWriter()
         for index, page in enumerate(reader.pages, 1):
-            page_replacements = replacements_by_page.get(index, [])
-            if page_replacements:
+            page_layouts = layouts.get(index, [])
+            if page_layouts:
                 width = float(page.mediabox.width)
                 height = float(page.mediabox.height)
                 with NamedTemporaryFile(suffix=".pdf") as overlay_file:
                     overlay = canvas.Canvas(overlay_file.name, pagesize=(width, height))
-                    for replacement in page_replacements:
-                        self._draw_replacement(overlay, replacement, width, height)
+                    for replacement, fitted in page_layouts:
+                        self._draw_replacement(overlay, replacement, fitted, width, height)
                     overlay.save()
                     overlay_reader = pypdf.PdfReader(overlay_file.name)
                     page.merge_page(overlay_reader.pages[0])
             writer.add_page(page)
 
-        with target_path.open("wb") as output:
+        target_path.parent.mkdir(parents=True, exist_ok=True)
+        with NamedTemporaryFile(dir=target_path.parent, suffix=".pdf", delete=False) as output:
+            temporary_path = Path(output.name)
             writer.write(output)
+        temporary_path.replace(target_path)
+        self.skipped_replacements = tuple(skipped)
 
     def validate(self, replacement: PDFReplacement, pages_count: int | None = None) -> None:
         left, top, right, bottom = replacement.bbox
@@ -72,37 +128,28 @@ class PDFPatcher:
         if right > replacement.page_pixel_size[0] or bottom > replacement.page_pixel_size[1]:
             raise ValueError("bbox exceeds page_pixel_size")
 
-    def _draw_replacement(self, overlay, replacement: PDFReplacement, width: float, height: float) -> None:
+    def _fit_replacement(self, replacement: PDFReplacement, width: float, height: float):
+        _, _, box_width, box_height = self._box_in_points(replacement, width, height)
+        return self._layout.fit(replacement.text, box_width, box_height)
+
+    @staticmethod
+    def _box_in_points(replacement: PDFReplacement, width: float, height: float) -> tuple[float, float, float, float]:
         pixel_width, pixel_height = replacement.page_pixel_size
         left, top, right, bottom = replacement.bbox
         scale_x = width / pixel_width
         scale_y = height / pixel_height
         x = left * scale_x
         y = height - bottom * scale_y
-        box_width = (right - left) * scale_x
-        box_height = (bottom - top) * scale_y
+        return x, y, (right - left) * scale_x, (bottom - top) * scale_y
+
+    def _draw_replacement(self, overlay, replacement: PDFReplacement, fitted, width: float, height: float) -> None:
+        x, y, box_width, box_height = self._box_in_points(replacement, width, height)
 
         overlay.setFillColorRGB(1, 1, 1)
         overlay.rect(x, y, box_width, box_height, stroke=0, fill=1)
         overlay.setFillColorRGB(0, 0, 0)
-        overlay.setFont(self.font_name, self.font_size)
-        line_height = self.font_size * 1.2
-        words = replacement.text.split()
-        lines: list[str] = []
-        current = ""
-        for word in words:
-            candidate = f"{current} {word}".strip()
-            if current and overlay.stringWidth(candidate, self.font_name, self.font_size) > box_width:
-                lines.append(current)
-                current = word
-            else:
-                current = candidate
-        if current:
-            lines.append(current)
-        if not lines:
-            lines = [replacement.text]
-        max_lines = max(1, int(box_height // line_height))
-        text = overlay.beginText(x + 1, y + box_height - line_height)
-        for line in lines[:max_lines]:
-            text.textLine(line)
-        overlay.drawText(text)
+        fitted.paragraph.drawOn(
+            overlay,
+            x + self.options.horizontal_padding,
+            y + box_height - self.options.vertical_padding - fitted.height,
+        )

--- a/pdf_craft/pipeline/pdf/text_layout.py
+++ b/pdf_craft/pipeline/pdf/text_layout.py
@@ -1,0 +1,139 @@
+"""ReportLab paragraph fitting for OCR source rectangles."""
+
+from dataclasses import dataclass
+from typing import Any, Literal, cast
+from xml.sax.saxutils import escape
+
+
+Alignment = Literal["left", "center", "right", "justify"]
+
+
+@dataclass(frozen=True)
+class PatchTextOptions:
+    """Typography and failure policy for text replacing an OCR bounding box."""
+
+    font_name: str = "STSong-Light"
+    max_font_size: float = 12.0
+    min_font_size: float = 4.0
+    line_height: float = 1.2
+    horizontal_padding: float = 1.0
+    vertical_padding: float = 1.0
+    alignment: Alignment = "left"
+    overflow: Literal["error", "skip"] = "error"
+
+
+@dataclass(frozen=True)
+class FittedParagraph:
+    """A paragraph proven to fit within a particular rectangle."""
+
+    paragraph: Any
+    font_size: float
+    width: float
+    height: float
+
+
+class BoxTextLayout:
+    """Fit continuous text into a fixed ReportLab rectangle without truncation."""
+
+    def __init__(self, options: PatchTextOptions | None = None) -> None:
+        self.options = options or PatchTextOptions()
+        self._validate_options()
+
+    def fit(self, text: str, width: float, height: float) -> FittedParagraph:
+        """Return the largest quarter-point Paragraph that completely fits."""
+        normalized = " ".join(text.split())
+        if not normalized:
+            raise ValueError("replacement text must not be empty")
+        available_width = width - (2 * self.options.horizontal_padding)
+        available_height = height - (2 * self.options.vertical_padding)
+        if available_width <= 0 or available_height <= 0:
+            raise ValueError("bbox is too small after text padding")
+
+        self._ensure_font(normalized)
+        minimum = self._paragraph(normalized, self.options.min_font_size)
+        minimum_width, minimum_height = self._natural_size(minimum, available_width)
+        if minimum_width > available_width or minimum_height > available_height:
+            raise ValueError(
+                "replacement text cannot fit bbox at minimum font size "
+                f"{self.options.min_font_size}: required {minimum_width:.2f}x{minimum_height:.2f}, "
+                f"available {available_width:.2f}x{available_height:.2f}"
+            )
+
+        low = int(round(self.options.min_font_size * 4))
+        high = int(round(self.options.max_font_size * 4))
+        best: FittedParagraph | None = None
+        while low <= high:
+            middle = (low + high) // 2
+            font_size = middle / 4
+            paragraph = self._paragraph(normalized, font_size)
+            natural_width, natural_height = self._natural_size(paragraph, available_width)
+            if natural_width <= available_width and natural_height <= available_height:
+                best = FittedParagraph(paragraph, font_size, natural_width, natural_height)
+                low = middle + 1
+            else:
+                high = middle - 1
+        if best is None:  # Defensive: min size was already checked above.
+            raise ValueError("replacement text cannot fit bbox")
+        return best
+
+    def _paragraph(self, text: str, font_size: float):
+        from reportlab.lib.enums import TA_CENTER, TA_JUSTIFY, TA_LEFT, TA_RIGHT
+        from reportlab.lib.styles import ParagraphStyle
+        from reportlab.platypus import Paragraph
+
+        alignment = {
+            "left": TA_LEFT,
+            "center": TA_CENTER,
+            "right": TA_RIGHT,
+            "justify": TA_JUSTIFY,
+        }[self.options.alignment]
+        style = ParagraphStyle(
+            "pdf-craft-patch",
+            fontName=self.options.font_name,
+            fontSize=font_size,
+            leading=font_size * self.options.line_height,
+            alignment=cast(Any, alignment),
+            wordWrap="CJK",
+        )
+        return Paragraph(escape(text), style)
+
+    @staticmethod
+    def _natural_size(paragraph, width: float) -> tuple[float, float]:
+        # A very tall frame asks Platypus for the full natural height rather
+        # than allowing a too-short frame to split and hide trailing content.
+        return paragraph.wrap(width, 1_000_000)
+
+    def _ensure_font(self, text: str) -> None:
+        from reportlab.pdfbase import pdfmetrics
+        from reportlab.pdfbase.cidfonts import UnicodeCIDFont
+
+        if self.options.font_name == "STSong-Light":
+            try:
+                pdfmetrics.getFont(self.options.font_name)
+            except KeyError:
+                pdfmetrics.registerFont(UnicodeCIDFont(self.options.font_name))
+        try:
+            pdfmetrics.getFont(self.options.font_name)
+        except KeyError as error:
+            raise ValueError(f"PDF patch font is unavailable: {self.options.font_name}") from error
+        if any(ord(character) > 255 for character in text) and self.options.font_name in {
+            "Courier", "Courier-Bold", "Courier-Oblique", "Courier-BoldOblique",
+            "Helvetica", "Helvetica-Bold", "Helvetica-Oblique", "Helvetica-BoldOblique",
+            "Times-Roman", "Times-Bold", "Times-Italic", "Times-BoldItalic",
+        }:
+            raise ValueError(
+                f"font {self.options.font_name} cannot reliably draw non-Latin replacement text"
+            )
+
+    def _validate_options(self) -> None:
+        options = self.options
+        if options.min_font_size <= 0 or options.max_font_size < options.min_font_size:
+            raise ValueError("font sizes must be positive and max_font_size >= min_font_size")
+        if options.line_height <= 0:
+            raise ValueError("line_height must be positive")
+        if options.horizontal_padding < 0 or options.vertical_padding < 0:
+            raise ValueError("text padding must not be negative")
+        if options.alignment not in {"left", "center", "right", "justify"}:
+            raise ValueError(f"unsupported text alignment: {options.alignment}")
+        if options.overflow not in {"error", "skip"}:
+            raise ValueError(f"unsupported overflow policy: {options.overflow}")

--- a/tests/test_pdf_patcher.py
+++ b/tests/test_pdf_patcher.py
@@ -1,11 +1,12 @@
 import tempfile
 import unittest
 from pathlib import Path
+from typing import Any
 
 import pypdf
 from reportlab.pdfgen import canvas
 
-from pdf_craft.pipeline.pdf import PDFPatcher, PDFReplacement
+from pdf_craft.pipeline.pdf import BoxTextLayout, PDFPatcher, PDFReplacement, PatchTextOptions
 
 
 class TestPDFPatcher(unittest.TestCase):
@@ -51,3 +52,63 @@ class TestPDFPatcher(unittest.TestCase):
                     root / "target.pdf",
                     [PDFReplacement(2, (1, 1, 10, 10), "text", (100, 100))],
                 )
+
+    def test_cjk_multiline_replacement_has_text_layer_and_fits_source_bbox(self):
+        with tempfile.TemporaryDirectory() as temp_dir:
+            root = Path(temp_dir)
+            source = root / "source.pdf"
+            target = root / "target.pdf"
+            doc = canvas.Canvas(str(source), pagesize=(200, 200))
+            doc.drawString(1, 1, "source")
+            doc.save()
+            replacement = PDFReplacement(
+                1, (60, 60, 360, 360), "\u8fd9\u662f\u4e00\u6bb5\u6ca1\u6709\u7a7a\u683c\u7684\u4e2d\u6587\u8bd1\u6587\uff0c\u5b83\u5e94\u8be5\u5728\u65b9\u6846\u5185\u81ea\u52a8\u6362\u884c\u3002" * 3, (600, 600)
+            )
+            patcher = PDFPatcher(options=PatchTextOptions(max_font_size=12, min_font_size=4))
+
+            fitted = BoxTextLayout(patcher.options).fit(replacement.text, 100, 100)
+            self.assertGreater(len(fitted.paragraph.blPara.lines), 1)
+            self.assertLessEqual(fitted.height + 2, 100)
+            patcher.patch(source, target, [replacement])
+
+            reader = pypdf.PdfReader(str(target))
+            self.assertEqual(len(reader.pages), 1)
+            page: Any = reader.pages[0]
+            self.assertIn("\u8fd9\u662f\u4e00\u6bb5", page.extract_text())  # pylint: disable=no-member
+
+    def test_preflight_failure_leaves_no_partial_target_file(self):
+        with tempfile.TemporaryDirectory() as temp_dir:
+            root = Path(temp_dir)
+            source = root / "source.pdf"
+            target = root / "target.pdf"
+            doc = canvas.Canvas(str(source), pagesize=(200, 200))
+            doc.drawString(1, 1, "source")
+            doc.save()
+            patcher = PDFPatcher(options=PatchTextOptions(max_font_size=8, min_font_size=8))
+
+            with self.assertRaisesRegex(ValueError, "page 1, bbox"):
+                patcher.patch(
+                    source,
+                    target,
+                    [PDFReplacement(1, (10, 10, 30, 30), "too much text " * 100, (200, 200))],
+                )
+            self.assertFalse(target.exists())
+
+    def test_explicit_skip_records_overflow_reason(self):
+        with tempfile.TemporaryDirectory() as temp_dir:
+            root = Path(temp_dir)
+            source = root / "source.pdf"
+            target = root / "target.pdf"
+            doc = canvas.Canvas(str(source), pagesize=(200, 200))
+            doc.drawString(1, 1, "source")
+            doc.save()
+            patcher = PDFPatcher(options=PatchTextOptions(max_font_size=8, min_font_size=8, overflow="skip"))
+
+            patcher.patch(
+                source,
+                target,
+                [PDFReplacement(1, (10, 10, 30, 30), "too much text " * 100, (200, 200))],
+            )
+
+            self.assertEqual(len(patcher.skipped_replacements), 1)
+            self.assertIn("cannot fit bbox", patcher.skipped_replacements[0].reason)

--- a/tests/test_pdf_text_layout.py
+++ b/tests/test_pdf_text_layout.py
@@ -1,0 +1,45 @@
+import unittest
+
+from pdf_craft.pipeline.pdf import BoxTextLayout, PatchTextOptions
+
+
+class TestBoxTextLayout(unittest.TestCase):
+    def test_wraps_cjk_without_spaces_into_multiple_lines(self):
+        layout = BoxTextLayout(PatchTextOptions(max_font_size=12, min_font_size=4))
+        fitted = layout.fit("这是没有空格的中文文本，需要在固定宽度的边框中自动换行。" * 3, 80, 100)
+
+        self.assertGreater(len(fitted.paragraph.blPara.lines), 1)
+        self.assertLessEqual(fitted.width, 78)
+        self.assertLessEqual(fitted.height, 98)
+
+    def test_normalizes_paragraph_whitespace_but_preserves_english_words(self):
+        layout = BoxTextLayout(PatchTextOptions(max_font_size=12, min_font_size=4))
+        fitted = layout.fit("First paragraph.\n\nSecond   paragraph has words.", 120, 100)
+
+        self.assertIn("First paragraph. Second paragraph has words.", fitted.paragraph.text)
+
+    def test_wraps_mixed_cjk_latin_and_numbers(self):
+        layout = BoxTextLayout(PatchTextOptions(max_font_size=12, min_font_size=4))
+        fitted = layout.fit("PDFCraft 2.0 \u6df7\u6392 text with 12345 \u548c\u5e38\u89c1\u6807\u70b9\uff0c\u5fc5\u987b\u5b8c\u6574\u653e\u5165\u8fb9\u6846\u3002" * 2, 100, 100)
+
+        self.assertGreater(len(fitted.paragraph.blPara.lines), 1)
+
+    def test_selects_largest_available_font_size(self):
+        options = PatchTextOptions(max_font_size=16, min_font_size=4)
+        fitted = BoxTextLayout(options).fit("short text", 300, 100)
+
+        self.assertEqual(fitted.font_size, 16)
+
+    def test_fails_when_minimum_font_cannot_fit(self):
+        options = PatchTextOptions(max_font_size=8, min_font_size=8)
+        with self.assertRaisesRegex(ValueError, "cannot fit bbox"):
+            BoxTextLayout(options).fit("too much text " * 100, 20, 10)
+
+    def test_default_cjk_font_is_registered_and_latin_font_rejects_cjk(self):
+        self.assertEqual(BoxTextLayout().fit("\u4e2d\u6587", 100, 100).font_size, 12)
+        with self.assertRaisesRegex(ValueError, "cannot reliably draw"):
+            BoxTextLayout(PatchTextOptions(font_name="Helvetica")).fit("\u4e2d\u6587", 100, 100)
+
+    def test_rejects_unavailable_font(self):
+        with self.assertRaisesRegex(ValueError, "font is unavailable"):
+            BoxTextLayout(PatchTextOptions(font_name="not-a-font")).fit("text", 100, 100)


### PR DESCRIPTION
## Summary
- use ReportLab Paragraph CJK wrapping and font fitting for PDF replacements
- preflight all replacement layouts before drawing overlays
- add layout, atomic failure, and CJK synthetic PDF coverage

## Validation
- poetry run python test.py
- poetry run pyright pdf_craft tests
- poetry run pylint pdf_craft tests
- real DeepSeek OCR 2 Vendor smoke on citation.pdf (worktree-private analysing output)