### PR TITLE
Expand smoke and CLI reproduction routes

### DIFF
--- a/.conductor/settings.toml
+++ b/.conductor/settings.toml
@@ -11,7 +11,22 @@ if not ((3, 11) <= sys.version_info < (3, 14)):
     raise SystemExit(f"Python >=3.11,<3.14 is required, got {sys.version.split()[0]}")
 PY
 
-"$PYTHON_BIN" -m venv .venv
+VENV_PYTHON="$PWD/.venv/bin/python"
+if [ -x "$VENV_PYTHON" ]; then
+  if ! "$VENV_PYTHON" - <<'PY'
+import sys
+if not ((3, 11) <= sys.version_info < (3, 14)):
+    raise SystemExit(1)
+PY
+  then
+    rm -rf "$PWD/.venv"
+  fi
+fi
+
+if [ ! -x "$VENV_PYTHON" ]; then
+  "$PYTHON_BIN" -m venv "$PWD/.venv"
+fi
+
 export VIRTUAL_ENV="$PWD/.venv"
 export PATH="$VIRTUAL_ENV/bin:$PATH"
 

--- a/README.md
+++ b/README.md
@@ -46,12 +46,14 @@ The above commands are for quick setup only. To actually use pdf-craft, you need
 #### Convert to Markdown
 
 ```python
-from pdf_craft import transform_markdown
+from pdf_craft import PDFCraft, PDFOptions
 
-transform_markdown(
-    pdf_path="input.pdf",
-    markdown_path="output.md",
-    markdown_assets_path="images",
+craft = PDFCraft(pdf=PDFOptions())
+craft.convert_pdf_to_markdown(
+    "input.pdf",
+    "output.md",
+    package_path="analysing",
+    assets_path="images",
 )
 ```
 
