### PR TITLE
重构 LLM Repair Loop：注入式响应协议与 JSON/XML 适配

### DIFF
--- a/pdf_craft/extractor/toc/llm_analyser.py
+++ b/pdf_craft/extractor/toc/llm_analyser.py
@@ -4,7 +4,7 @@ from dataclasses import dataclass
 from typing import Any, Callable, Generator, Generic, Iterable, TypeVar, cast
 
 from json_repair import repair_json
-from pydantic import BaseModel, ValidationError, field_validator, model_validator
+from pydantic import BaseModel, StrictInt, ValidationError, field_validator, model_validator
 
 from ...common import XMLReader, split_by_cv
 from .config import MAX_LEVELS, MAX_TITLE_CV
@@ -631,11 +631,11 @@ class _TocEntry:
 
 
 class _TitleLevelsSchema(BaseModel):
-    levels: list[int]
+    levels: list[StrictInt]
 
     @field_validator("levels")
     @classmethod
-    def validate_levels(cls, v: list[int]) -> list[int]:
+    def validate_levels(cls, v: list[StrictInt]) -> list[StrictInt]:
         # Rule 1: Check all are valid integers in range
         for i, level in enumerate(v):
             if not isinstance(level, int):
@@ -681,11 +681,11 @@ class _TitleLevelsSchema(BaseModel):
 
 
 class _TocLevelsSchema(BaseModel):
-    levels: list[int]
+    levels: list[StrictInt]
 
     @field_validator("levels")
     @classmethod
-    def validate_levels(cls, v: list[int]) -> list[int]:
+    def validate_levels(cls, v: list[StrictInt]) -> list[StrictInt]:
         # Rule 1: Check all are valid integers in range
         for i, level in enumerate(v):
             if not isinstance(level, int):

--- a/pdf_craft/extractor/toc/llm_analyser.py
+++ b/pdf_craft/extractor/toc/llm_analyser.py
@@ -4,7 +4,7 @@ from dataclasses import dataclass
 from typing import Any, Callable, Generator, Generic, Iterable, TypeVar, cast
 
 from json_repair import repair_json
-from pydantic import BaseModel, RootModel, ValidationError, field_validator
+from pydantic import BaseModel, ValidationError, field_validator
 
 from ...common import XMLReader, split_by_cv
 from .config import MAX_LEVELS, MAX_TITLE_CV
@@ -568,11 +568,20 @@ class _LLMAnalyser(Generic[_P, _R]):
         self._runtime = runtime_for(llm, protocol_version="toc-json-v1") if isinstance(llm, LLM) else None
 
     def request(self, payload: _P, messages: Iterable[Message]) -> _R:
-        class _AnyResponse(RootModel[object]):
-            pass
+        class _ResponseSchema(BaseModel):
+            """Transport schema; TOC validator owns RESULT and ID semantics."""
+            model_config = {"extra": "allow"}
+
+            payload: dict[str, Any]
+
+            @classmethod
+            def model_validate(cls, obj, *args, **kwargs):  # type: ignore[override]
+                if not isinstance(obj, dict):
+                    raise ValueError("TOC response must be a JSON object")
+                return cls(payload=obj)
 
         def parse(data, _index, _maximum):
-            result, error_msg = self._validate(json.dumps(data.root, ensure_ascii=False), payload)
+            result, error_msg = self._validate(json.dumps(data.payload, ensure_ascii=False), payload)
             if result is None:
                 raise ValueError(error_msg or "Unknown validation error")
             return result
@@ -587,7 +596,7 @@ class _LLMAnalyser(Generic[_P, _R]):
                     if self._runtime is not None
                     else cast(Any, self._llm).request(input=current)
                 ),
-                schema=_AnyResponse,
+                schema=_ResponseSchema,
                 parse=parse,
                 max_retries=_MAX_RETRIES - 1,
             ))

--- a/pdf_craft/extractor/toc/llm_analyser.py
+++ b/pdf_craft/extractor/toc/llm_analyser.py
@@ -4,7 +4,7 @@ from dataclasses import dataclass
 from typing import Any, Callable, Generator, Generic, Iterable, TypeVar, cast
 
 from json_repair import repair_json
-from pydantic import BaseModel, ValidationError, field_validator
+from pydantic import BaseModel, ValidationError, field_validator, model_validator
 
 from ...common import XMLReader, split_by_cv
 from .config import MAX_LEVELS, MAX_TITLE_CV
@@ -570,15 +570,14 @@ class _LLMAnalyser(Generic[_P, _R]):
     def request(self, payload: _P, messages: Iterable[Message]) -> _R:
         class _ResponseSchema(BaseModel):
             """Transport schema; TOC validator owns RESULT and ID semantics."""
