### PR TITLE
chore: skip CodeRabbit auto review for Moskize91

### DIFF
--- a/.coderabbit.yaml
+++ b/.coderabbit.yaml
@@ -1,0 +1,5 @@
+# yaml-language-server: $schema=https://coderabbit.ai/integrations/schema.v2.json
+reviews:
+  auto_review:
+    ignore_usernames:
+      - Moskize91


### PR DESCRIPTION
Adds _.coderabbit.yaml_ with `reviews.auto_review.ignore_usernames` so CodeRabbit skips automatic reviews on PRs authored by Moskize91. Other authors are unaffected, and a review can still be requested manually with `@coderabbitai review`.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Added configuration metadata for automated code reviews.
  * Configured automated reviews to ignore a specified username.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->