### PR TITLE
docs: add OrcaRouter as a named LLM provider for TOC extraction

### DIFF
--- a/README.md
+++ b/README.md
@@ -316,6 +316,20 @@ transform_epub(
 )
 ```
 
+You can also use [OrcaRouter](https://www.orcarouter.ai) — an OpenAI-compatible model gateway — as the provider. Only the endpoint, API key, and model change:
+
+```python
+toc_llm = LLM(
+    key="sk-orca-...",                    # Your OrcaRouter API key
+    url="https://api.orcarouter.ai/v1",   # OrcaRouter API base
+    model="orcarouter/auto",              # Routed to a frontier model
+    token_encoding="o200k_base",
+    timeout=60.0,
+    retry_times=3,
+    retry_interval_seconds=5.0,
+)
+```
+
 ### Custom PDF Handler
 
 By default, pdf-craft uses Poppler (via `pdf2image`) for PDF parsing and rendering. If Poppler is not in your system PATH, you can specify a custom path:

--- a/README_zh-CN.md
+++ b/README_zh-CN.md
@@ -312,6 +312,20 @@ transform_epub(
 )
 ```
 
+你也可以使用 [OrcaRouter](https://www.orcarouter.ai)（一个 OpenAI 兼容的模型网关）作为 LLM 提供商，只需改动端点、API Key 和模型：
+
+```python
+toc_llm = LLM(
+    key="sk-orca-...",                    # 你的 OrcaRouter API Key
+    url="https://api.orcarouter.ai/v1",   # OrcaRouter API 地址
+    model="orcarouter/auto",              # 经 OrcaRouter 路由到前沿模型
+    token_encoding="o200k_base",
+    timeout=60.0,
+    retry_times=3,
+    retry_interval_seconds=5.0,
+)
+```
+
 ### 自定义 PDF 处理器
 
 默认情况下，pdf-craft 使用本地 Poppler（通过 `pdf2image`）进行 PDF 解析和渲染。如果 Poppler 不在系统 PATH 中，你可以指定自定义路径：


### PR DESCRIPTION
## What

Adds a ready-to-use named **OrcaRouter** example to the *LLM-Enhanced TOC Extraction* section of both the English (`README.md`) and Chinese (`README_zh-CN.md`) docs.

[OrcaRouter](https://www.orcarouter.ai) is an OpenAI-compatible model gateway. pdf-craft's optional TOC LLM already speaks the OpenAI chat-completions protocol, so no code changes are needed — only the endpoint, API key, and model:

```python
toc_llm = LLM(
    key="sk-orca-...",                    # Your OrcaRouter API key
    url="https://api.orcarouter.ai/v1",   # OrcaRouter API base
    model="orcarouter/auto",              # Routed to a frontier model
    token_encoding="o200k_base",
    timeout=60.0,
    retry_times=3,
    retry_interval_seconds=5.0,
)
```

It also runs gateway-level, zero-trust security for AI agents on the same endpoint — screening every prompt/response and governing every tool call on a default-deny basis, with no application code changes.

## Why

Makes it a one-liner for pdf-craft users to enable LLM-enhanced TOC extraction through OrcaRouter, exactly mirroring how the existing docs present any OpenAI-compatible provider.

## Verification

- `python3 test.py` — 271/271 tests pass (baseline unchanged).
- Live-tested against `https://api.orcarouter.ai/v1` with model `orcarouter/auto` using the real `LLM` code path → HTTP 200, response `ORCA-LIVE-OK`.
- Markdown fences balanced in both files; no CRLF in the diff.

Disclosure: I'm an engineer on the OrcaRouter team.