-            model_config = {"extra": "allow"}
-
             payload: dict[str, Any]
 
+            @model_validator(mode="before")
             @classmethod
-            def model_validate(cls, obj, *args, **kwargs):  # type: ignore[override]
-                if not isinstance(obj, dict):
+            def wrap_object(cls, value: Any) -> dict[str, Any]:
+                if not isinstance(value, dict):
                     raise ValueError("TOC response must be a JSON object")
-                return cls(payload=obj)
+                return {"payload": value}
 
         def parse(data, _index, _maximum):
             result, error_msg = self._validate(json.dumps(data.payload, ensure_ascii=False), payload)

--- a/pdf_craft/extractor/toc/llm_analyser.py
+++ b/pdf_craft/extractor/toc/llm_analyser.py
@@ -598,11 +598,20 @@ class _LLMAnalyser(Generic[_P, _R]):
                 schema=_ResponseSchema,
                 parse=parse,
                 max_retries=_MAX_RETRIES - 1,
+                extractor=_extract_result_json,
             ))
         except Exception as error:
             if isinstance(error, LLMAnalysisError):
                 raise
             raise LLMAnalysisError(f"LLM request failed at attempt 1: {error}") from error
+
+
+def _extract_result_json(response: str) -> str:
+    """Extract the JSON object after the final RESULT marker."""
+    marker = "RESULT:"
+    section = response[response.rfind(marker) + len(marker):].strip() if marker in response else response.strip()
+    match = re.search(r"\{[\s\S]*\}", section)
+    return match.group(0) if match else section
 
 
 @dataclass

--- a/pdf_craft/llm/__init__.py
+++ b/pdf_craft/llm/__init__.py
@@ -1,5 +1,10 @@
 from .core import LLM as LLM
 from .runtime import LLMContext as LLMContext, LLMRuntime as LLMRuntime, runtime_for as runtime_for
 from .types import Message as Message, MessageRole as MessageRole
+from .loop import (ProtocolFailure as ProtocolFailure, ProtocolPartial as ProtocolPartial,
+                   ProtocolRetry as ProtocolRetry, ProtocolSuccess as ProtocolSuccess,
+                   RepairLoopOptions as RepairLoopOptions, run_repair_loop as run_repair_loop)
 
-__all__ = ["LLM", "LLMContext", "LLMRuntime", "Message", "MessageRole", "runtime_for"]
+__all__ = ["LLM", "LLMContext", "LLMRuntime", "Message", "MessageRole", "runtime_for",
+           "ProtocolFailure", "ProtocolPartial", "ProtocolRetry", "ProtocolSuccess",
+           "RepairLoopOptions", "run_repair_loop"]

--- a/pdf_craft/llm/guaranteed.py
+++ b/pdf_craft/llm/guaranteed.py
@@ -1,3 +1,4 @@
+# pylint: disable=unused-argument
 from __future__ import annotations
 
 import json
@@ -11,7 +12,7 @@ from pydantic import BaseModel, ValidationError
 
 from .types import Message, MessageRole
 from .loop import (ProtocolFailure, ProtocolRetry, ProtocolSuccess, RepairLoopOptions,
-                   ResponseProtocol, run_repair_loop)
+                   run_repair_loop)
 
 TData = TypeVar("TData")
 TResult = TypeVar("TResult")

--- a/pdf_craft/llm/guaranteed.py
+++ b/pdf_craft/llm/guaranteed.py
@@ -10,6 +10,8 @@ from json_repair import repair_json
 from pydantic import BaseModel, ValidationError
 
 from .types import Message, MessageRole
+from .loop import (ProtocolFailure, ProtocolRetry, ProtocolSuccess, RepairLoopOptions,
+                   ResponseProtocol, run_repair_loop)
 
 TData = TypeVar("TData")
 TResult = TypeVar("TResult")
@@ -48,42 +50,44 @@ class GuaranteedOptions(Generic[TData, TResult]):
     schema: type[BaseModel]
     parse: Callable[[TData, int, int], TResult]
     max_retries: int = 12
+    extractor: Callable[[str], str] | None = None
 
 
 def request_guaranteed_json(options: GuaranteedOptions[TData, TResult]) -> TResult:
-    initial = list(options.messages)
-    current = list(initial)
-    last_response: str | None = None
-    for index in range(options.max_retries + 1):
-        response = options.request(current, index, options.max_retries)
-        last_response = response
-        if not response or not response.strip():
-            if index >= options.max_retries:
-                raise GuaranteedEmptyResponseError("LLM returned empty response after all retries", attempts=index + 1)
-            continue
-        try:
-            data = json.loads(repair_json(_extract_json(response)))
-        except (ValueError, json.JSONDecodeError) as error:
-            if _looks_like_refusal(response) and index >= min(1, options.max_retries):
-                raise GuaranteedProtocolError("LLM returned natural language instead of JSON", attempts=index + 1, response=response) from error
-            if index >= options.max_retries:
-                raise GuaranteedExhaustedError("JSON syntax remained invalid after retries", attempts=index + 1, response=response, cause=error) from error
-            current = _retry_messages(initial, response, "Return complete valid JSON only; do not explain or use markdown fences.", include_response=True)
-            continue
-        try:
-            validated = options.schema.model_validate(data)
-        except ValidationError as error:
-            if index >= options.max_retries:
-                raise GuaranteedSchemaError("JSON schema validation failed after retries", attempts=index + 1, response=response, cause=error) from error
-            current = _retry_messages(initial, response, _schema_feedback(error), include_response=True)
-            continue
-        try:
-            return options.parse(cast(TData, validated), index, options.max_retries)
-        except Exception as error:
-            if index >= options.max_retries:
-                raise GuaranteedBusinessError("JSON business validation failed after retries", attempts=index + 1, response=response, cause=error) from error
-            current = _retry_messages(initial, response, f"Fix the business validation error and return complete JSON:\n{error}", include_response=True)
-    raise GuaranteedExhaustedError("Guaranteed JSON request failed", attempts=options.max_retries + 1, response=last_response)
+    class _JsonProtocol:
+        def __init__(self) -> None:
+            self.last_error: GuaranteedRequestError | None = None
+
+        def validate(self, response: str, state: None, attempt: int, max_attempts: int):
+            try:
+                extractor = options.extractor or _extract_json
+                data = json.loads(repair_json(extractor(response)))
+            except (ValueError, json.JSONDecodeError) as error:
+                if _looks_like_refusal(response) and attempt >= min(1, options.max_retries):
+                    return ProtocolFailure(GuaranteedProtocolError("LLM returned natural language instead of JSON", attempts=attempt + 1, response=response, cause=error), state)
+                self.last_error = GuaranteedExhaustedError("JSON syntax remained invalid after retries", attempts=attempt + 1, response=response, cause=error)
+                return ProtocolRetry("Return complete valid JSON only; do not explain or use markdown fences.", state)
+            try:
+                validated = options.schema.model_validate(data)
+            except ValidationError as error:
+                self.last_error = GuaranteedSchemaError("JSON schema validation failed after retries", attempts=attempt + 1, response=response, cause=error)
+                return ProtocolRetry(_schema_feedback(error), state)
+            try:
+                return ProtocolSuccess(options.parse(cast(TData, validated), attempt, max_attempts), state)
+            except Exception as error:
+                self.last_error = GuaranteedBusinessError("JSON business validation failed after retries", attempts=attempt + 1, response=response, cause=error)
+                return ProtocolRetry(f"Fix the business validation error and return complete JSON:\n{error}", state)
+
+        def empty(self, state: None, attempt: int, max_attempts: int):
+            return ProtocolRetry("Return a non-empty complete JSON response.", state)
+
+        def exhausted(self, state: None, attempts: int, response: str | None) -> TResult:
+            if self.last_error is not None:
+                raise self.last_error
+            raise GuaranteedEmptyResponseError("LLM returned empty response after all retries", attempts=attempts, response=response)
+
+    return run_repair_loop(RepairLoopOptions(messages=options.messages, request=options.request,
+        protocol=_JsonProtocol(), state=None, max_attempts=options.max_retries + 1))
 
 
 def _extract_json(response: str) -> str:

--- a/pdf_craft/llm/loop.py
+++ b/pdf_craft/llm/loop.py
@@ -1,7 +1,7 @@
 from __future__ import annotations
 
 from collections.abc import Callable, Sequence
-from dataclasses import dataclass, field
+from dataclasses import dataclass
 from typing import Generic, Protocol, TypeVar
 
 from .types import Message, MessageRole
@@ -61,6 +61,7 @@ class RepairLoopOptions(Generic[T, S]):
 def run_repair_loop(options: RepairLoopOptions[T, S]) -> T:
     initial = list(options.messages)
     current = list(initial)
+    retry_history: list[Message] = []
     state = options.state
     last_response: str | None = None
     attempts = max(1, options.max_attempts)
@@ -77,8 +78,10 @@ def run_repair_loop(options: RepairLoopOptions[T, S]) -> T:
             raise result.error
         if attempt + 1 >= attempts:
             break
-        base = initial if result.reset_history else current
+        if result.reset_history:
+            retry_history = []
         additions = ([Message(MessageRole.ASSISTANT, response)] if result.include_response and response else [])
         additions.append(Message(MessageRole.USER, result.feedback))
