### PR TITLE
fix: harden smoke Markdown resources and reports

### DIFF
--- a/pdf_craft/markdown/render/render.py
+++ b/pdf_craft/markdown/render/render.py
@@ -1,4 +1,5 @@
 from pathlib import Path
+from os.path import relpath
 from shutil import copy
 from typing import Generator
 
@@ -20,12 +21,17 @@ def render_markdown_file(
     cover_path: Path | None,
     aborted: AbortedCheck,
 ):
-    assets_ref_path = output_assets_path
-    if not assets_ref_path.is_absolute():
-        output_assets_path = output_path.parent / output_assets_path
+    # ``output_assets_path`` is a destination relative to the Markdown file,
+    # unless it is absolute.  Keep the copy destination and emitted Markdown
+    # reference separate so neither depends on the process working directory.
+    if output_assets_path.is_absolute():
+        assets_destination = output_assets_path
+    else:
+        assets_destination = output_path.parent / output_assets_path
+    assets_ref_path = Path(relpath(assets_destination, output_path.parent))
 
     output_path.parent.mkdir(parents=True, exist_ok=True)
-    output_assets_path.mkdir(parents=True, exist_ok=True)
+    assets_destination.mkdir(parents=True, exist_ok=True)
     read_chapters = create_chapters_reader(chapters_path)
 
     references: list[Reference] = []