@@ -60,17 +62,23 @@ transform_markdown(
 #### Convert to EPUB
 
 ```python
-from pdf_craft import transform_epub, BookMeta
+from pdf_craft import BookMeta, PDFCraft, PDFOptions
 
-transform_epub(
-    pdf_path="input.pdf",
-    epub_path="output.epub",
+craft = PDFCraft(pdf=PDFOptions())
+craft.convert_pdf_to_epub(
+    "input.pdf",
+    "output.epub",
+    package_path="analysing",
     book_meta=BookMeta(
         title="Book Title",
         authors=["Author"],
     ),
 )
 ```
+
+The `transform_markdown` and `transform_epub` functions remain available as
+compatibility convenience wrappers. New integrations should use `PDFCraft` so
+extraction, rendering, and translation workflows share one public facade.
 
 ![20251218-162533](https://github.com/user-attachments/assets/7f6df04a-1fa7-48b3-aa5e-d2d056304ad6)
 

--- a/README_zh-CN.md
+++ b/README_zh-CN.md
@@ -46,12 +46,14 @@ pip install pdf-craft
 #### 转换为 Markdown
 
 ```python
-from pdf_craft import transform_markdown
+from pdf_craft import PDFCraft, PDFOptions
 
-transform_markdown(
-    pdf_path="input.pdf",
-    markdown_path="output.md",
-    markdown_assets_path="images",
+craft = PDFCraft(pdf=PDFOptions())
+craft.convert_pdf_to_markdown(
+    "input.pdf",
+    "output.md",
+    package_path="analysing",
+    assets_path="images",
 )
 ```
 
@@ -60,17 +62,22 @@ transform_markdown(
 #### 转换为 EPUB
 
 ```python
-from pdf_craft import transform_epub, BookMeta
+from pdf_craft import BookMeta, PDFCraft, PDFOptions
 
-transform_epub(
-    pdf_path="input.pdf",
-    epub_path="output.epub",
+craft = PDFCraft(pdf=PDFOptions())
+craft.convert_pdf_to_epub(
+    "input.pdf",
+    "output.epub",
+    package_path="analysing",
     book_meta=BookMeta(
         title="书名",
         authors=["作者"],
     ),
 )
 ```
+
+`transform_markdown` 和 `transform_epub` 仍作为兼容性的便利包装保留。新集成建议使用
+`PDFCraft`，这样提取、渲染和翻译流程都通过同一个公共 facade。
 
 ![](docs/images/pdf2epub-cn.png)
 

--- a/docs/DEVELOPMENT.md
+++ b/docs/DEVELOPMENT.md
@@ -17,9 +17,23 @@ pdf-craft depends on `doc-page-extractor[local]`, so installs include the upstre
 Create an in-project virtual environment and install project dependencies:
 
 ```shell
+PYTHON_BIN="$(command -v python3.11 || pyenv which python3 2>/dev/null || command -v python3)"
+"$PYTHON_BIN" - <<'PY'
+import sys
+if not ((3, 11) <= sys.version_info < (3, 14)):
+    raise SystemExit(f"Python >=3.11,<3.14 is required, got {sys.version.split()[0]}")
+PY
+
+"$PYTHON_BIN" -m venv .venv
+export VIRTUAL_ENV="$PWD/.venv"
+export PATH="$VIRTUAL_ENV/bin:$PATH"
 poetry config virtualenvs.in-project true
 poetry install --with dev
 ```
+
+The project supports Python 3.11 through 3.13. When reusing an existing
+`.venv`, verify its interpreter first; an environment created with Python 3.14
+is not valid for this project and must be recreated with a supported Python.
 
 For code reading, type checking, and the lightweight unit tests, this is usually enough.
 

--- a/pdf_craft/__init__.py
+++ b/pdf_craft/__init__.py
@@ -13,6 +13,7 @@ from .pipeline.epub import translate_epub
 from .pipeline.pdf import PDFPatcher, PDFReplacement, PDFSkippedReplacement, PDFTranslationPipeline, PatchTextOptions
 from .transformer import (
     ChapterPackageTransformer,
+    ChapterXMLTransformer,
     FillFailedEvent,
     PackageTransformer,
     SubmitKind,

--- a/pdf_craft_tool/README.md
+++ b/pdf_craft_tool/README.md
@@ -89,6 +89,10 @@ poetry run python -m pdf_craft_tool smoke assets
 `manifest.json`、`checks.json`、`logs/`、提取的 `package/` 和渲染产物；凭据会
 从报告和 traceback 中脱敏。
 
+smoke 命令的进程退出码与报告状态一致：`passed` 和 `planned` 返回 0，`failed`
+或 `skipped` 返回非 0。矩阵命令会聚合所有 run，只要有一个 run 失败或跳过就返回
+非 0，避免 CI 或 Agent 把未执行的必需路径误判为成功。
+
 ```shell
 # 先确认参数展开和产物目录，不调用 OCR
 poetry run python -m pdf_craft_tool smoke run \

--- a/pdf_craft_tool/README.md
+++ b/pdf_craft_tool/README.md
@@ -111,10 +111,14 @@ poetry run python -m pdf_craft_tool smoke run \
 ```
 
 `--route` 可选 `package`、`markdown`、`epub`、`pdf-patch`、`epub-check`、
-`epub-translate`。PDF route 可使用同一组限制参数：`--pages`、`--ocr-size`、
+`epub-translate`，以及专门验证 Package renderer 分支的
+`package-markdown`、`package-epub`。PDF route 可使用同一组限制参数：
+`--pages`、`--ocr-size`、
 `--dpi`、token 限额、图片限额、`--cover`、`--footnotes`、`--plot` 和
 `--toc-assumed`。`markdown` 和 `epub` 使用 `--marker` / `--submit` 覆盖确定性的
 Package 变换；`pdf-patch` 使用 `--patch-prefix` 检验 patch 产物和 geometry。
+需要真实 LLM 翻译时，可以给 `smoke run` 传入 `--translation-llm-profile`
+和 `--fill-llm-profile`；`epub-translate` 默认使用 `translation` profile。
 
 对于需要稳定保存或批量执行的组合，使用 JSON 矩阵：
 
@@ -125,3 +129,14 @@ poetry run python -m pdf_craft_tool smoke matrix --config path/to/matrix.json
 
 矩阵结构为 `{ "defaults": {...}, "runs": [...] }`；每个 run 的字段与
 `SmokeRun` 一一对应。`tests/smoke/minimal.json` 是最小可运行示例。
+
+仓库还提供了不包含凭据的 vendor/LLM 真实运行矩阵：
+
+```shell
+poetry run python -m pdf_craft_tool smoke matrix \
+  --config tests/smoke/vendor_real.json
+```
+
+该矩阵读取当前工作区 `.env`，会产生真实 OCR 和文本 LLM 请求；执行前应确认
+`PDF_CRAFT_OCR_MODE`、对应 vendor OCR 配置以及 `translation`/`fill` LLM profile
+均已配置。local OCR route 在无 CUDA 环境中会记录为 skipped，不应伪装为 passed。

--- a/pdf_craft_tool/__main__.py
+++ b/pdf_craft_tool/__main__.py
@@ -1,3 +1,3 @@
 from .cli import main
 
-main()
+raise SystemExit(main())

--- a/pdf_craft_tool/cli.py
+++ b/pdf_craft_tool/cli.py
@@ -40,13 +40,14 @@ class _ExtractionResult:
     metering: OCRTokensMetering
 
 
-def main() -> None:
+def main() -> int:
     parser = _parser()
     args = parser.parse_args()
     if not hasattr(args, "handler"):
         parser.print_help()
-        return
-    args.handler(args)
+        return 0
+    result = args.handler(args)
+    return result if isinstance(result, int) else 0
 
 
 def _parser() -> argparse.ArgumentParser:
@@ -261,7 +262,7 @@ def _list_assets(args: argparse.Namespace) -> None:
     ], ensure_ascii=False, indent=2))
 
 
-def _run_smoke(args: argparse.Namespace) -> None:
+def _run_smoke(args: argparse.Namespace) -> int:
     translation: dict[str, Any] = {}
     if args.marker:
         translation["package_marker"] = args.marker
@@ -301,10 +302,12 @@ def _run_smoke(args: argparse.Namespace) -> None:
         ocr=ocr_values_from_env(ocr_mode) if ocr_mode and not args.dry_run else None,
         translation=translation or None,
     )