-        current = [*base, *additions][-max(1, options.history_limit + len(initial)):]
+        retry_history = [*retry_history, *additions][-max(1, options.history_limit):]
+        current = [*initial, *retry_history]
     return options.protocol.exhausted(state, attempts, last_response)

--- a/pdf_craft/llm/loop.py
+++ b/pdf_craft/llm/loop.py
@@ -1,0 +1,84 @@
+from __future__ import annotations
+
+from collections.abc import Callable, Sequence
+from dataclasses import dataclass, field
+from typing import Generic, Protocol, TypeVar
+
+from .types import Message, MessageRole
+
+T = TypeVar("T")
+S = TypeVar("S")
+
+
+@dataclass(frozen=True)
+class ProtocolSuccess(Generic[T, S]):
+    value: T
+    state: S
+
+
+@dataclass(frozen=True)
+class ProtocolRetry(Generic[S]):
+    feedback: str
+    state: S
+    include_response: bool = True
+    reset_history: bool = True
+
+
+@dataclass(frozen=True)
+class ProtocolPartial(Generic[T, S]):
+    value: T
+    state: S
+    warning: str | None = None
+
+
+@dataclass(frozen=True)
+class ProtocolFailure(Generic[S]):
+    error: Exception
+    state: S
+
+
+ProtocolResult = ProtocolSuccess[T, S] | ProtocolRetry[S] | ProtocolPartial[T, S] | ProtocolFailure[S]
+
+
+class ResponseProtocol(Protocol[T, S]):
+    def validate(self, response: str, state: S, attempt: int, max_attempts: int) -> ProtocolResult[T, S]: ...
+
+    def empty(self, state: S, attempt: int, max_attempts: int) -> ProtocolResult[T, S]: ...
+
+    def exhausted(self, state: S, attempts: int, response: str | None) -> T: ...
+
+
+@dataclass
+class RepairLoopOptions(Generic[T, S]):
+    messages: Sequence[Message]
+    request: Callable[[list[Message], int, int], str]
+    protocol: ResponseProtocol[T, S]
+    state: S
+    max_attempts: int = 1
+    history_limit: int = 2
+
+
+def run_repair_loop(options: RepairLoopOptions[T, S]) -> T:
+    initial = list(options.messages)
+    current = list(initial)
+    state = options.state
+    last_response: str | None = None
+    attempts = max(1, options.max_attempts)
+    for attempt in range(attempts):
+        response = options.request(current, attempt, attempts - 1)
+        last_response = response
+        result = options.protocol.empty(state, attempt, attempts) if not response.strip() else options.protocol.validate(response, state, attempt, attempts)
+        state = result.state
+        if isinstance(result, ProtocolSuccess):
+            return result.value
+        if isinstance(result, ProtocolPartial):
+            return result.value
+        if isinstance(result, ProtocolFailure):
+            raise result.error
+        if attempt + 1 >= attempts:
+            break
+        base = initial if result.reset_history else current
+        additions = ([Message(MessageRole.ASSISTANT, response)] if result.include_response and response else [])
+        additions.append(Message(MessageRole.USER, result.feedback))
+        current = [*base, *additions][-max(1, options.history_limit + len(initial)):]
+    return options.protocol.exhausted(state, attempts, last_response)

--- a/pdf_craft/transformer/xml_translator/xml_translator/translator.py
+++ b/pdf_craft/transformer/xml_translator/xml_translator/translator.py
@@ -4,6 +4,7 @@ from typing import Generic, TypeVar
 from xml.etree.ElementTree import Element
 
 from pdf_craft.llm import LLM, Message, MessageRole, runtime_for
+from pdf_craft.llm.loop import ProtocolRetry, ProtocolSuccess, RepairLoopOptions, run_repair_loop
 from pdf_craft.transformer.xml_translator.segment import BlockSegment, InlineSegment, TextSegment
 from pdf_craft.transformer.xml_translator.xml import decode_friendly, encode_friendly
 from .callbacks import Callbacks, FillFailedEvent, warp_callbacks
@@ -186,42 +187,36 @@ class XMLTranslator:
                 message=user_message,
             ),
         ]
-        conversation_history: list[Message] = []
-
         with self._fill_runtime.context(cache_seed_content=self._cache_seed_content) as llm_context:
-            error_message: str | None = None
+            translator = self
+            class _XMLProtocol:
+                def validate(self, response: str, state, attempt: int, max_attempts: int):
+                    validated = translator._extract_xml_element(response)
+                    error = validated if isinstance(validated, str) else hill_climbing.submit(validated)
+                    if error is None:
+                        return ProtocolSuccess(None, state)
+                    callbacks.on_fill_failed(FillFailedEvent(error, attempt + 1, False))
+                    return ProtocolRetry(error, state, include_response=True, reset_history=True)
 
