### PR TITLE
Add real table/formula regression matrix

### DIFF
--- a/pdf_craft/llm/runtime.py
+++ b/pdf_craft/llm/runtime.py
@@ -163,6 +163,7 @@ class LLMContext(AbstractContextManager["LLMContext"]):
             "model": self.runtime.config.model, "cache_key": key,
             **({"error": type(error).__name__} if error else {}),
         }, ensure_ascii=False))
+        _close_file_handlers(self.runtime._logger)
 
 
 def runtime_for(config: LLM, *, protocol_version: str = "1") -> LLMRuntime:
@@ -179,3 +180,9 @@ def _create_logger(path):
         handler.setFormatter(logging.Formatter("%(message)s"))
         logger.addHandler(handler)
     return logger
+
+
+def _close_file_handlers(logger: logging.Logger) -> None:
+    for handler in logger.handlers:
+        if isinstance(handler, logging.FileHandler):
+            handler.close()

--- a/pdf_craft/pipeline/pdf/patcher.py
+++ b/pdf_craft/pipeline/pdf/patcher.py
@@ -1,6 +1,6 @@
 from dataclasses import dataclass
 from pathlib import Path
-from tempfile import NamedTemporaryFile
+from tempfile import NamedTemporaryFile, TemporaryDirectory
 from typing import Iterable
 
 from pdf_craft.pdf.handler import DefaultPDFHandler, PDFHandler
@@ -107,8 +107,9 @@ class PDFPatcher:
             for index, page in enumerate(reader.pages, 1):
                 width = float(page.mediabox.width)
                 height = float(page.mediabox.height)
-                with NamedTemporaryFile(suffix=".pdf") as overlay_file:
-                    overlay = canvas.Canvas(overlay_file.name, pagesize=(width, height))
+                with TemporaryDirectory() as temp_dir:
+                    overlay_path = Path(temp_dir) / "overlay.pdf"
+                    overlay = canvas.Canvas(str(overlay_path), pagesize=(width, height))
                     page_layouts = layouts.get(index, [])
                     render_dpi = page_layouts[0][0].dpi if page_layouts else self.dpi
                     raw_page = document.render_page(index, render_dpi)
@@ -118,7 +119,7 @@ class PDFPatcher:
                     for replacement, fitted in page_layouts:
                         self._draw_text(overlay, replacement, fitted, width, height)
                     overlay.save()
-                    overlay_reader = pypdf.PdfReader(overlay_file.name)
+                    overlay_reader = pypdf.PdfReader(str(overlay_path))
                     writer.add_page(overlay_reader.pages[0])
         finally:
             document.close()

--- a/pdf_craft_tool/cli.py
+++ b/pdf_craft_tool/cli.py
@@ -2,7 +2,7 @@
 
 import argparse
 import json
-from dataclasses import dataclass
+from dataclasses import dataclass, replace
 from pathlib import Path
 from typing import Any, cast
 
@@ -291,8 +291,62 @@ def _run_smoke(args: argparse.Namespace) -> None:
 
 def _run_matrix(args: argparse.Namespace) -> None:
     config = json.loads(args.config.read_text(encoding="utf-8"))
-    for run in expand_matrix(config, args.assets_root):
+    runs = expand_matrix(config, args.assets_root)
+    env_error: str | None = None
+    if any(_matrix_run_needs_env(run) for run in runs):
+        try:
+            load_project_env(_project_root())
+        except SystemExit as error:
+            env_error = str(error)
+    for run in runs:
+        if env_error and _matrix_run_needs_env(run):
+            run = replace(run, configuration_error=env_error)
+        else:
+            try:
+                run = _resolve_matrix_runtime(run, args.output_root)
+            except SystemExit as error:
+                run = replace(run, configuration_error=str(error))
         print(run_smoke(run, assets_root=args.assets_root, output_root=args.output_root, dry_run=args.dry_run))