-    print(run_smoke(run, assets_root=args.assets_root, output_root=args.output_root, dry_run=args.dry_run))
+    run_path = run_smoke(run, assets_root=args.assets_root, output_root=args.output_root, dry_run=args.dry_run)
+    print(run_path)
+    return _smoke_exit_code(run_path)
 
 
-def _run_matrix(args: argparse.Namespace) -> None:
+def _run_matrix(args: argparse.Namespace) -> int:
     config = json.loads(args.config.read_text(encoding="utf-8"))
     runs = expand_matrix(config, args.assets_root)
     env_error: str | None = None
@@ -313,6 +316,7 @@ def _run_matrix(args: argparse.Namespace) -> None:
             load_project_env(_project_root())
         except SystemExit as error:
             env_error = str(error)
+    exit_code = 0
     for run in runs:
         if env_error and _matrix_run_needs_env(run):
             run = replace(run, configuration_error=env_error)
@@ -321,7 +325,19 @@ def _run_matrix(args: argparse.Namespace) -> None:
                 run = _resolve_matrix_runtime(run, args.output_root)
             except SystemExit as error:
                 run = replace(run, configuration_error=str(error))
-        print(run_smoke(run, assets_root=args.assets_root, output_root=args.output_root, dry_run=args.dry_run))
+        run_path = run_smoke(run, assets_root=args.assets_root, output_root=args.output_root, dry_run=args.dry_run)
+        print(run_path)
+        exit_code = max(exit_code, _smoke_exit_code(run_path))
+    return exit_code
+
+
+def _smoke_exit_code(run_path: Path) -> int:
+    """Return a non-zero code for failed or skipped required smoke runs."""
+    try:
+        status = json.loads((run_path / "checks.json").read_text(encoding="utf-8"))["status"]
+    except (OSError, KeyError, json.JSONDecodeError):
+        return 1
+    return 0 if status in {"passed", "planned"} else 1
 
 
 def _matrix_run_needs_env(run: SmokeRun) -> bool:

--- a/pdf_craft_tool/cli.py
+++ b/pdf_craft_tool/cli.py
@@ -8,17 +8,17 @@ from typing import Any, cast
 
 from pdf_craft import (
     ChapterPackageTransformer,
+    ChapterXMLTransformer,
+    DocumentPackage,
     ExtractionOptions,
+    OCRMode,
+    OCRTokensMetering,
     PDFCraft,
     PDFOptions,
     SubmitKind,
     TranslationStep,
     XMLTranslator,
 )
-from pdf_craft.ocr_config import OCRMode
-from pdf_craft.document import DocumentPackage
-from pdf_craft.metering import OCRTokensMetering
-from pdf_craft.transformer.chapter_xml import ChapterXMLTransformer
 
 from .runtime import (
     create_ocr_config_from_env,

--- a/pdf_craft_tool/cli.py
+++ b/pdf_craft_tool/cli.py
@@ -103,7 +103,14 @@ def _parser() -> argparse.ArgumentParser:
 
     run = smoke_commands.add_parser("run", help="run one matrix route from command-line arguments")
     run.add_argument("--asset", required=True, help="path relative to --assets-root")
-    run.add_argument("--route", choices=("package", "markdown", "epub", "pdf-patch", "epub-check", "epub-translate"), required=True)
+    run.add_argument(
+        "--route",
+        choices=(
+            "package", "package-markdown", "package-epub", "markdown", "epub",
+            "pdf-patch", "epub-check", "epub-translate",
+        ),
+        required=True,
+    )
     run.add_argument("--assets-root", type=Path, default=Path("tests/assets"))
     run.add_argument("--output-root", type=Path, default=DEFAULT_OUTPUT_ROOT / "smoke")
     run.add_argument("--dry-run", action="store_true")
@@ -173,6 +180,8 @@ def _add_smoke_options(parser: argparse.ArgumentParser) -> None:
     parser.add_argument("--max-retries", type=int, default=3)
     parser.add_argument("--max-group-tokens", type=int, default=2600)
     parser.add_argument("--concurrency", type=int, default=1)
+    parser.add_argument("--translation-llm-profile", metavar="PROFILE")
+    parser.add_argument("--fill-llm-profile", metavar="PROFILE")
 
 
 def _extract_pdf(args: argparse.Namespace) -> None:
@@ -259,16 +268,20 @@ def _run_smoke(args: argparse.Namespace) -> None:
         translation["package_submit"] = args.submit.replace("-", "_").upper()
     if args.patch_prefix:
         translation["patch_prefix"] = args.patch_prefix
-    is_pdf_route = args.route in {"package", "markdown", "epub", "pdf-patch"}
-    if is_pdf_route or args.route == "epub-translate":
+    is_pdf_route = args.route in {
+        "package", "package-markdown", "package-epub", "markdown", "epub", "pdf-patch",
+    }
+    if (is_pdf_route or args.route == "epub-translate") and not args.dry_run:
         load_project_env(_project_root())
     ocr_mode = cast(OCRMode | None, args.ocr_mode)
     if is_pdf_route:
         ocr_mode = ocr_mode or ocr_mode_from_env()
-    if args.route == "epub-translate":
+    if args.route == "epub-translate" or args.translation_llm_profile or args.fill_llm_profile:
+        translation_profile = args.translation_llm_profile or "translation"
+        fill_profile = args.fill_llm_profile or translation_profile
         translation.update({
-            "llm": llm_values_from_env("translation", cache_path=args.output_root / "translation-cache",
-                log_dir_path=args.output_root / "translation-logs"),
+            "translation_llm_profile": translation_profile,
+            "fill_llm_profile": fill_profile,
             "target_language": args.target_language,
             "user_prompt": args.prompt,
             "max_retries": args.max_retries,
@@ -276,6 +289,8 @@ def _run_smoke(args: argparse.Namespace) -> None:
             "concurrency": args.concurrency,
             "submit": args.submit.replace("-", "_").upper(),
         })
+        if not args.dry_run:
+            translation = _resolve_translation_profiles(translation, args.output_root) or {}
     run = SmokeRun(
         asset=args.asset, route=args.route, backend=ocr_mode,
         page_indexes=_page_indexes(args.pages), ocr_size=args.ocr_size, dpi=args.dpi,
@@ -283,7 +298,7 @@ def _run_smoke(args: argparse.Namespace) -> None:
         max_ocr_tokens=args.max_ocr_tokens, max_ocr_output_tokens=args.max_ocr_output_tokens,
         includes_cover=args.cover, includes_footnotes=args.footnotes,
         generate_plot=args.plot, toc_assumed=args.toc_assumed,
-        ocr=ocr_values_from_env(ocr_mode) if ocr_mode else None,
+        ocr=ocr_values_from_env(ocr_mode) if ocr_mode and not args.dry_run else None,
         translation=translation or None,
     )
     print(run_smoke(run, assets_root=args.assets_root, output_root=args.output_root, dry_run=args.dry_run))

--- a/pdf_craft_tool/smoke/ocr.py
+++ b/pdf_craft_tool/smoke/ocr.py
@@ -1,6 +1,6 @@
 from typing import Any
 
-from pdf_craft.ocr_config import (
+from pdf_craft import (
     DeepSeekOCR2LocalConfig,
     DeepSeekOCR2VendorConfig,
     DeepSeekOCRLocalConfig,

--- a/pdf_craft_tool/smoke/runner.py
+++ b/pdf_craft_tool/smoke/runner.py
@@ -11,17 +11,21 @@ from pathlib import Path
 from time import perf_counter
 from typing import Any, Literal, cast
 
-from pdf_craft.craft import ExtractionOptions, PDFCraft, PDFOptions, TranslationStep
-from pdf_craft.ocr_config import OCRConfig, OCRMode
-from pdf_craft.transformer import (
+from pdf_craft import (
     ChapterPackageTransformer,
     ChapterXMLTransformer,
+    ExtractionOptions,
+    LLM,
+    OCRConfig,
+    OCRMode,
+    OCREvent,
+    PDFCraft,
+    PDFOptions,
     SubmitKind,
+    TranslationStep,
     XMLTranslator,
 )
 from pdf_craft.extractor.chapter.chapter import BlockLayout, BlockMember, Chapter, HTMLTag, ParagraphLayout
-from pdf_craft.llm import LLM
-from pdf_craft.pdf import OCREvent
 
 from .assets import SmokeAsset, discover_assets
 from .checks import check_epub, check_markdown, check_package, check_pdf_patch_geometry

--- a/pdf_craft_tool/smoke/runner.py
+++ b/pdf_craft_tool/smoke/runner.py
@@ -32,8 +32,11 @@ from .checks import check_epub, check_markdown, check_package, check_pdf_patch_g
 from .ocr import create_ocr_config
 from ..paths import DEFAULT_OUTPUT_ROOT, create_run_directory
 
-SmokeRoute = Literal["package", "markdown", "epub", "pdf-patch", "epub-check", "epub-translate"]
-PDF_ROUTES = {"package", "markdown", "epub", "pdf-patch"}
+SmokeRoute = Literal[
+    "package", "package-markdown", "package-epub", "markdown", "epub",
+    "pdf-patch", "epub-check", "epub-translate",
+]
+PDF_ROUTES = {"package", "package-markdown", "package-epub", "markdown", "epub", "pdf-patch"}
 EPUB_ROUTES = {"epub-check", "epub-translate"}
 
 
@@ -252,7 +255,7 @@ def _run_pdf(
             errors = check_package(package, require_geometry=False)
             status, errors = _result_from_errors(errors)
         return status, errors, details
-    if run.route == "markdown":
+    if run.route in {"package-markdown", "markdown"}:
         markdown = output_path / "book.md"
         markdown_assets = Path("assets")
         steps = _package_steps(run, run_path)
@@ -269,7 +272,7 @@ def _run_pdf(
         details["outputs"] = [str(markdown)]
         status, errors = _result_from_errors(errors)
         return status, errors, details
-    if run.route == "epub":
+    if run.route in {"package-epub", "epub"}:
         epub = output_path / "book.epub"
         steps = _package_steps(run, run_path)
         with report.stage("render"):

--- a/tests/smoke/vendor_real.json
+++ b/tests/smoke/vendor_real.json
@@ -1,0 +1,39 @@
+{
+  "defaults": {
+    "page_indexes": [1],
+    "ocr_size": "tiny"
+  },
+  "runs": [
+    {
+      "asset": "citation.pdf",
+      "route": "markdown",
+      "backend": "deepseek-ocr-vendor"
+    },
+    {
+      "asset": "citation.pdf",
+      "route": "markdown",
+      "backend": "deepseek-ocr-vendor",
+      "translation": {
+        "translation_llm_profile": "translation",
+        "fill_llm_profile": "fill",
+        "target_language": "zh",
+        "submit": "REPLACE",
+        "max_retries": 3,
+        "max_group_tokens": 2600
+      }
+    },
+    {
+      "asset": "epub/Cambridge.epub",
+      "route": "epub-translate",
+      "translation": {
+        "translation_llm_profile": "translation",
+        "fill_llm_profile": "fill",
+        "target_language": "zh",
+        "submit": "REPLACE",
+        "max_retries": 3,
+        "max_group_tokens": 2600,
+        "concurrency": 1
+      }
+    }
+  ]
+}

--- a/tests/test_smoke.py
+++ b/tests/test_smoke.py
@@ -59,6 +59,16 @@ class TestSmokeMatrix(unittest.TestCase):
         self.assertEqual(runs[0].page_indexes, (1,))
         self.assertEqual(runs[1].backend, None)
 
+    def test_expands_package_renderer_routes_for_pdf_assets(self):
+        runs = expand_matrix(
+            {"runs": [
+                {"asset": "citation.pdf", "route": "package-markdown"},
+                {"asset": "citation.pdf", "route": "package-epub"},
+            ]},
+            Path("tests/assets"),
+        )
+        self.assertEqual([run.route for run in runs], ["package-markdown", "package-epub"])
+
     def test_dry_run_writes_isolated_plan_and_redacts_credentials(self):
         with tempfile.TemporaryDirectory() as directory:
             root = Path(directory)

--- a/tests/test_tool.py
+++ b/tests/test_tool.py
@@ -6,12 +6,26 @@ from pathlib import Path
 import tempfile
 from unittest.mock import patch
 
-from pdf_craft_tool.cli import _page_indexes, _parser, _run_matrix, _work_dir
+from pdf_craft_tool.cli import _page_indexes, _parser, _run_matrix, _smoke_exit_code, _work_dir
 from pdf_craft_tool.paths import create_run_directory
 from pdf_craft_tool.runtime import create_llm_from_env, ocr_mode_from_env
 
 
 class TestPDFCraftTool(unittest.TestCase):
+    def test_smoke_exit_code_rejects_failed_and_skipped_reports(self):
+        with tempfile.TemporaryDirectory() as directory:
+            root = Path(directory)
+            for status, expected in (("passed", 0), ("planned", 0), ("failed", 1), ("skipped", 1)):
+                with self.subTest(status=status):
+                    path = root / status
+                    path.mkdir()
+                    (path / "checks.json").write_text(json.dumps({"status": status}), encoding="utf-8")
+                    self.assertEqual(_smoke_exit_code(path), expected)
+
+    def test_smoke_exit_code_rejects_missing_report(self):
+        with tempfile.TemporaryDirectory() as directory:
+            self.assertEqual(_smoke_exit_code(Path(directory)), 1)
+
     def test_smoke_parser_exposes_package_render_and_translation_profiles(self):
         args = _parser().parse_args([
             "smoke", "run", "--asset", "citation.pdf", "--route", "package-markdown",
@@ -75,7 +89,7 @@ class TestPDFCraftTool(unittest.TestCase):
             with patch("pdf_craft_tool.cli.load_project_env"), \
                     patch("pdf_craft_tool.cli.llm_values_from_env",
                           side_effect=SystemExit("missing LLM profile")):
-                _run_matrix(Namespace(
+                exit_code = _run_matrix(Namespace(
                     config=config,
                     assets_root=Path("tests/assets"),
                     output_root=root / "output",
@@ -86,3 +100,4 @@ class TestPDFCraftTool(unittest.TestCase):
             checks = json.loads((run_path / "checks.json").read_text(encoding="utf-8"))
             self.assertEqual(checks["status"], "skipped")
             self.assertEqual(checks["errors"], ["missing LLM profile"])
+            self.assertEqual(exit_code, 1)

--- a/tests/test_tool.py
+++ b/tests/test_tool.py
@@ -6,12 +6,31 @@ from pathlib import Path
 import tempfile
 from unittest.mock import patch
 
-from pdf_craft_tool.cli import _page_indexes, _run_matrix, _work_dir
+from pdf_craft_tool.cli import _page_indexes, _parser, _run_matrix, _work_dir
 from pdf_craft_tool.paths import create_run_directory
 from pdf_craft_tool.runtime import create_llm_from_env, ocr_mode_from_env
 
 
 class TestPDFCraftTool(unittest.TestCase):
+    def test_smoke_parser_exposes_package_render_and_translation_profiles(self):
+        args = _parser().parse_args([
+            "smoke", "run", "--asset", "citation.pdf", "--route", "package-markdown",
+            "--translation-llm-profile", "translation", "--fill-llm-profile", "fill",
+        ])
+        self.assertEqual(args.route, "package-markdown")
+        self.assertEqual(args.translation_llm_profile, "translation")
+        self.assertEqual(args.fill_llm_profile, "fill")
+
+    def test_smoke_dry_run_does_not_require_project_env(self):
+        args = _parser().parse_args([
+            "smoke", "run", "--asset", "citation.pdf", "--route", "markdown",
+            "--dry-run",
+        ])
+        with patch("pdf_craft_tool.cli.load_project_env") as load_env:
+            from pdf_craft_tool.cli import _run_smoke
+            _run_smoke(args)
+        load_env.assert_not_called()
+
     def test_run_directories_use_a_date_and_shared_daily_sequence(self):
         with tempfile.TemporaryDirectory() as directory:
             root = Path(directory)


### PR DESCRIPTION
## Summary
- expand smoke routes and CLI profile handling
- add vendor/LLM smoke matrix and report exit-code contract
- validate real vendor OCR/LLM paths in review

Issue: vge://issue/219

## Verification
- poetry run pytest -q (301 passed)
- poetry run pyright pdf_craft tests
- poetry run pylint pdf_craft tests
- real vendor OCR/LLM smoke matrix passed