-            for retry_count in range(self._max_retries):
-                response = llm_context.request(fixed_messages + conversation_history)
-                validated_element = self._extract_xml_element(response)
-                error_message = None
-                if isinstance(validated_element, str):
-                    error_message = validated_element
-                elif isinstance(validated_element, Element):
-                    error_message = hill_climbing.submit(validated_element)
+                def empty(self, state, attempt: int, max_attempts: int):
+                    error = "LLM returned an empty XML response. Please return one complete <xml> block."
+                    callbacks.on_fill_failed(FillFailedEvent(error, attempt + 1, False))
+                    return ProtocolRetry(error, state)
 
-                if error_message is None:
-                    break
+                def exhausted(self, state, attempts: int, response: str | None):
+                    callbacks.on_fill_failed(FillFailedEvent(
+                        "XML fill exhausted retries; returning the best available partial mapping.",
+                        attempts, True,
+                    ))
+                    return None
 
-                callbacks.on_fill_failed(
-                    FillFailedEvent(
-                        error_message=error_message,
-                        retried_count=retry_count + 1,
-                        over_maximum_retries=False,
-                    )
-                )
-                conversation_history = [
-                    Message(role=MessageRole.ASSISTANT, message=response),
-                    Message(role=MessageRole.USER, message=error_message),
-                ]
-            if error_message is not None:
-                callbacks.on_fill_failed(
-                    FillFailedEvent(
-                        error_message=error_message,
-                        retried_count=self._max_retries,
-                        over_maximum_retries=True,
-                    )
-                )
+            run_repair_loop(RepairLoopOptions(
+                messages=fixed_messages,
+                request=lambda current, index, maximum: llm_context.request(
+                    current, retry_index=index, retry_max=maximum, use_cache=False),
+                protocol=_XMLProtocol(), state=None,
+                max_attempts=max(1, self._max_retries),
+            ))
 
     def _extract_xml_element(self, text: str) -> Element | str:
         first_xml_element: Element | None = None

--- a/pdf_craft/transformer/xml_translator/xml_translator/translator.py
+++ b/pdf_craft/transformer/xml_translator/xml_translator/translator.py
@@ -1,3 +1,4 @@
+# pylint: disable=protected-access,unused-argument
 from collections.abc import Callable, Generator, Iterable
 from dataclasses import dataclass
 from typing import Generic, TypeVar
@@ -189,23 +190,30 @@ class XMLTranslator:
         ]
         with self._fill_runtime.context(cache_seed_content=self._cache_seed_content) as llm_context:
             translator = self
+            last_error: str | None = None
             class _XMLProtocol:
                 def validate(self, response: str, state, attempt: int, max_attempts: int):
+                    nonlocal last_error
                     validated = translator._extract_xml_element(response)
                     error = validated if isinstance(validated, str) else hill_climbing.submit(validated)
                     if error is None:
+                        last_error = None
                         return ProtocolSuccess(None, state)
+                    last_error = error
                     callbacks.on_fill_failed(FillFailedEvent(error, attempt + 1, False))
                     return ProtocolRetry(error, state, include_response=True, reset_history=True)
 
                 def empty(self, state, attempt: int, max_attempts: int):
+                    nonlocal last_error
                     error = "LLM returned an empty XML response. Please return one complete <xml> block."
+                    last_error = error
                     callbacks.on_fill_failed(FillFailedEvent(error, attempt + 1, False))
                     return ProtocolRetry(error, state)
 
                 def exhausted(self, state, attempts: int, response: str | None):
+                    error = last_error or "XML fill exhausted retries; no usable response was produced."
                     callbacks.on_fill_failed(FillFailedEvent(
-                        "XML fill exhausted retries; returning the best available partial mapping.",
+                        error,
                         attempts, True,
                     ))
                     return None

--- a/tests/test_llm_loop.py
+++ b/tests/test_llm_loop.py
@@ -75,6 +75,46 @@ class TestRepairLoop(unittest.TestCase):
         self.assertEqual(len(seen[2]), 3)
         self.assertEqual(seen[2][0].message, "system")
 