+
+
+def _matrix_run_needs_env(run: SmokeRun) -> bool:
+    if run.backend and run.ocr is None:
+        return True
+    translation = run.translation or {}
+    return any(
+        key in translation
+        for key in ("llm_profile", "translation_llm_profile", "fill_llm_profile")
+    )
+
+
+def _resolve_matrix_runtime(run: SmokeRun, output_root: Path) -> SmokeRun:
+    ocr = run.ocr
+    if run.backend and ocr is None:
+        ocr = ocr_values_from_env(run.backend)
+    translation = _resolve_translation_profiles(run.translation, output_root)
+    return replace(run, ocr=ocr, translation=translation)
+
+
+def _resolve_translation_profiles(translation: dict[str, Any] | None, output_root: Path) -> dict[str, Any] | None:
+    if not translation:
+        return translation
+    resolved = dict(translation)
+    profile = resolved.pop("llm_profile", None)
+    translation_profile = resolved.pop("translation_llm_profile", profile)
+    fill_profile = resolved.pop("fill_llm_profile", profile)
+    if translation_profile and "llm" not in resolved:
+        resolved["llm"] = llm_values_from_env(
+            str(translation_profile),
+            cache_path=output_root / "_c" / "t",
+            log_dir_path=output_root / "_l" / "t",
+        )
+    if fill_profile and fill_profile != translation_profile and "fill_llm" not in resolved:
+        resolved["fill_llm"] = llm_values_from_env(
+            str(fill_profile),
+            cache_path=output_root / "_c" / "f",
+            log_dir_path=output_root / "_l" / "f",
+        )
+    return resolved
 
 
 def _extract(args: argparse.Namespace, package_path: Path) -> _ExtractionResult:

--- a/pdf_craft_tool/smoke/assets.py
+++ b/pdf_craft_tool/smoke/assets.py
@@ -14,8 +14,9 @@ def discover_assets(root: Path) -> list[SmokeAsset]:
     for path in sorted(root.rglob("*")):
         if not path.is_file():
             continue
+        name = path.relative_to(root).as_posix()
         if path.suffix.lower() == ".pdf":
-            assets.append(SmokeAsset(str(path.relative_to(root)), "pdf", path))
+            assets.append(SmokeAsset(name, "pdf", path))
         elif path.suffix.lower() == ".epub":
-            assets.append(SmokeAsset(str(path.relative_to(root)), "epub", path))
+            assets.append(SmokeAsset(name, "epub", path))
     return assets

--- a/pdf_craft_tool/smoke/runner.py
+++ b/pdf_craft_tool/smoke/runner.py
@@ -13,7 +13,12 @@ from typing import Any, Literal, cast
 
 from pdf_craft.craft import ExtractionOptions, PDFCraft, PDFOptions, TranslationStep
 from pdf_craft.ocr_config import OCRConfig, OCRMode
-from pdf_craft.transformer import SubmitKind
+from pdf_craft.transformer import (
+    ChapterPackageTransformer,
+    ChapterXMLTransformer,
+    SubmitKind,
+    XMLTranslator,
+)
 from pdf_craft.sequence.chapter import BlockLayout, BlockMember, Chapter, HTMLTag, ParagraphLayout
 from pdf_craft.llm import LLM
 from pdf_craft.pdf import OCREvent
@@ -45,6 +50,7 @@ class SmokeRun:
     toc_assumed: bool = False
     ocr: dict[str, Any] | None = None
     translation: dict[str, Any] | None = None
+    configuration_error: str | None = None
 
 
 @dataclass
