### PR TITLE
chore: establish PDFCraft entry and tool setup baseline

### DIFF
--- a/.conductor/settings.toml
+++ b/.conductor/settings.toml
@@ -11,7 +11,22 @@ if not ((3, 11) <= sys.version_info < (3, 14)):
     raise SystemExit(f"Python >=3.11,<3.14 is required, got {sys.version.split()[0]}")
 PY
 
-"$PYTHON_BIN" -m venv .venv
+VENV_PYTHON="$PWD/.venv/bin/python"
+if [ -x "$VENV_PYTHON" ]; then
+  if ! "$VENV_PYTHON" - <<'PY'
+import sys
+if not ((3, 11) <= sys.version_info < (3, 14)):
+    raise SystemExit(1)
+PY
+  then
+    rm -rf "$PWD/.venv"
+  fi
+fi
+
+if [ ! -x "$VENV_PYTHON" ]; then
+  "$PYTHON_BIN" -m venv "$PWD/.venv"
+fi
+
 export VIRTUAL_ENV="$PWD/.venv"
 export PATH="$VIRTUAL_ENV/bin:$PATH"
 

--- a/README.md
+++ b/README.md
@@ -46,12 +46,14 @@ The above commands are for quick setup only. To actually use pdf-craft, you need
 #### Convert to Markdown
 
 ```python
-from pdf_craft import transform_markdown
+from pdf_craft import PDFCraft, PDFOptions
 
-transform_markdown(
-    pdf_path="input.pdf",
-    markdown_path="output.md",
-    markdown_assets_path="images",
+craft = PDFCraft(pdf=PDFOptions())
+craft.convert_pdf_to_markdown(
+    "input.pdf",
+    "output.md",
+    package_path="analysing",
+    assets_path="images",
 )
 ```
 