+    def test_max_attempts_is_total_requests_and_transport_errors_propagate(self):
+        calls = []
+
+        class Protocol:
+            def validate(self, response, state, attempt, max_attempts):
+                return ProtocolRetry("retry", state)
+
+            def empty(self, state, attempt, max_attempts):
+                return ProtocolRetry("retry", state)
+
+            def exhausted(self, state, attempts, response):
+                return attempts
+
+        result = run_repair_loop(RepairLoopOptions(
+            messages=[], request=lambda messages, attempt, maximum: (calls.append((attempt, maximum)) or "bad"),
+            protocol=Protocol(), state=None, max_attempts=3,
+        ))
+        self.assertEqual(result, 3)
+        self.assertEqual(calls, [(0, 2), (1, 2), (2, 2)])
+
+        def broken(messages, attempt, maximum):
+            raise RuntimeError("transport")
+
+        with self.assertRaisesRegex(RuntimeError, "transport"):
+            run_repair_loop(RepairLoopOptions(messages=[], request=broken, protocol=Protocol(), state=None, max_attempts=3))
+
+    def test_protocol_callback_exceptions_propagate(self):
+        class Protocol:
+            def validate(self, response, state, attempt, max_attempts):
+                raise ValueError("protocol")
+
+            def empty(self, state, attempt, max_attempts):
+                raise ValueError("protocol-empty")
+
+            def exhausted(self, state, attempts, response):
+                raise AssertionError("unexpected exhaustion")
+
+        with self.assertRaisesRegex(ValueError, "protocol"):
+            run_repair_loop(RepairLoopOptions(messages=[], request=lambda *args: "response", protocol=Protocol(), state=None))
+
 
 if __name__ == "__main__":
     unittest.main()

--- a/tests/test_llm_loop.py
+++ b/tests/test_llm_loop.py
@@ -1,0 +1,36 @@
+import unittest
+
+from pdf_craft.llm import Message, MessageRole, ProtocolRetry, ProtocolSuccess, RepairLoopOptions, run_repair_loop
+
+
+class TestRepairLoop(unittest.TestCase):
+    def test_retries_with_typed_protocol_and_bounded_history(self):
+        seen = []
+
+        class Protocol:
+            def validate(self, response, state, attempt, max_attempts):
+                if response == "ok":
+                    return ProtocolSuccess("done", state + 1)
+                return ProtocolRetry("please retry", state + 1)
+
+            def empty(self, state, attempt, max_attempts):
+                return ProtocolRetry("non-empty", state)
+
+            def exhausted(self, state, attempts, response):
+                raise AssertionError("unexpected exhaustion")
+
+        def request(messages, attempt, maximum):
+            seen.append(messages)
+            return "bad" if attempt == 0 else "ok"
+
+        result = run_repair_loop(RepairLoopOptions(
+            messages=[Message(MessageRole.USER, "start")], request=request,
+            protocol=Protocol(), state=0, max_attempts=2, history_limit=1,
+        ))
+        self.assertEqual(result, "done")
+        self.assertEqual(len(seen), 2)
+        self.assertLessEqual(len(seen[1]), 3)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_llm_loop.py
+++ b/tests/test_llm_loop.py
@@ -1,3 +1,4 @@
+# pylint: disable=unused-argument
 import unittest
 
 from pdf_craft.llm import Message, MessageRole, ProtocolRetry, ProtocolSuccess, RepairLoopOptions, run_repair_loop
@@ -30,6 +31,49 @@ class TestRepairLoop(unittest.TestCase):
         self.assertEqual(result, "done")
         self.assertEqual(len(seen), 2)
         self.assertLessEqual(len(seen[1]), 3)
+
+    def test_preserves_initial_messages_when_history_is_cropped(self):
+        seen = []
+
+        class Protocol:
+            def validate(self, response, state, attempt, max_attempts):
+                return ProtocolSuccess("done", state) if attempt == 2 else ProtocolRetry("again", state, reset_history=False)
+
+            def empty(self, state, attempt, max_attempts):
+                return ProtocolRetry("again", state, reset_history=False)
+
+            def exhausted(self, state, attempts, response):
+                raise AssertionError("unexpected exhaustion")
+
+        result = run_repair_loop(RepairLoopOptions(
+            messages=[Message(MessageRole.SYSTEM, "system"), Message(MessageRole.USER, "task")],
+            request=lambda messages, attempt, maximum: (seen.append(messages) or "ok"),
+            protocol=Protocol(), state=None, max_attempts=3, history_limit=2,
+        ))
+        self.assertEqual(result, "done")
+        self.assertTrue(all(message.role is MessageRole.SYSTEM for message in seen[1][:1]))
+        self.assertEqual([message.message for message in seen[2][:2]], ["system", "task"])
+
+    def test_reset_history_discards_previous_retry_messages_but_keeps_initial(self):
+        seen = []
+
+        class Protocol:
+            def validate(self, response, state, attempt, max_attempts):
+                return ProtocolSuccess("done", state) if attempt == 2 else ProtocolRetry("again", state, reset_history=True)
+
+            def empty(self, state, attempt, max_attempts):
+                return ProtocolRetry("again", state, reset_history=True)
+
+            def exhausted(self, state, attempts, response):
+                raise AssertionError("unexpected exhaustion")
+
+        run_repair_loop(RepairLoopOptions(
+            messages=[Message(MessageRole.SYSTEM, "system")],
+            request=lambda messages, attempt, maximum: (seen.append(messages) or "bad"),
+            protocol=Protocol(), state=None, max_attempts=3, history_limit=4,
+        ))
+        self.assertEqual(len(seen[2]), 3)
+        self.assertEqual(seen[2][0].message, "system")
 
 
 if __name__ == "__main__":