@@ -47,7 +53,7 @@ def render_markdown_file(
             for part in render_layouts(
                 layouts=chapter.layouts,
                 assets_path=assets_path,
-                output_assets_path=output_assets_path,
+                output_assets_path=assets_destination,
                 asset_ref_path=assets_ref_path,
                 toc_level=chapter.level,
                 ref_id_to_number=ref_id_to_number,
@@ -59,7 +65,7 @@ def render_markdown_file(
         for part in _render_footnotes_section(
             references=references,
             assets_path=assets_path,
-            output_assets_path=output_assets_path,
+            output_assets_path=assets_destination,
             asset_ref_path=assets_ref_path,
         ):
             f.write(part)
@@ -67,7 +73,7 @@ def render_markdown_file(
     if cover_path is not None:
         copy(
             src=cover_path,
-            dst=output_assets_path / cover_path.name,
+            dst=assets_destination / cover_path.name,
         )
 
 

--- a/pdf_craft/renderer/markdown/renderer.py
+++ b/pdf_craft/renderer/markdown/renderer.py
@@ -9,5 +9,5 @@ class MarkdownRenderer:
                aborted=lambda: False) -> None:
         package.validate()
         render_markdown_file(package.chapters_path, package.assets_path, output_path,
-                             assets_path or output_path.parent / "assets",
+                             assets_path or Path("assets"),
                              cover_path or package.cover_path, aborted)

--- a/pdf_craft/smoke/checks.py
+++ b/pdf_craft/smoke/checks.py
@@ -57,12 +57,22 @@ def check_pdf_patch_geometry(package: DocumentPackage) -> list[str]:
     return []
 
 
-def check_markdown(path: Path, assets_path: Path) -> list[str]:
+def check_markdown(path: Path, _assets_path: Path | None = None) -> list[str]:
+    """Validate local image links relative to the Markdown document.
+
+    ``assets_path`` is retained as an ignored compatibility parameter.  The
+    target path in Markdown is always interpreted from ``path.parent``.
+    """
     if not path.is_file() or not path.read_text(encoding="utf-8").strip():
         return ["Markdown output is missing or empty"]
     errors: list[str] = []
     for target in re.findall(r"!\[[^]]*\]\(([^)]+)\)", path.read_text(encoding="utf-8")):
-        target_path = assets_path / target
+        target = target.strip().split(maxsplit=1)[0].strip("<>")
+        if not target or target.startswith(("#", "data:", "http://", "https://")):
+            continue
+        target_path = Path(target)
+        if not target_path.is_absolute():
+            target_path = path.parent / target_path
         if not target_path.exists():
             errors.append(f"Markdown image reference is missing: {target}")
     return errors

--- a/pdf_craft/smoke/checks.py
+++ b/pdf_craft/smoke/checks.py
@@ -4,6 +4,7 @@ import zipfile
 from posixpath import normpath
 from pathlib import Path
 from xml.etree import ElementTree
+from urllib.parse import urlparse
 
 import pypdf
 
@@ -68,7 +69,8 @@ def check_markdown(path: Path, _assets_path: Path | None = None) -> list[str]:
     errors: list[str] = []
     for target in re.findall(r"!\[[^]]*\]\(([^)]+)\)", path.read_text(encoding="utf-8")):
         target = target.strip().split(maxsplit=1)[0].strip("<>")
-        if not target or target.startswith(("#", "data:", "http://", "https://")):
+        parsed = urlparse(target)
+        if not target or target.startswith("#") or parsed.scheme or parsed.netloc:
             continue
         target_path = Path(target)
         if not target_path.is_absolute():

--- a/pdf_craft/smoke/runner.py
+++ b/pdf_craft/smoke/runner.py
@@ -410,6 +410,25 @@ def _is_secret_key(key: str) -> bool:
     )
 
 
+def _secret_values(run: SmokeRun) -> list[str]:
+    values: list[str] = []
+
+    def visit(value: Any) -> None:
+        if isinstance(value, dict):
+            for key, item in value.items():
+                if _is_secret_key(key) and isinstance(item, str) and item:
+                    values.append(item)
+                else:
+                    visit(item)
+        elif isinstance(value, list | tuple):
+            for item in value:
+                visit(item)
+
+    visit(run.ocr)
+    visit(run.translation)
+    return sorted(set(values), key=len, reverse=True)
+
+
 def _run_id(run: SmokeRun) -> str:
     stamp = datetime.now(UTC).strftime("%Y%m%dT%H%M%SZ")
     return f"{stamp}-{Path(run.asset).stem}-{run.route}-{uuid.uuid4().hex[:8]}"

--- a/pdf_craft/smoke/runner.py
+++ b/pdf_craft/smoke/runner.py
@@ -5,7 +5,8 @@ import traceback
 import uuid
 import zipfile
 from copy import deepcopy
-from dataclasses import asdict, dataclass
+from contextlib import contextmanager
+from dataclasses import asdict, dataclass, field
 from datetime import UTC, datetime
 from pathlib import Path
 from time import perf_counter
@@ -16,6 +17,7 @@ from pdf_craft.ocr_config import OCRConfig, OCRMode
 from pdf_craft.transformer import SubmitKind
 from pdf_craft.sequence.chapter import BlockLayout, BlockMember, Chapter, HTMLTag, ParagraphLayout
 from pdf_craft.llm import LLM
+from pdf_craft.pdf import OCREvent
 
 from .assets import SmokeAsset, discover_assets
 from .checks import check_epub, check_markdown, check_package, check_pdf_patch_geometry
@@ -43,6 +45,55 @@ class SmokeRun:
     toc_assumed: bool = False
     ocr: dict[str, Any] | None = None
     translation: dict[str, Any] | None = None
+
+
+@dataclass
+class _ExecutionReport:
+    stages: list[dict[str, Any]] = field(default_factory=list)
+    ocr_events: list[dict[str, Any]] = field(default_factory=list)
+    secret_values: tuple[str, ...] = ()
+    current_stage: str = "configure"
+
+    @contextmanager
+    def stage(self, name: str):
+        self.current_stage = name
+        entry: dict[str, Any] = {
+            "stage": name, "started_at": datetime.now(UTC).isoformat(),
+            "status": "running",
+        }
+        self.stages.append(entry)
+        started = perf_counter()
+        try:
+            yield
+        except Exception:
+            entry["status"] = "failed"
+            raise
+        else:
+            entry["status"] = "passed"
+        finally:
+            entry["finished_at"] = datetime.now(UTC).isoformat()
+            entry["elapsed_seconds"] = round(perf_counter() - started, 3)
+
+    def skipped(self, name: str, reason: str) -> None:
+        now = datetime.now(UTC).isoformat()
+        self.stages.append({"stage": name, "started_at": now, "finished_at": now,
+                            "elapsed_seconds": 0.0, "status": "skipped", "reason": reason})
+
+    def on_ocr_event(self, event: OCREvent) -> None:
+        payload: dict[str, Any] = {
+            "kind": event.kind.name.lower(), "page_index": event.page_index,
+            "total_pages": event.total_pages, "cost_time_ms": event.cost_time_ms,
+            "input_tokens": event.input_tokens, "output_tokens": event.output_tokens,
+        }
+        if event.error is not None:
+            payload["error_type"] = type(event.error).__name__
+            payload["error"] = self.redact_text(str(event.error))
+        self.ocr_events.append(payload)
+
+    def redact_text(self, text: str) -> str:
+        for value in self.secret_values:
+            text = text.replace(value, "[redacted]")
+        return text
 
 
 def expand_matrix(config: dict[str, Any], assets_root: Path) -> list[SmokeRun]:
@@ -86,65 +137,88 @@ def run_smoke(
         _finish(run_path, manifest, "planned", [])
         return run_path
     started = perf_counter()
+    report = _ExecutionReport(secret_values=tuple(_secret_values(run)))
     try:
-        status, errors, details = _execute(run, asset, run_path)
+        status, errors, details = _execute(run, asset, run_path, report)
     except Exception as error:  # preserve the full failure report for manual inspection
-        (run_path / "logs" / "traceback.txt").write_text(traceback.format_exc(), encoding="utf-8")
-        status, errors, details = "failed", [str(error)], {}
+        traceback_path = run_path / "logs" / "traceback.txt"
+        traceback_path.write_text(report.redact_text(traceback.format_exc()), encoding="utf-8")
+        message = report.redact_text(str(error))
+        status, errors, details = "failed", [message], {
+            "failure": {"stage": report.current_stage, "exception_type": type(error).__name__,
+                        "message": message, "traceback_path": str(traceback_path.relative_to(run_path))}
+        }
     manifest["elapsed_seconds"] = round(perf_counter() - started, 3)
     manifest.update(details)
-    _finish(run_path, manifest, status, errors)
+    manifest["timeline"] = report.stages
+    manifest["ocr_events"] = report.ocr_events
+    with report.stage("finish"):
+        pass
+    _finish(run_path, manifest, status, [report.redact_text(error) for error in errors])
     return run_path
 
 
-def _execute(run: SmokeRun, asset: SmokeAsset, run_path: Path) -> tuple[str, list[str], dict[str, Any]]:
+def _execute(run: SmokeRun, asset: SmokeAsset, run_path: Path,
+             report: _ExecutionReport) -> tuple[str, list[str], dict[str, Any]]:
     if asset.format == "epub":
         output = run_path / "output" / "book.epub"
+        report.skipped("configure", "EPUB routes do not require OCR configuration")
+        report.skipped("extract", "EPUB routes do not extract a DocumentPackage")
         if run.route == "epub-check":
-            shutil.copy2(asset.path, output)
-            status, errors = _result_from_errors(check_epub(output))
+            with report.stage("render"):
+                shutil.copy2(asset.path, output)
+            with report.stage("check"):
+                status, errors = _result_from_errors(check_epub(output))
             return status, errors, {"outputs": [str(output)]}
         if not run.translation or not isinstance(run.translation.get("llm"), dict):
+            report.skipped("render", "missing translation.llm")
+            report.skipped("check", "translation was not run")
             return "skipped", ["EPUB translation requires translation.llm with explicit credentials"], {}
-        llm = LLM(**run.translation["llm"])
-        submit = SubmitKind[run.translation.get("submit", "REPLACE").upper()]
-        PDFCraft().translate_epub(
-            asset.path,
-            output,
-            target_language=run.translation.get("target_language", "zh"),
-            submit=submit,
-            user_prompt=run.translation.get("user_prompt"),
-            max_retries=run.translation.get("max_retries", 5),
-            max_group_tokens=run.translation.get("max_group_tokens", 2600),
-            concurrency=run.translation.get("concurrency", 1),
-            llm=llm,
-        )
-        status, errors = _result_from_errors(check_epub(output))
+        with report.stage("render"):
+            llm = LLM(**run.translation["llm"])
+            submit = SubmitKind[run.translation.get("submit", "REPLACE").upper()]
+            PDFCraft().translate_epub(asset.path, output, target_language=run.translation.get("target_language", "zh"),
+                                      submit=submit, user_prompt=run.translation.get("user_prompt"),
+                                      max_retries=run.translation.get("max_retries", 5),
+                                      max_group_tokens=run.translation.get("max_group_tokens", 2600),
+                                      concurrency=run.translation.get("concurrency", 1), llm=llm)
+        with report.stage("check"):
+            status, errors = _result_from_errors(check_epub(output))
         return status, errors, {"outputs": [str(output)]}
 
     if run.backend is None or run.ocr is None:
+        report.skipped("configure", "missing OCR backend configuration")
+        report.skipped("extract", "missing OCR backend configuration")
+        report.skipped("render", "missing OCR backend configuration")
+        report.skipped("check", "missing OCR backend configuration")
         return "skipped", ["PDF route requires an explicit OCR backend"], {}
-    return _run_pdf(run, asset, run_path, create_ocr_config(run.backend, run.ocr))
+    with report.stage("configure"):
+        ocr = create_ocr_config(run.backend, run.ocr)
+    return _run_pdf(run, asset, run_path, ocr, report)
 
 
 def _run_pdf(
-    run: SmokeRun, asset: SmokeAsset, run_path: Path, ocr: OCRConfig
+    run: SmokeRun, asset: SmokeAsset, run_path: Path, ocr: OCRConfig,
+    report: _ExecutionReport | None = None,
 ) -> tuple[str, list[str], dict[str, Any]]:
     package_path = run_path / "package"
     output_path = run_path / "output"
     craft = PDFCraft(pdf=PDFOptions(ocr=ocr))
     try:
-        package, metering = craft.extract_pdf_with_metering(
-            asset.path, package_path, ExtractionOptions(
-                page_indexes=run.page_indexes, ocr_size=cast(Any, run.ocr_size), dpi=run.dpi,
-                max_page_image_file_size=run.max_page_image_file_size,
-                max_ocr_tokens=run.max_ocr_tokens,
-                max_ocr_output_tokens=run.max_ocr_output_tokens,
-                includes_cover=run.includes_cover,
-                includes_footnotes=run.includes_footnotes,
+        report = report or _ExecutionReport()
+        with report.stage("extract"):
+            package, metering = craft.extract_pdf_with_metering(
+                asset.path, package_path, ExtractionOptions(
+                    page_indexes=run.page_indexes, ocr_size=cast(Any, run.ocr_size), dpi=run.dpi,
+                    max_page_image_file_size=run.max_page_image_file_size,
+                    max_ocr_tokens=run.max_ocr_tokens,
+                    max_ocr_output_tokens=run.max_ocr_output_tokens,
+                    includes_cover=run.includes_cover,
+                    includes_footnotes=run.includes_footnotes,
                 generate_plot=run.generate_plot, toc_assumed=run.toc_assumed,
+                on_ocr_event=report.on_ocr_event,
+                )
             )
-        )
     except Exception as error:
         unavailable = _unavailable_ocr_reason(error)
         if unavailable is not None:
@@ -154,49 +228,61 @@ def _run_pdf(
         "package": str(package_path),
         "metering": {"input_tokens": metering.input_tokens, "output_tokens": metering.output_tokens},
     }
-    errors = check_package(package, require_geometry=run.route == "pdf-patch")
-    if run.route == "pdf-patch":
-        errors.extend(check_pdf_patch_geometry(package))
-    if errors and run.route == "pdf-patch":
-        return "failed", errors, details
     if run.route == "package":
-        status, errors = _result_from_errors(errors)
+        report.skipped("render", "package route has no renderer")
+        with report.stage("check"):
+            errors = check_package(package, require_geometry=False)
+            status, errors = _result_from_errors(errors)
         return status, errors, details
     if run.route == "markdown":
         markdown = output_path / "book.md"
-        markdown_assets = output_path / "assets"
+        markdown_assets = Path("assets")
         steps = _package_steps(run)
-        if steps:
-            package = craft.transform_package(package, run_path / "translated", steps)
-        craft.render_markdown(package, markdown, markdown_assets)
-        errors.extend(check_markdown(markdown, markdown_assets))
-        marker = (run.translation or {}).get("package_marker")
-        if isinstance(marker, str) and markdown.is_file() and marker not in markdown.read_text(encoding="utf-8"):
-            errors.append(f"Package translation marker missing from Markdown: {marker}")
+        with report.stage("render"):
+            if steps:
+                package = craft.transform_package(package, run_path / "translated", steps)
+            craft.render_markdown(package, markdown, markdown_assets)
+        with report.stage("check"):
+            errors = check_package(package)
+            errors.extend(check_markdown(markdown))
+            marker = (run.translation or {}).get("package_marker")
+            if isinstance(marker, str) and markdown.is_file() and marker not in markdown.read_text(encoding="utf-8"):
+                errors.append(f"Package translation marker missing from Markdown: {marker}")
         details["outputs"] = [str(markdown)]
         status, errors = _result_from_errors(errors)
         return status, errors, details
     if run.route == "epub":
         epub = output_path / "book.epub"
         steps = _package_steps(run)
-        if steps:
-            package = craft.transform_package(package, run_path / "translated", steps)
-        craft.render_epub(package, epub)
-        errors.extend(check_epub(epub))
-        marker = (run.translation or {}).get("package_marker")
-        if isinstance(marker, str) and not _epub_contains_marker(epub, marker):
-            errors.append(f"Package translation marker missing from EPUB: {marker}")
+        with report.stage("render"):
+            if steps:
+                package = craft.transform_package(package, run_path / "translated", steps)
+            craft.render_epub(package, epub)
+        with report.stage("check"):
+            errors = check_package(package)
+            errors.extend(check_epub(epub))
+            marker = (run.translation or {}).get("package_marker")
+            if isinstance(marker, str) and not _epub_contains_marker(epub, marker):
+                errors.append(f"Package translation marker missing from EPUB: {marker}")
         details["outputs"] = [str(epub)]
         status, errors = _result_from_errors(errors)
         return status, errors, details
     prefix = (run.translation or {}).get("patch_prefix")
     if not isinstance(prefix, str):
+        report.skipped("render", "missing PDF patch transformer")
+        with report.stage("check"):
+            errors = check_package(package, require_geometry=True)
+            errors.extend(check_pdf_patch_geometry(package))
         return "skipped", errors + ["PDF patching requires translation.patch_prefix or an application transformer"], details
     target = output_path / "book.pdf"
-    craft.translate_pdf(asset.path, package, target, lambda text: prefix + text)
+    with report.stage("render"):
+        craft.translate_pdf(asset.path, package, target, lambda text: prefix + text)
     from .checks import check_pdf
     import pypdf
-    errors.extend(check_pdf(target, len(pypdf.PdfReader(str(asset.path)).pages)))
+    with report.stage("check"):
+        errors = check_package(package, require_geometry=True)
+        errors.extend(check_pdf_patch_geometry(package))
+        errors.extend(check_pdf(target, len(pypdf.PdfReader(str(asset.path)).pages)))
     details["outputs"] = [str(target)]
     status, errors = _result_from_errors(errors)
     return status, errors, details
@@ -290,7 +376,9 @@ def _finish(run_path: Path, manifest: dict[str, Any], status: str, errors: list[
     manifest["status"] = status
     manifest["finished_at"] = datetime.now(UTC).isoformat()
     _write_json(run_path / "manifest.json", manifest)
-    _write_json(run_path / "checks.json", {"status": status, "errors": errors})
+    _write_json(run_path / "checks.json", {"status": status, "errors": errors,
+                                             "timeline": manifest.get("timeline", []),
+                                             "failure": manifest.get("failure")})
 
 
 def _write_json(path: Path, value: dict[str, Any]) -> None:
@@ -300,13 +388,26 @@ def _write_json(path: Path, value: dict[str, Any]) -> None:
 def _redact(value: Any) -> Any:
     if isinstance(value, dict):
         return {
-            key: "[redacted]" if any(part in key.lower() for part in ("key", "secret", "token", "password"))
+            key: "[redacted]" if _is_secret_key(key)
             else _redact(item)
             for key, item in value.items()
         }
     if isinstance(value, list | tuple):
         return [_redact(item) for item in value]
     return value
+
+
+def _is_secret_key(key: str) -> bool:
+    normalized = key.lower().replace("-", "_")
+    if normalized in {
+        "ak", "sk", "api_key", "apikey", "access_key", "secret_key", "password", "secret",
+        "token", "api_token", "access_token", "refresh_token", "auth_token", "bearer_token",
+    }:
+        return True
+    return (
+        normalized.startswith(("secret_", "password_", "credential_"))
+        or normalized.endswith(("_secret", "_password", "_credential", "_token", "_key"))
+    )
 
 
 def _run_id(run: SmokeRun) -> str:

--- a/pdf_craft/transform.py
+++ b/pdf_craft/transform.py
@@ -74,7 +74,7 @@ class Transform:
         # Compatibility wrapper.  PDFCraft owns the production workflow.
         from .craft import ExtractionOptions, PDFCraft
         if markdown_assets_path is None:
-            markdown_assets_path = Path(markdown_path).parent / "assets"
+            markdown_assets_path = Path("assets")
         try:
             with EnsureFolder(path=to_path(analysing_path) if analysing_path is not None else None) as package_path:
                 return PDFCraft.from_engine(self).convert_pdf_to_markdown(

--- a/tests/test_craft.py
+++ b/tests/test_craft.py
@@ -228,8 +228,8 @@ class TestPDFCraft(unittest.TestCase):
                 Transform().transform_epub("source.pdf", "book.epub")
         self.assertIs(raised.exception, error)
 
-    def test_legacy_markdown_uses_output_directory_for_default_assets(self):
+    def test_legacy_markdown_uses_assets_relative_to_markdown_output(self):
         facade = Mock()
         with patch("pdf_craft.craft.PDFCraft.from_engine", return_value=facade):
             Transform().transform_markdown("source.pdf", "output/book.md")
-        self.assertEqual(facade.convert_pdf_to_markdown.call_args.kwargs["assets_path"], Path("output/assets"))
+        self.assertEqual(facade.convert_pdf_to_markdown.call_args.kwargs["assets_path"], Path("assets"))

--- a/tests/test_smoke.py
+++ b/tests/test_smoke.py
@@ -8,22 +8,25 @@ from unittest.mock import patch
 
 from pdf_craft.document import DocumentPackage
 from pdf_craft.extractor import PDFExtractor
+from pdf_craft.common import save_xml
+from pdf_craft.markdown.render import render_markdown_file
 from pdf_craft.metering import OCRTokensMetering
 from pdf_craft.ocr_config import OCRConfig
+from pdf_craft.pdf import OCREvent, OCREventKind
 from pdf_craft.smoke.assets import discover_assets
-from pdf_craft.smoke.checks import check_epub
-from pdf_craft.smoke.checks import check_pdf_patch_geometry
+from pdf_craft.smoke.checks import check_epub, check_markdown, check_pdf_patch_geometry
 from pdf_craft.smoke.runner import (
     SmokeAsset,
     SmokeRun,
+    _redact,
     _epub_contains_marker,
     _run_pdf,
     expand_matrix,
     run_smoke,
 )
-from pdf_craft.common.xml import save_xml
-from pdf_craft.sequence.chapter import BlockLayout, Chapter, ParagraphLayout
-from pdf_craft.sequence.chapter import encode as encode_chapter
+from pdf_craft.sequence.chapter import AssetLayout, BlockLayout, Chapter, ParagraphLayout, encode
+
+encode_chapter = encode
 
 
 class _CaptureTransform:
@@ -68,6 +71,90 @@ class TestSmokeMatrix(unittest.TestCase):
             self.assertEqual(manifest["run"]["ocr"]["api_key"], "[redacted]")
             self.assertTrue((run_path / "checks.json").exists())
             self.assertTrue((run_path / "logs").is_dir())
+
+    def test_redact_covers_nested_vendor_credentials_without_hiding_limits(self):
+        value = {
+            "deepseek": {"api_key": "key", "max_tokens": 1200},
+            "unlimited": [{"ak": "access", "sk": "secret", "max_ocr_tokens": 900}],
+            "nested": {"access_key": "access", "secret_key": "secret", "password": "pw"},
+        }
+        redacted = _redact(value)
+        self.assertEqual(redacted["deepseek"]["api_key"], "[redacted]")
+        self.assertEqual(redacted["unlimited"][0]["ak"], "[redacted]")
+        self.assertEqual(redacted["unlimited"][0]["sk"], "[redacted]")
+        self.assertEqual(redacted["nested"]["access_key"], "[redacted]")
+        self.assertEqual(redacted["nested"]["secret_key"], "[redacted]")
+        self.assertEqual(redacted["nested"]["password"], "[redacted]")
+        self.assertEqual(redacted["deepseek"]["max_tokens"], 1200)
+        self.assertEqual(redacted["unlimited"][0]["max_ocr_tokens"], 900)
+
+    def test_markdown_assets_are_copied_and_resolved_from_book_parent(self):
+        with tempfile.TemporaryDirectory() as directory:
+            root = Path(directory)
+            package = _package_with_image(root / "package")
+            markdown = root / "output" / "book.md"
+            render_markdown_file(package.chapters_path, package.assets_path, markdown,
+                                 Path("assets"), package.cover_path, lambda: False)
+            self.assertTrue((root / "output" / "assets" / "image.png").is_file())
+            self.assertTrue((root / "output" / "assets" / "cover.png").is_file())
+            self.assertIn("![](assets/image.png)", markdown.read_text())
+            self.assertEqual(check_markdown(markdown), [])
+
+    def test_markdown_absolute_asset_destination_has_resolvable_relative_link(self):
+        with tempfile.TemporaryDirectory() as directory:
+            root = Path(directory)
+            package = _package_with_image(root / "package")
+            markdown = root / "output" / "book.md"
+            destination = root / "external-assets"
+            render_markdown_file(package.chapters_path, package.assets_path, markdown,
+                                 destination, None, lambda: False)
+            self.assertTrue((destination / "image.png").is_file())
+            self.assertIn("![](../external-assets/image.png)", markdown.read_text())
+            self.assertEqual(check_markdown(markdown), [])
+
+    def test_markdown_without_resources_still_validates(self):
+        with tempfile.TemporaryDirectory() as directory:
+            root = Path(directory)
+            package = _package_without_assets(root / "package")
+            markdown = root / "output" / "book.md"
+            render_markdown_file(package.chapters_path, package.assets_path, markdown,
+                                 Path("assets"), None, lambda: False)
+            self.assertEqual(check_markdown(markdown), [])
+
+    def test_pdf_run_records_ocr_events_and_stage_timeline(self):
+        with tempfile.TemporaryDirectory() as directory:
+            root = Path(directory)
+            package = _package_without_assets(root / "fixture-package")
+            metering = OCRTokensMetering(5, 7)
+            with patch("pdf_craft.smoke.runner.PDFCraft") as craft_class:
+                craft = craft_class.return_value
+                def extract(_source, _path, options):
+                    options.on_ocr_event(OCREvent(OCREventKind.COMPLETE, 1, 1, 12, 5, 7))
+                    return package, metering
+                craft.extract_pdf_with_metering.side_effect = extract
+                run_path = run_smoke(
+                    SmokeRun("double_column.pdf", "package", "deepseek-ocr-local", ocr={}),
+                    assets_root=Path("tests/assets"), output_root=root,
+                )
+            manifest = json.loads((run_path / "manifest.json").read_text())
+            self.assertEqual(manifest["status"], "passed")
+            self.assertEqual([item["stage"] for item in manifest["timeline"]],
+                             ["configure", "extract", "render", "check", "finish"])
+            self.assertEqual(manifest["ocr_events"], [{"kind": "complete", "page_index": 1,
+                "total_pages": 1, "cost_time_ms": 12, "input_tokens": 5, "output_tokens": 7}])
+
+    def test_failed_configuration_records_stage_and_traceback_path(self):
+        with tempfile.TemporaryDirectory() as directory:
+            with patch("pdf_craft.smoke.runner.create_ocr_config", side_effect=ValueError("bad OCR")):
+                run_path = run_smoke(
+                    SmokeRun("double_column.pdf", "package", "deepseek-ocr-vendor", ocr={"api_key": "secret"}),
+                    assets_root=Path("tests/assets"), output_root=Path(directory),
+                )
+            manifest = json.loads((run_path / "manifest.json").read_text())
+            self.assertEqual(manifest["failure"]["stage"], "configure")
+            self.assertEqual(manifest["failure"]["exception_type"], "ValueError")
+            self.assertEqual(manifest["failure"]["traceback_path"], "logs/traceback.txt")
+            self.assertTrue((run_path / "logs" / "traceback.txt").is_file())
 
     def test_epub_check_copies_and_validates_real_fixture(self):
         with tempfile.TemporaryDirectory() as directory:
@@ -215,3 +302,23 @@ def _container() -> str:
 
 def _opf(manifest: str, spine: str, spine_attrs: str) -> str:
     return f'<package version="2.0"><manifest>{manifest}</manifest><spine {spine_attrs}>{spine}</spine></package>'
+
+
+def _package_with_image(root: Path) -> DocumentPackage:
+    package = _package_without_assets(root)
+    (package.assets_path / "image.png").write_bytes(b"image")
+    cover = root / "cover.png"
+    cover.write_bytes(b"cover")
+    package = DocumentPackage(package.chapters_path, package.assets_path, None, cover, package.metadata_path)
+    chapter = Chapter(None, -1, [AssetLayout(1, "image", (0, 0, 1, 1), [], [], [], "image")])
+    save_xml(encode(chapter), package.chapters_path / "chapter_head.xml")
+    return package
+
+
+def _package_without_assets(root: Path) -> DocumentPackage:
+    package = DocumentPackage.from_path(root)
+    package.chapters_path.mkdir(parents=True)
+    package.assets_path.mkdir()
+    chapter = Chapter(None, -1, [ParagraphLayout("text", 0, [BlockLayout(1, 1, (0, 0, 1, 1), ["content"])])])
+    save_xml(encode(chapter), package.chapters_path / "chapter_head.xml")
+    return package

--- a/tests/test_smoke.py
+++ b/tests/test_smoke.py
@@ -121,6 +121,16 @@ class TestSmokeMatrix(unittest.TestCase):
                                  Path("assets"), None, lambda: False)
             self.assertEqual(check_markdown(markdown), [])
 
+    def test_markdown_check_skips_urls_and_protocol_relative_links(self):
+        with tempfile.TemporaryDirectory() as directory:
+            markdown = Path(directory) / "book.md"
+            markdown.write_text(
+                "![](mailto:reader@example.com)\n![](ftp://example.com/image.png)\n"
+                "![](//cdn.example.com/image.png)\n![](assets/missing.png)\n",
+                encoding="utf-8",
+            )
+            self.assertEqual(check_markdown(markdown), ["Markdown image reference is missing: assets/missing.png"])
+
     def test_pdf_run_records_ocr_events_and_stage_timeline(self):
         with tempfile.TemporaryDirectory() as directory:
             root = Path(directory)
@@ -155,6 +165,33 @@ class TestSmokeMatrix(unittest.TestCase):
             self.assertEqual(manifest["failure"]["exception_type"], "ValueError")
             self.assertEqual(manifest["failure"]["traceback_path"], "logs/traceback.txt")
             self.assertTrue((run_path / "logs" / "traceback.txt").is_file())
+
+    def test_persisted_errors_redact_vendor_credentials(self):
+        with tempfile.TemporaryDirectory() as directory:
+            secrets = {"api_key": "api-secret", "ak": "access-secret", "sk": "signing-secret"}
+            with patch("pdf_craft.smoke.runner.create_ocr_config"), \
+                 patch("pdf_craft.smoke.runner.PDFCraft") as craft_class:
+                craft = craft_class.return_value
+
+                def extract(_source, _path, options):
+                    options.on_ocr_event(OCREvent(
+                        OCREventKind.FAILED, 1, 1,
+                        error=ValueError("OCR rejected api-secret and access-secret"),
+                    ))
+                    raise ValueError("request failed with signing-secret")
+
+                craft.extract_pdf_with_metering.side_effect = extract
+                run_path = run_smoke(
+                    SmokeRun("double_column.pdf", "package", "deepseek-ocr-vendor", ocr=secrets),
+                    assets_root=Path("tests/assets"), output_root=Path(directory),
+                )
+            persisted = "\n".join((run_path / name).read_text() for name in (
+                "manifest.json", "checks.json", "logs/traceback.txt",
+            ))
+            self.assertNotIn("api-secret", persisted)
+            self.assertNotIn("access-secret", persisted)
+            self.assertNotIn("signing-secret", persisted)
+            self.assertIn("[redacted]", persisted)
 
     def test_epub_check_copies_and_validates_real_fixture(self):
         with tempfile.TemporaryDirectory() as directory:


### PR DESCRIPTION
## Summary
- normalize Markdown asset copies and references relative to book.md
- record smoke execution stages and OCR events, with credential-safe failure output
- recognize non-local Markdown image URLs and retain Package translation smoke behavior after rebase

## Validation
- poetry run python test.py
- poetry run pyright pdf_craft tests
- poetry run pylint pdf_craft tests
- Vendor OCR Markdown reruns for DeepSeek OCR, DeepSeek OCR2, and Unlimited OCR passed before the rebase