@@ -60,17 +62,23 @@ transform_markdown(
 #### Convert to EPUB
 
 ```python
-from pdf_craft import transform_epub, BookMeta
+from pdf_craft import BookMeta, PDFCraft, PDFOptions
 
-transform_epub(
-    pdf_path="input.pdf",
-    epub_path="output.epub",
+craft = PDFCraft(pdf=PDFOptions())
+craft.convert_pdf_to_epub(
+    "input.pdf",
+    "output.epub",
+    package_path="analysing",
     book_meta=BookMeta(
         title="Book Title",
         authors=["Author"],
     ),
 )
 ```
+
+The `transform_markdown` and `transform_epub` functions remain available as
+compatibility convenience wrappers. New integrations should use `PDFCraft` so
+extraction, rendering, and translation workflows share one public facade.
 
 ![20251218-162533](https://github.com/user-attachments/assets/7f6df04a-1fa7-48b3-aa5e-d2d056304ad6)
 

--- a/README_zh-CN.md
+++ b/README_zh-CN.md
@@ -46,12 +46,14 @@ pip install pdf-craft
 #### 转换为 Markdown
 
 ```python
-from pdf_craft import transform_markdown
+from pdf_craft import PDFCraft, PDFOptions
 
-transform_markdown(
-    pdf_path="input.pdf",
-    markdown_path="output.md",
-    markdown_assets_path="images",
+craft = PDFCraft(pdf=PDFOptions())
+craft.convert_pdf_to_markdown(
+    "input.pdf",
+    "output.md",
+    package_path="analysing",
+    assets_path="images",
 )
 ```
 
@@ -60,17 +62,22 @@ transform_markdown(
 #### 转换为 EPUB
 
 ```python
-from pdf_craft import transform_epub, BookMeta
+from pdf_craft import BookMeta, PDFCraft, PDFOptions
 
-transform_epub(
-    pdf_path="input.pdf",
-    epub_path="output.epub",
+craft = PDFCraft(pdf=PDFOptions())
+craft.convert_pdf_to_epub(
+    "input.pdf",
+    "output.epub",
+    package_path="analysing",
     book_meta=BookMeta(
         title="书名",
         authors=["作者"],
     ),
 )
 ```
+
+`transform_markdown` 和 `transform_epub` 仍作为兼容性的便利包装保留。新集成建议使用
+`PDFCraft`，这样提取、渲染和翻译流程都通过同一个公共 facade。
 
 ![](docs/images/pdf2epub-cn.png)
 

--- a/docs/DEVELOPMENT.md
+++ b/docs/DEVELOPMENT.md
@@ -17,9 +17,23 @@ pdf-craft depends on `doc-page-extractor[local]`, so installs include the upstre
 Create an in-project virtual environment and install project dependencies:
 
 ```shell
+PYTHON_BIN="$(command -v python3.11 || pyenv which python3 2>/dev/null || command -v python3)"
+"$PYTHON_BIN" - <<'PY'
+import sys
+if not ((3, 11) <= sys.version_info < (3, 14)):
+    raise SystemExit(f"Python >=3.11,<3.14 is required, got {sys.version.split()[0]}")
+PY
+
+"$PYTHON_BIN" -m venv .venv
+export VIRTUAL_ENV="$PWD/.venv"
+export PATH="$VIRTUAL_ENV/bin:$PATH"
 poetry config virtualenvs.in-project true
 poetry install --with dev
 ```
+
+The project supports Python 3.11 through 3.13. When reusing an existing
+`.venv`, verify its interpreter first; an environment created with Python 3.14
+is not valid for this project and must be recreated with a supported Python.
 
 For code reading, type checking, and the lightweight unit tests, this is usually enough.
 

--- a/pdf_craft/__init__.py
+++ b/pdf_craft/__init__.py
@@ -13,6 +13,7 @@ from .pipeline.epub import translate_epub
 from .pipeline.pdf import PDFPatcher, PDFReplacement, PDFSkippedReplacement, PDFTranslationPipeline, PatchTextOptions
 from .transformer import (
     ChapterPackageTransformer,
+    ChapterXMLTransformer,
     FillFailedEvent,
     PackageTransformer,
     SubmitKind,

--- a/pdf_craft_tool/cli.py
+++ b/pdf_craft_tool/cli.py
@@ -8,17 +8,17 @@ from typing import Any, cast
 
 from pdf_craft import (
     ChapterPackageTransformer,
+    ChapterXMLTransformer,
+    DocumentPackage,
     ExtractionOptions,
+    OCRMode,
+    OCRTokensMetering,
     PDFCraft,
     PDFOptions,
     SubmitKind,
     TranslationStep,
     XMLTranslator,
 )
-from pdf_craft.ocr_config import OCRMode
-from pdf_craft.document import DocumentPackage
-from pdf_craft.metering import OCRTokensMetering
-from pdf_craft.transformer.chapter_xml import ChapterXMLTransformer
 
 from .runtime import (
     create_ocr_config_from_env,

--- a/pdf_craft_tool/smoke/ocr.py
+++ b/pdf_craft_tool/smoke/ocr.py
@@ -1,6 +1,6 @@
 from typing import Any
 
-from pdf_craft.ocr_config import (
+from pdf_craft import (
     DeepSeekOCR2LocalConfig,
     DeepSeekOCR2VendorConfig,
     DeepSeekOCRLocalConfig,

--- a/pdf_craft_tool/smoke/runner.py
+++ b/pdf_craft_tool/smoke/runner.py
@@ -11,17 +11,21 @@ from pathlib import Path
 from time import perf_counter
 from typing import Any, Literal, cast
 
-from pdf_craft.craft import ExtractionOptions, PDFCraft, PDFOptions, TranslationStep
-from pdf_craft.ocr_config import OCRConfig, OCRMode
-from pdf_craft.transformer import (
+from pdf_craft import (
     ChapterPackageTransformer,
     ChapterXMLTransformer,
+    ExtractionOptions,
+    LLM,
+    OCRConfig,
+    OCRMode,
+    OCREvent,
+    PDFCraft,
+    PDFOptions,
     SubmitKind,
+    TranslationStep,
     XMLTranslator,
 )
 from pdf_craft.extractor.chapter.chapter import BlockLayout, BlockMember, Chapter, HTMLTag, ParagraphLayout
-from pdf_craft.llm import LLM
-from pdf_craft.pdf import OCREvent
 
 from .assets import SmokeAsset, discover_assets
 from .checks import check_epub, check_markdown, check_package, check_pdf_patch_geometry


### PR DESCRIPTION
## Summary
- make PDFCraft the documented primary conversion facade while preserving compatibility wrappers
- make Conductor setup recreate incompatible Python 3.14 environments
- route pdf_craft_tool imports through the public pdf_craft API

## Verification
- poetry run pytest (296 passed)
- poetry run pyright pdf_craft tests (0 errors)
- pdf_craft_tool --help, smoke assets, and smoke matrix dry-run

CUDA OCR and generated artifacts are intentionally not included.