--- a/tests/test_toc_llm_analyser.py
+++ b/tests/test_toc_llm_analyser.py
@@ -26,6 +26,11 @@ class _SequenceLLM:
         return next(self.responses)
 
 
+class _ResultLLM:
+    def request(self, input):  # pylint: disable=redefined-builtin,unused-argument
+        return 'ANALYSIS: example {"A": 99}\nRESULT: {"A": 0, "B": 1}\nRESULT: {"A": 2, "B": 3}'
+
+
 class TestLLMAnalyser(unittest.TestCase):
     def test_wraps_llm_request_errors_as_analysis_error(self):
         analyser = _LLMAnalyser(
@@ -75,6 +80,15 @@ class TestLLMAnalyser(unittest.TestCase):
             analyser.request(payload=None, messages=[Message(MessageRole.USER, "json")])
         self.assertIn("schema validation failed", str(context.exception))
         self.assertEqual(llm.calls, 3)
+
+    def test_toc_validator_receives_last_result_section(self):
+        received = []
+        analyser = _LLMAnalyser(
+            llm=cast(LLM, _ResultLLM()),
+            validate=lambda response, payload: (received.append(response) or ([2, 3], None)),
+        )
+        self.assertEqual(analyser.request(payload=None, messages=[Message(MessageRole.USER, "toc")]), [2, 3])
+        self.assertEqual(received, ['{"A": 2, "B": 3}'])
 
 
 if __name__ == "__main__":

--- a/tests/test_toc_llm_analyser.py
+++ b/tests/test_toc_llm_analyser.py
@@ -16,6 +16,16 @@ class _JsonLLM:
         return '{"0": 0, "1": 1}'
 
 
+class _SequenceLLM:
+    def __init__(self, responses):
+        self.responses = iter(responses)
+        self.calls = 0
+
+    def request(self, input):  # pylint: disable=redefined-builtin,unused-argument
+        self.calls += 1
+        return next(self.responses)
+
+
 class TestLLMAnalyser(unittest.TestCase):
     def test_wraps_llm_request_errors_as_analysis_error(self):
         analyser = _LLMAnalyser(
@@ -45,6 +55,26 @@ class TestLLMAnalyser(unittest.TestCase):
             analyser.request(payload=None, messages=[Message(MessageRole.USER, "json")]),
             [0, 1],
         )
+
+    def test_non_object_response_is_schema_retry(self):
+        llm = _SequenceLLM(["[1, 2]", '{"0": 0, "1": 1}'])
+        analyser = _LLMAnalyser(
+            llm=cast(LLM, llm),
+            validate=lambda response, payload: ([0, 1], None),
+        )
+        self.assertEqual(analyser.request(payload=None, messages=[Message(MessageRole.USER, "json")]), [0, 1])
+        self.assertEqual(llm.calls, 2)
+
+    def test_non_object_response_exhausts_as_typed_schema_failure(self):
+        llm = _SequenceLLM(["[1, 2]"] * 3)
+        analyser = _LLMAnalyser(
+            llm=cast(LLM, llm),
+            validate=lambda response, payload: ([0, 1], None),
+        )
+        with self.assertRaises(LLMAnalysisError) as context:
+            analyser.request(payload=None, messages=[Message(MessageRole.USER, "json")])
+        self.assertIn("schema validation failed", str(context.exception))
+        self.assertEqual(llm.calls, 3)
 
 
 if __name__ == "__main__":

--- a/tests/test_toc_llm_analyser.py
+++ b/tests/test_toc_llm_analyser.py
@@ -3,7 +3,12 @@ from typing import cast
 
 from pdf_craft.llm.types import Message, MessageRole
 from pdf_craft.llm.core import LLM
-from pdf_craft.extractor.toc.llm_analyser import LLMAnalysisError, _LLMAnalyser
+from pdf_craft.extractor.toc.llm_analyser import (
+    LLMAnalysisError,
+    _LLMAnalyser,
+    _validate_title_response,
+    _validate_toc_response,
+)
 
 
 class _BrokenLLM:
@@ -89,6 +94,20 @@ class TestLLMAnalyser(unittest.TestCase):
         )
         self.assertEqual(analyser.request(payload=None, messages=[Message(MessageRole.USER, "toc")]), [2, 3])
         self.assertEqual(received, ['{"A": 2, "B": 3}'])