@@ -132,6 +138,13 @@ def run_smoke(
     manifest = _manifest(run, asset, dry_run)
     _write_json(run_path / "manifest.json", manifest)
     (run_path / "logs").mkdir()
+    if run.configuration_error:
+        report = _ExecutionReport()
+        for stage in ("configure", "extract", "render", "check"):
+            report.skipped(stage, run.configuration_error)
+        manifest["timeline"] = report.stages
+        _finish(run_path, manifest, "skipped", [run.configuration_error])
+        return run_path
     if dry_run:
         _finish(run_path, manifest, "planned", [])
         return run_path
@@ -145,7 +158,7 @@ def run_smoke(
         message = report.redact_text(str(error))
         status, errors, details = "failed", [message], {
             "failure": {"stage": report.current_stage, "exception_type": type(error).__name__,
-                        "message": message, "traceback_path": str(traceback_path.relative_to(run_path))}
+                        "message": message, "traceback_path": traceback_path.relative_to(run_path).as_posix()}
         }
     manifest["elapsed_seconds"] = round(perf_counter() - started, 3)
     manifest.update(details)
@@ -175,12 +188,14 @@ def _execute(run: SmokeRun, asset: SmokeAsset, run_path: Path,
             return "skipped", ["EPUB translation requires translation.llm with explicit credentials"], {}
         with report.stage("render"):
             llm = LLM(**run.translation["llm"])
+            fill_llm = LLM(**run.translation["fill_llm"]) if isinstance(run.translation.get("fill_llm"), dict) else llm
             submit = SubmitKind[run.translation.get("submit", "REPLACE").upper()]
             PDFCraft().translate_epub(asset.path, output, target_language=run.translation.get("target_language", "zh"),
                                       submit=submit, user_prompt=run.translation.get("user_prompt"),
                                       max_retries=run.translation.get("max_retries", 5),
                                       max_group_tokens=run.translation.get("max_group_tokens", 2600),
-                                      concurrency=run.translation.get("concurrency", 1), llm=llm)
+                                      concurrency=run.translation.get("concurrency", 1),
+                                      translation_llm=llm, fill_llm=fill_llm)
         with report.stage("check"):
             status, errors = _result_from_errors(check_epub(output))
         return status, errors, {"outputs": [str(output)]}
@@ -236,7 +251,7 @@ def _run_pdf(
     if run.route == "markdown":
         markdown = output_path / "book.md"
         markdown_assets = Path("assets")
-        steps = _package_steps(run)
+        steps = _package_steps(run, run_path)
         with report.stage("render"):
             if steps:
                 package = craft.transform_package(package, run_path / "translated", steps)
@@ -252,7 +267,7 @@ def _run_pdf(
         return status, errors, details
     if run.route == "epub":
         epub = output_path / "book.epub"
-        steps = _package_steps(run)
+        steps = _package_steps(run, run_path)
         with report.stage("render"):
             if steps:
                 package = craft.transform_package(package, run_path / "translated", steps)
@@ -266,16 +281,20 @@ def _run_pdf(
         details["outputs"] = [str(epub)]
         status, errors = _result_from_errors(errors)
         return status, errors, details
+    translation_transformer = _xml_translation_transformer(run, run_path)
     prefix = (run.translation or {}).get("patch_prefix")
-    if not isinstance(prefix, str):
+    if translation_transformer is None and not isinstance(prefix, str):
         report.skipped("render", "missing PDF patch transformer")
         with report.stage("check"):
             errors = check_package(package, require_geometry=True)
             errors.extend(check_pdf_patch_geometry(package))
-        return "skipped", errors + ["PDF patching requires translation.patch_prefix or an application transformer"], details
+        return "skipped", errors + [
+            "PDF patching requires translation.patch_prefix or translation.llm"
+        ], details
     target = output_path / "book.pdf"
     with report.stage("render"):
-        craft.translate_pdf(asset.path, package, target, lambda text: prefix + text)
+        transformer = translation_transformer if translation_transformer is not None else lambda text: prefix + text
+        craft.translate_pdf(asset.path, package, target, transformer)
     from .checks import check_pdf
     import pypdf
     with report.stage("check"):
@@ -346,14 +365,41 @@ class _DeterministicChapterTransformer:
         return item
 
 
-def _package_steps(run: SmokeRun):
+def _package_steps(run: SmokeRun, run_path: Path):
+    translation_transformer = _xml_translation_transformer(run, run_path)
+    if translation_transformer is not None:
+        translation = run.translation or {}
+        mode = SubmitKind[translation.get("submit", "REPLACE").upper()]
+        return (TranslationStep(ChapterPackageTransformer(translation_transformer), mode),)
+
     translation = run.translation or {}
     marker = translation.get("package_marker")
     if not isinstance(marker, str):
         return ()
     mode = SubmitKind[translation.get("package_submit", "REPLACE").upper()]
-    from pdf_craft.transformer import ChapterPackageTransformer
     return (TranslationStep(ChapterPackageTransformer(_DeterministicChapterTransformer(marker)), mode),)
+
+
+def _xml_translation_transformer(run: SmokeRun, run_path: Path) -> ChapterXMLTransformer | None:
+    translation = run.translation or {}
+    llm_values = translation.get("llm")
+    if not isinstance(llm_values, dict):
+        return None
+    translation_llm = LLM(**llm_values)
+    fill_values = translation.get("fill_llm")
+    fill_llm = LLM(**fill_values) if isinstance(fill_values, dict) else translation_llm
+    translator = XMLTranslator(
+        translation_llm=translation_llm,
+        fill_llm=fill_llm,
+        target_language=translation.get("target_language", "zh"),
+        user_prompt=translation.get("user_prompt"),
+        ignore_translated_error=False,
+        max_retries=translation.get("max_retries", 5),
+        max_fill_displaying_errors=translation.get("max_fill_displaying_errors", 3),
+        max_group_score=translation.get("max_group_tokens", 2600),
+        cache_seed_content=f"pdf-craft-smoke:{run.asset}:{run.route}:{run.backend}:{run_path.name}",
+    )
+    return ChapterXMLTransformer(cast(Any, translator), SubmitKind[translation.get("submit", "REPLACE").upper()])
 
 
 def _result_from_errors(errors: list[str]) -> tuple[str, list[str]]:
@@ -393,6 +439,8 @@ def _redact(value: Any) -> Any:
         }
     if isinstance(value, list | tuple):
         return [_redact(item) for item in value]
+    if isinstance(value, Path):
+        return str(value)
     return value
 
 

--- a/tests/smoke/table_formula_real.json
+++ b/tests/smoke/table_formula_real.json
@@ -1,0 +1,275 @@
+{
+  "defaults": {
+    "asset": "table&formula.pdf",
+    "ocr_size": "gundam",
+    "includes_cover": true,
+    "includes_footnotes": true,
+    "generate_plot": true
+  },
+  "runs": [
+    {
+      "route": "markdown",
+      "backend": "deepseek-ocr-local"
+    },
+    {
+      "route": "markdown",
+      "backend": "deepseek-ocr-local",
+      "translation": {
+        "llm_profile": "translation",
+        "fill_llm_profile": "fill",
+        "target_language": "Simplified Chinese",
+        "submit": "REPLACE",
+        "max_retries": 5,
+        "max_group_tokens": 2600
+      }
+    },
+    {
+      "route": "epub",
+      "backend": "deepseek-ocr-local"
+    },
+    {
+      "route": "epub",
+      "backend": "deepseek-ocr-local",
+      "translation": {
+        "llm_profile": "translation",
+        "fill_llm_profile": "fill",
+        "target_language": "Simplified Chinese",
+        "submit": "REPLACE",
+        "max_retries": 5,
+        "max_group_tokens": 2600
+      }
+    },
+    {
+      "route": "pdf-patch",
+      "backend": "deepseek-ocr-local",
+      "translation": {
+        "llm_profile": "translation",
+        "fill_llm_profile": "fill",
+        "target_language": "Simplified Chinese",
+        "submit": "REPLACE",
+        "max_retries": 5,
+        "max_group_tokens": 2600
+      }
+    },
+    {
+      "route": "markdown",
+      "backend": "deepseek-ocr2-local"
+    },
+    {
+      "route": "markdown",
+      "backend": "deepseek-ocr2-local",
+      "translation": {
+        "llm_profile": "translation",
+        "fill_llm_profile": "fill",
+        "target_language": "Simplified Chinese",
+        "submit": "REPLACE",
+        "max_retries": 5,
+        "max_group_tokens": 2600
+      }
+    },
+    {
+      "route": "epub",
+      "backend": "deepseek-ocr2-local"
+    },
+    {
+      "route": "epub",
+      "backend": "deepseek-ocr2-local",
+      "translation": {
+        "llm_profile": "translation",
+        "fill_llm_profile": "fill",
+        "target_language": "Simplified Chinese",
+        "submit": "REPLACE",
+        "max_retries": 5,
+        "max_group_tokens": 2600
+      }
+    },
+    {
+      "route": "pdf-patch",
+      "backend": "deepseek-ocr2-local",
+      "translation": {
+        "llm_profile": "translation",
+        "fill_llm_profile": "fill",
+        "target_language": "Simplified Chinese",
+        "submit": "REPLACE",
+        "max_retries": 5,
+        "max_group_tokens": 2600
+      }
+    },
+    {
+      "route": "markdown",
+      "backend": "unlimited-ocr-local"
+    },
+    {
+      "route": "markdown",
+      "backend": "unlimited-ocr-local",
+      "translation": {
+        "llm_profile": "translation",
+        "fill_llm_profile": "fill",
+        "target_language": "Simplified Chinese",
+        "submit": "REPLACE",
+        "max_retries": 5,
+        "max_group_tokens": 2600
+      }
+    },
+    {
+      "route": "epub",
+      "backend": "unlimited-ocr-local"
+    },
+    {
+      "route": "epub",
+      "backend": "unlimited-ocr-local",
+      "translation": {
+        "llm_profile": "translation",
+        "fill_llm_profile": "fill",
+        "target_language": "Simplified Chinese",
+        "submit": "REPLACE",
+        "max_retries": 5,
+        "max_group_tokens": 2600
+      }
+    },
+    {
+      "route": "pdf-patch",
+      "backend": "unlimited-ocr-local",
+      "translation": {
+        "llm_profile": "translation",
+        "fill_llm_profile": "fill",
+        "target_language": "Simplified Chinese",
+        "submit": "REPLACE",
+        "max_retries": 5,
+        "max_group_tokens": 2600
+      }
+    },
+    {
+      "route": "markdown",
+      "backend": "deepseek-ocr-vendor"
+    },
+    {
+      "route": "markdown",
+      "backend": "deepseek-ocr-vendor",
+      "translation": {
+        "llm_profile": "translation",
+        "fill_llm_profile": "fill",
+        "target_language": "Simplified Chinese",
+        "submit": "REPLACE",
+        "max_retries": 5,
+        "max_group_tokens": 2600
+      }
+    },
+    {
+      "route": "epub",
+      "backend": "deepseek-ocr-vendor"
+    },
+    {
+      "route": "epub",
+      "backend": "deepseek-ocr-vendor",
+      "translation": {
+        "llm_profile": "translation",
+        "fill_llm_profile": "fill",
+        "target_language": "Simplified Chinese",
+        "submit": "REPLACE",
+        "max_retries": 5,
+        "max_group_tokens": 2600
+      }
+    },
+    {
+      "route": "pdf-patch",
+      "backend": "deepseek-ocr-vendor",
+      "translation": {
+        "llm_profile": "translation",
+        "fill_llm_profile": "fill",
+        "target_language": "Simplified Chinese",
+        "submit": "REPLACE",
+        "max_retries": 5,
+        "max_group_tokens": 2600
+      }
+    },
+    {
+      "route": "markdown",
+      "backend": "deepseek-ocr2-vendor"
+    },
+    {
+      "route": "markdown",
+      "backend": "deepseek-ocr2-vendor",
+      "translation": {
+        "llm_profile": "translation",
+        "fill_llm_profile": "fill",
+        "target_language": "Simplified Chinese",
+        "submit": "REPLACE",
+        "max_retries": 5,
+        "max_group_tokens": 2600
+      }
+    },
+    {
+      "route": "epub",
+      "backend": "deepseek-ocr2-vendor"
+    },
+    {
+      "route": "epub",
+      "backend": "deepseek-ocr2-vendor",
+      "translation": {
+        "llm_profile": "translation",
+        "fill_llm_profile": "fill",
+        "target_language": "Simplified Chinese",
+        "submit": "REPLACE",
+        "max_retries": 5,
+        "max_group_tokens": 2600
+      }
+    },
+    {
+      "route": "pdf-patch",
+      "backend": "deepseek-ocr2-vendor",
+      "translation": {
+        "llm_profile": "translation",
+        "fill_llm_profile": "fill",
+        "target_language": "Simplified Chinese",
+        "submit": "REPLACE",
+        "max_retries": 5,
+        "max_group_tokens": 2600
+      }
+    },
+    {
+      "route": "markdown",
+      "backend": "unlimited-ocr-vendor"
+    },
+    {
+      "route": "markdown",
+      "backend": "unlimited-ocr-vendor",
+      "translation": {
+        "llm_profile": "translation",
+        "fill_llm_profile": "fill",
+        "target_language": "Simplified Chinese",
+        "submit": "REPLACE",
+        "max_retries": 5,
+        "max_group_tokens": 2600
+      }
+    },
+    {
+      "route": "epub",
+      "backend": "unlimited-ocr-vendor"
+    },
+    {
+      "route": "epub",
+      "backend": "unlimited-ocr-vendor",
+      "translation": {
+        "llm_profile": "translation",
+        "fill_llm_profile": "fill",
+        "target_language": "Simplified Chinese",
+        "submit": "REPLACE",
+        "max_retries": 5,
+        "max_group_tokens": 2600
+      }
+    },
+    {
+      "route": "pdf-patch",
+      "backend": "unlimited-ocr-vendor",
+      "translation": {
+        "llm_profile": "translation",
+        "fill_llm_profile": "fill",
+        "target_language": "Simplified Chinese",
+        "submit": "REPLACE",
+        "max_retries": 5,
+        "max_group_tokens": 2600
+      }
+    }
+  ]
+}

--- a/tests/test_smoke.py
+++ b/tests/test_smoke.py
@@ -86,6 +86,7 @@ class TestSmokeMatrix(unittest.TestCase):
         self.assertEqual(redacted["nested"]["access_key"], "[redacted]")
         self.assertEqual(redacted["nested"]["secret_key"], "[redacted]")
         self.assertEqual(redacted["nested"]["password"], "[redacted]")
+        self.assertEqual(_redact({"cache_path": Path("models-cache")})["cache_path"], str(Path("models-cache")))
         self.assertEqual(redacted["deepseek"]["max_tokens"], 1200)
         self.assertEqual(redacted["unlimited"][0]["max_ocr_tokens"], 900)
 

--- a/tests/test_tool.py
+++ b/tests/test_tool.py
@@ -1,10 +1,12 @@
+import json
 import unittest
+from argparse import Namespace
 from datetime import datetime
 from pathlib import Path
 import tempfile
 from unittest.mock import patch
 
-from pdf_craft_tool.cli import _page_indexes, _work_dir
+from pdf_craft_tool.cli import _page_indexes, _run_matrix, _work_dir
 from pdf_craft_tool.paths import create_run_directory
 from pdf_craft_tool.runtime import create_llm_from_env, ocr_mode_from_env
 
@@ -40,3 +42,28 @@ class TestPDFCraftTool(unittest.TestCase):
     def test_ocr_mode_uses_the_prefixed_runtime_variable(self):
         with patch.dict("os.environ", {"PDF_CRAFT_OCR_MODE": "unlimited-ocr-vendor"}, clear=True):
             self.assertEqual(ocr_mode_from_env(), "unlimited-ocr-vendor")
+
+    def test_matrix_records_missing_profile_as_skipped_run(self):
+        with tempfile.TemporaryDirectory() as directory:
+            root = Path(directory)
+            config = root / "matrix.json"
+            config.write_text(json.dumps({"runs": [{
+                "asset": "epub/Cambridge.epub",
+                "route": "epub-translate",
+                "translation": {"llm_profile": "custom"},
+            }]}), encoding="utf-8")
+
+            with patch("pdf_craft_tool.cli.load_project_env"), \
+                    patch("pdf_craft_tool.cli.llm_values_from_env",
+                          side_effect=SystemExit("missing LLM profile")):
+                _run_matrix(Namespace(
+                    config=config,
+                    assets_root=Path("tests/assets"),
+                    output_root=root / "output",
+                    dry_run=True,
+                ))
+
+            run_path = next((root / "output").iterdir())
+            checks = json.loads((run_path / "checks.json").read_text(encoding="utf-8"))
+            self.assertEqual(checks["status"], "skipped")
+            self.assertEqual(checks["errors"], ["missing LLM profile"])


### PR DESCRIPTION
## Summary
- Add a real `tests/smoke/table_formula_real.json` matrix for `tests/assets/table&formula.pdf` across all 6 OCR modes and Markdown/EPUB/PDF-patch translated/untranslated routes.
- Teach `pdf_craft_tool smoke matrix` to resolve OCR and real LLM profiles from `.env`, and record per-run skipped manifests when a backend/profile is not configured instead of aborting the whole matrix.
- Enable real LLM translation in smoke Markdown, EPUB, EPUB-translate, and PDF-patch routes.
- Fix Windows runtime issues found during regression: PDF overlay temp files, POSIX smoke asset names/traceback paths, JSON-safe manifest redaction, and LLM log file handles.

## Validation
- `poetry run python test.py` -> 284 OK
- `poetry run pyright pdf_craft tests pdf_craft_tool` -> 0 errors
- `poetry run pylint pdf_craft tests pdf_craft_tool` -> 10.00/10
- CUDA check: `torch 2.9.1+cu128`, CUDA 12.8, RTX 4090 available
- Smoke dry-run: `poetry run python -m pdf_craft_tool smoke matrix --config tests/smoke/table_formula_real.json --output-root pdf-craft-output/table-formula-real --dry-run`
- Real smoke matrix: `poetry run python -m pdf_craft_tool smoke matrix --config tests/smoke/table_formula_real.json --output-root pdf-craft-output/table-formula-real`

## Real Matrix Notes
- Local CUDA OCR modes passed for untranslated Markdown and EPUB:
  - `deepseek-ocr-local`
  - `deepseek-ocr2-local`
  - `unlimited-ocr-local`
- Vendor OCR passed for available untranslated runs:
  - `unlimited-ocr-vendor` Markdown/EPUB passed
  - `deepseek-ocr-vendor` EPUB passed; Markdown hit a transient SSL EOF in the full matrix and passed on immediate single-run retry
- Translation/PDF-patch routes were recorded as skipped because the configured real LLM profile resolves to OOMOL, but `oo llm config --json` is unavailable in this environment.
- `deepseek-ocr2-vendor` routes were recorded as skipped because `PDF_CRAFT_DEEPSEEK_OCR2_*` env vars are missing.