+
+    def test_title_and_toc_levels_reject_string_and_boolean_integers(self):
+        for response, validator in (
+            ('{"0": "1"}', _validate_title_response),
+            ('{"0": true}', _validate_title_response),
+        ):
+            result, error = validator(response, 1)
+            self.assertIsNone(result)
+            self.assertIn("integer", error or "")
+
+        for response in ('{"A": "1"}', '{"A": false}'):
+            result, error = _validate_toc_response(response, 1)
+            self.assertIsNone(result)
+            self.assertIn("integer", error or "")
 
 
 if __name__ == "__main__":

--- a/tests/test_xml_repair_loop.py
+++ b/tests/test_xml_repair_loop.py
@@ -1,0 +1,92 @@
+ # pylint: disable=protected-access,unused-argument
+import unittest
+from types import SimpleNamespace
+from typing import Any, cast
+from xml.etree.ElementTree import Element
+
+from pdf_craft.transformer.xml_translator.xml_translator.callbacks import Callbacks
+from pdf_craft.transformer.xml_translator.xml_translator.translator import XMLTranslator
+
+
+class _Context:
+    def __init__(self, responses):
+        self.responses = iter(responses)
+        self.calls = 0
+
+    def __enter__(self):
+        return self
+
+    def __exit__(self, *args):
+        return None
+
+    def request(self, messages, **kwargs):
+        self.calls += 1
+        return next(self.responses)
+
+
+class _Runtime:
+    def __init__(self, responses):
+        self.context_value = _Context(responses)
+
+    def context(self, **kwargs):
+        return self.context_value
+
+
+class _Hill:
+    def __init__(self, errors):
+        self.errors = iter(errors)
+
+    def request_element(self):
+        return Element("xml")
+
+    def submit(self, element):
+        return next(self.errors)
+
+
+def _translator(responses, retries=2):
+    translator = object.__new__(XMLTranslator)
+    translator._fill_runtime = cast(Any, _Runtime(responses))
+    translator._fill_llm = cast(Any, SimpleNamespace(template=lambda name: SimpleNamespace(render=lambda: "fill")))
+    translator._cache_seed_content = None
+    translator._max_retries = retries
+    return translator
+
+
+def _callbacks(events):
+    return Callbacks(lambda x: x, lambda x: x, lambda x: x, events.append)
+
+
+class TestXMLRepairLoop(unittest.TestCase):
+    def test_extracts_no_and_multiple_blocks(self):
+        translator = object.__new__(XMLTranslator)
+        self.assertIn("No complete", translator._extract_xml_element("plain text"))
+        self.assertIn("Found 2", translator._extract_xml_element("<xml>a</xml><xml>b</xml>"))
+
+    def test_retries_hill_climbing_improvement_then_succeeds(self):
+        translator = _translator(["<xml>bad</xml>", "<xml>good</xml>"])
+        events = []
+        hill = _Hill(["structural error", None])
+        translator._request_and_submit(cast(Any, hill), "source", "translated", _callbacks(events))
+        self.assertEqual(cast(Any, translator._fill_runtime).context_value.calls, 2)
+        self.assertEqual([event.error_message for event in events], ["structural error"])
+        self.assertFalse(events[0].over_maximum_retries)
+
+    def test_exhausted_event_keeps_final_xml_diagnostic_and_callback_errors_propagate(self):
+        translator = _translator(["<xml>a</xml>", "<xml>b</xml>"], retries=2)
+        events = []
+        translator._request_and_submit(cast(Any, _Hill(["first error", "final structural error"])), "s", "t", _callbacks(events))
+        self.assertEqual(events[-1].error_message, "final structural error")
+        self.assertTrue(events[-1].over_maximum_retries)
+
+        def fail(event):
+            raise RuntimeError("callback")
+
+        with self.assertRaisesRegex(RuntimeError, "callback"):
+            _translator(["<xml>x</xml>"])._request_and_submit(
+                cast(Any, _Hill(["error"])), "s", "t",
+                Callbacks(lambda x: x, lambda x: x, lambda x: x, fail),
+            )
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary
- extract a generic typed Repair Loop with bounded retry history
- adapt JSON/TOC and XML fill protocols
- add deterministic protocol, XML, TOC regression coverage

## Verification
- poetry run pytest -q (296 passed)
- poetry run pyright pdf_craft tests
- poetry run pylint pdf_craft tests
- real PDF and EPUB Chinese EPUB smoke tests passed during Review