### PR TITLE
统一六种 OCR 的 .env 配置与 CLI/smoke backend 选择

### DIFF
--- a/.env.template
+++ b/.env.template
@@ -5,11 +5,21 @@
 # deepseek-ocr-vendor, deepseek-ocr2-vendor, unlimited-ocr-vendor.
 PDF_CRAFT_OCR_MODE=deepseek-ocr-local
 
-# Local OCR backends. Used only on a CUDA-capable machine.
-PDF_CRAFT_DEEPSEEK_MODELS_CACHE_PATH=./models-cache
-PDF_CRAFT_DEEPSEEK_LOCAL_ONLY=true
-PDF_CRAFT_UNLIMITED_MODELS_CACHE_PATH=./models-cache
-PDF_CRAFT_UNLIMITED_LOCAL_ONLY=true
+# DeepSeek OCR local. Used only on a CUDA-capable machine.
+PDF_CRAFT_DEEPSEEK_OCR_LOCAL_MODELS_CACHE_PATH=./models-cache
+PDF_CRAFT_DEEPSEEK_OCR_LOCAL_ONLY=true
+# Optional comma-separated CUDA device indexes, for example: 0,1
+PDF_CRAFT_DEEPSEEK_OCR_LOCAL_ENABLE_DEVICES_NUMBERS=
+
+# DeepSeek OCR 2 local. Keep this independent from DeepSeek OCR local.
+PDF_CRAFT_DEEPSEEK_OCR2_LOCAL_MODELS_CACHE_PATH=./models-cache
+PDF_CRAFT_DEEPSEEK_OCR2_LOCAL_ONLY=true
+PDF_CRAFT_DEEPSEEK_OCR2_LOCAL_ENABLE_DEVICES_NUMBERS=
+
+# Unlimited OCR local. Keep this independent from the DeepSeek local backends.
+PDF_CRAFT_UNLIMITED_OCR_LOCAL_MODELS_CACHE_PATH=./models-cache
+PDF_CRAFT_UNLIMITED_OCR_LOCAL_ONLY=true
+PDF_CRAFT_UNLIMITED_OCR_LOCAL_ENABLE_DEVICES_NUMBERS=
 
 # DeepSeek OCR vendor.
 PDF_CRAFT_DEEPSEEK_OCR_BASE_URL=

--- a/docs/DEVELOPMENT.md
+++ b/docs/DEVELOPMENT.md
@@ -75,7 +75,7 @@ poetry run python -c "import torch; print(f'PyTorch version: {torch.__version__}
 pdfinfo -v
 ```
 
-Vendor OCR does not require local CUDA. Copy `.env.template` to `.env`, set `PDF_CRAFT_OCR_MODE` to `deepseek-ocr-vendor`, `deepseek-ocr2-vendor`, or `unlimited-ocr-vendor`, and fill the matching `PDF_CRAFT_*` credentials. Local modes use the `PDF_CRAFT_DEEPSEEK_*` and `PDF_CRAFT_UNLIMITED_*` model-path settings. Library code does not automatically read `.env`; only the manual scripts load it.
+Vendor OCR does not require local CUDA. Copy `.env.template` to `.env` and fill every backend's configuration group once. `PDF_CRAFT_OCR_MODE` selects only the default backend; CLI and smoke can select any of the six modes per run without editing `.env`. The three local modes each have independent `*_MODELS_CACHE_PATH`, `*_LOCAL_ONLY`, and optional `*_ENABLE_DEVICES_NUMBERS` settings; vendor modes each have their own credentials and endpoint settings. Library code does not automatically read `.env`; only the manual scripts load it.
 
 ## Validation
 

--- a/docs/DEVELOPMENT_zh-CN.md
+++ b/docs/DEVELOPMENT_zh-CN.md
@@ -61,7 +61,7 @@ poetry run python -c "import torch; print(f'PyTorch version: {torch.__version__}
 pdfinfo -v
 ```
 
-供应商 OCR 不需要本地 CUDA。复制 `.env.template` 为 `.env`，把 `PDF_CRAFT_OCR_MODE` 设为 `deepseek-ocr-vendor`、`deepseek-ocr2-vendor` 或 `unlimited-ocr-vendor`，再填写对应的 `PDF_CRAFT_*` 凭据。本地模式使用 `PDF_CRAFT_DEEPSEEK_*` 和 `PDF_CRAFT_UNLIMITED_*` 中的模型路径配置。库代码不会自动读取 `.env`；只有手动脚本会加载它。
+供应商 OCR 不需要本地 CUDA。复制 `.env.template` 为 `.env` 后，一次性填写全部 backend 配置分组。`PDF_CRAFT_OCR_MODE` 只选择默认 backend；CLI 和 smoke 可以在每次运行时选择六种 mode 中的任意一种，无需改写 `.env`。三种本地 mode 分别使用独立的 `*_MODELS_CACHE_PATH`、`*_LOCAL_ONLY` 和可选的 `*_ENABLE_DEVICES_NUMBERS` 设置；供应商 mode 各自使用独立的凭据和 endpoint。库代码不会自动读取 `.env`；只有手动脚本会加载它。
 
 ## 验证
 

--- a/pdf_craft_tool/README.md
+++ b/pdf_craft_tool/README.md
@@ -10,9 +10,26 @@ Renderer、Pipeline 和 Transformer。
 poetry run python -m pdf_craft_tool --help
 ```
 
-先复制 `.env.template` 为 `.env`，根据需要填写 `PDF_CRAFT_*` OCR 配置。翻译
+先复制 `.env.template` 为 `.env`，一次性填写全部六种 `PDF_CRAFT_*` OCR 配置；切换
+backend 时不需要再修改 `.env`。翻译
 翻译或可选的 TOC 层级增强需要文本 chat-completion LLM profile；OCR-only endpoint
 不能代替它。默认 profile 使用本机 `oo llm config --json` 提供的 OOMOL 连接，凭据不写入 `.env`。
+
+## OCR backend 配置与选择
+
+`.env.template` 为以下六种 backend 分别保留配置分组：
+
+- `deepseek-ocr-local`
+- `deepseek-ocr2-local`
+- `unlimited-ocr-local`
+- `deepseek-ocr-vendor`
+- `deepseek-ocr2-vendor`
+- `unlimited-ocr-vendor`
+
+`PDF_CRAFT_OCR_MODE` 只是未传参数时的默认选择，不会启用、清空或覆盖其他 backend。
+所有 PDF CLI 命令和 `smoke run` 的 `--ocr-mode` 都可显式选择其中一个 backend；矩阵在每个
+run 的 `backend` 字段中选择。local backend 使用自己的模型缓存、offline 和可选 CUDA device
+配置；vendor backend 使用自己的认证和 endpoint 配置。
 
 ## 工作目录
 
@@ -49,6 +66,7 @@ PDF 提取参数可在以上三个 PDF 命令中组合使用：
 ```
 
 `--ocr-mode` 覆盖 `.env` 内的 `PDF_CRAFT_OCR_MODE`；不传时使用 `.env` 的默认值。
+它只决定本次运行使用哪个已配置 backend，不会改写 `.env`。
 
 ## 翻译
 
@@ -144,3 +162,13 @@ poetry run python -m pdf_craft_tool smoke matrix \
 该矩阵读取当前工作区 `.env`，会产生真实 OCR 和文本 LLM 请求；执行前应确认
 `PDF_CRAFT_OCR_MODE`、对应 vendor OCR 配置以及 `translation`/`fill` LLM profile
 均已配置。local OCR route 在无 CUDA 环境中会记录为 skipped，不应伪装为 passed。
+
+全部六种 OCR backend 的最小矩阵位于 `tests/smoke/all_ocr_backends.json`：
+
+```shell
+poetry run python -m pdf_craft_tool smoke matrix \
+  --config tests/smoke/all_ocr_backends.json
+```
+
+该矩阵会对每个 backend 分别报告 `passed`、`failed` 或 `skipped`。无 CUDA 的 local
+backend 应明确 `skipped`；不要把它当作 vendor backend 的失败或成功。

--- a/pdf_craft_tool/runtime.py
+++ b/pdf_craft_tool/runtime.py
@@ -50,18 +50,51 @@ def create_ocr_config_from_env(mode: OCRMode | None = None) -> OCRConfig:
     mode = mode or cast(OCRMode, _str("PDF_CRAFT_OCR_MODE", default="deepseek-ocr-local"))
     if mode == "deepseek-ocr-local":
         return DeepSeekOCRLocalConfig(
-            models_cache_path=_str("PDF_CRAFT_DEEPSEEK_MODELS_CACHE_PATH", default="models-cache"),
-            local_only=_bool("PDF_CRAFT_DEEPSEEK_LOCAL_ONLY", default=True),
+            models_cache_path=_backend_str(
+                "PDF_CRAFT_DEEPSEEK_OCR_LOCAL_MODELS_CACHE_PATH",
+                "PDF_CRAFT_DEEPSEEK_MODELS_CACHE_PATH",
+                default="models-cache",
+            ),
+            local_only=_backend_bool(
+                "PDF_CRAFT_DEEPSEEK_OCR_LOCAL_ONLY",
+                "PDF_CRAFT_DEEPSEEK_LOCAL_ONLY",
+                default=True,
+            ),
+            enable_devices_numbers=_optional_ints(
+                "PDF_CRAFT_DEEPSEEK_OCR_LOCAL_ENABLE_DEVICES_NUMBERS"
+            ),
         )
     if mode == "deepseek-ocr2-local":
         return DeepSeekOCR2LocalConfig(
-            models_cache_path=_str("PDF_CRAFT_DEEPSEEK_MODELS_CACHE_PATH", default="models-cache"),
-            local_only=_bool("PDF_CRAFT_DEEPSEEK_LOCAL_ONLY", default=True),
+            models_cache_path=_backend_str(
+                "PDF_CRAFT_DEEPSEEK_OCR2_LOCAL_MODELS_CACHE_PATH",
+                "PDF_CRAFT_DEEPSEEK_MODELS_CACHE_PATH",
+                default="models-cache",
+            ),
+            local_only=_backend_bool(
+                "PDF_CRAFT_DEEPSEEK_OCR2_LOCAL_ONLY",
+                "PDF_CRAFT_DEEPSEEK_LOCAL_ONLY",
+                default=True,
+            ),
+            enable_devices_numbers=_optional_ints(
+                "PDF_CRAFT_DEEPSEEK_OCR2_LOCAL_ENABLE_DEVICES_NUMBERS"
+            ),
         )
     if mode == "unlimited-ocr-local":
         return UnlimitedOCRLocalConfig(
-            models_cache_path=_str("PDF_CRAFT_UNLIMITED_MODELS_CACHE_PATH", default="models-cache"),
-            local_only=_bool("PDF_CRAFT_UNLIMITED_LOCAL_ONLY", default=True),
+            models_cache_path=_backend_str(
+                "PDF_CRAFT_UNLIMITED_OCR_LOCAL_MODELS_CACHE_PATH",
+                "PDF_CRAFT_UNLIMITED_MODELS_CACHE_PATH",
+                default="models-cache",
+            ),
+            local_only=_backend_bool(
+                "PDF_CRAFT_UNLIMITED_OCR_LOCAL_ONLY",
+                "PDF_CRAFT_UNLIMITED_LOCAL_ONLY",
+                default=True,
+            ),
+            enable_devices_numbers=_optional_ints(
+                "PDF_CRAFT_UNLIMITED_OCR_LOCAL_ENABLE_DEVICES_NUMBERS"
+            ),
         )
     if mode == "deepseek-ocr-vendor":
         return DeepSeekOCRVendorConfig(
@@ -161,6 +194,11 @@ def _str(name: str, default: str | None = None) -> str:
     return value or (default or "")
 
 
+def _backend_str(name: str, legacy_name: str, default: str) -> str:
+    """Read a backend-specific setting, retaining the pre-six-backend alias."""
+    return _str(name) or _str(legacy_name, default)
+
+
 def _required(name: str) -> str:
     value = _str(name)
     if not value:
@@ -177,6 +215,26 @@ def _bool(name: str, default: bool) -> bool:
     if value.lower() in {"0", "false", "no", "off"}:
         return False
     raise SystemExit(f"{name} must be a boolean")
+
+
+def _backend_bool(name: str, legacy_name: str, default: bool) -> bool:
+    """Read a backend-specific boolean, retaining the pre-six-backend alias."""
+    if _str(name):
+        return _bool(name, default)
+    return _bool(legacy_name, default)
+
+
+def _optional_ints(name: str) -> tuple[int, ...] | None:
+    value = _str(name)
+    if not value:
+        return None
+    try:
+        values = tuple(int(item.strip()) for item in value.split(","))
+    except ValueError as error:
+        raise SystemExit(f"{name} must be comma-separated integers") from error
+    if not values:
+        return None
+    return values
 
 
 def _int(name: str, default: int) -> int:

--- a/tests/smoke/all_ocr_backends.json
+++ b/tests/smoke/all_ocr_backends.json
@@ -1,0 +1,16 @@
+{
+  "defaults": {
+    "asset": "citation.pdf",
+    "route": "package",
+    "page_indexes": [1],
+    "ocr_size": "tiny"
+  },
+  "runs": [
+    {"backend": "deepseek-ocr-local"},
+    {"backend": "deepseek-ocr2-local"},
+    {"backend": "unlimited-ocr-local"},
+    {"backend": "deepseek-ocr-vendor"},
+    {"backend": "deepseek-ocr2-vendor"},
+    {"backend": "unlimited-ocr-vendor"}
+  ]
+}

--- a/tests/test_tool.py
+++ b/tests/test_tool.py
@@ -8,7 +8,7 @@ from unittest.mock import patch
 
 from pdf_craft_tool.cli import _page_indexes, _parser, _run_matrix, _smoke_exit_code, _work_dir
 from pdf_craft_tool.paths import create_run_directory
-from pdf_craft_tool.runtime import create_llm_from_env, ocr_mode_from_env
+from pdf_craft_tool.runtime import create_llm_from_env, create_ocr_config_from_env, ocr_mode_from_env
 
 
 class TestPDFCraftTool(unittest.TestCase):
@@ -75,6 +75,82 @@ class TestPDFCraftTool(unittest.TestCase):
     def test_ocr_mode_uses_the_prefixed_runtime_variable(self):
         with patch.dict("os.environ", {"PDF_CRAFT_OCR_MODE": "unlimited-ocr-vendor"}, clear=True):
             self.assertEqual(ocr_mode_from_env(), "unlimited-ocr-vendor")
+
+    def test_each_local_backend_reads_its_own_environment_namespace(self):
+        cases = (
+            (
+                "deepseek-ocr-local",
+                "PDF_CRAFT_DEEPSEEK_OCR",
+                "DeepSeekOCRLocalConfig",
+            ),
+            (
+                "deepseek-ocr2-local",
+                "PDF_CRAFT_DEEPSEEK_OCR2",
+                "DeepSeekOCR2LocalConfig",
+            ),
+            (
+                "unlimited-ocr-local",
+                "PDF_CRAFT_UNLIMITED_OCR",
+                "UnlimitedOCRLocalConfig",
+            ),
+        )
+        for mode, prefix, expected_type in cases:
+            with self.subTest(mode=mode), patch.dict("os.environ", {
+                "PDF_CRAFT_OCR_MODE": mode,
+                f"{prefix}_LOCAL_MODELS_CACHE_PATH": f"/{mode}",
+                f"{prefix}_LOCAL_ONLY": "false",
+                f"{prefix}_LOCAL_ENABLE_DEVICES_NUMBERS": "1, 3",
+            }, clear=True):
+                config = create_ocr_config_from_env()
+                self.assertEqual(type(config).__name__, expected_type)
+                self.assertEqual(str(getattr(config, "models_cache_path")), f"/{mode}")
+                self.assertFalse(getattr(config, "local_only"))
+                self.assertEqual(getattr(config, "enable_devices_numbers"), (1, 3))
+
+    def test_local_backend_selection_keeps_legacy_shared_settings_as_fallback(self):
+        with patch.dict("os.environ", {
+            "PDF_CRAFT_OCR_MODE": "deepseek-ocr2-local",
+            "PDF_CRAFT_DEEPSEEK_MODELS_CACHE_PATH": "/legacy-cache",
+            "PDF_CRAFT_DEEPSEEK_LOCAL_ONLY": "false",
+        }, clear=True):
+            config = create_ocr_config_from_env()
+        self.assertEqual(str(getattr(config, "models_cache_path")), "/legacy-cache")
+        self.assertFalse(getattr(config, "local_only"))
+
+    def test_each_vendor_backend_requires_only_its_own_environment_namespace(self):
+        cases = (
+            (
+                "deepseek-ocr-vendor",
+                {
+                    "PDF_CRAFT_DEEPSEEK_OCR_BASE_URL": "https://ocr.example/v1",
+                    "PDF_CRAFT_DEEPSEEK_OCR_API_KEY": "key",
+                    "PDF_CRAFT_DEEPSEEK_OCR_MODEL": "ocr",
+                },
+                "DeepSeekOCRVendorConfig",
+            ),
+            (
+                "deepseek-ocr2-vendor",
+                {
+                    "PDF_CRAFT_DEEPSEEK_OCR2_BASE_URL": "https://ocr2.example/v1",
+                    "PDF_CRAFT_DEEPSEEK_OCR2_API_KEY": "key",
+                    "PDF_CRAFT_DEEPSEEK_OCR2_MODEL": "ocr2",
+                },
+                "DeepSeekOCR2VendorConfig",
+            ),
+            (
+                "unlimited-ocr-vendor",
+                {
+                    "PDF_CRAFT_UNLIMITED_OCR_ACCESS_KEY": "ak",
+                    "PDF_CRAFT_UNLIMITED_OCR_SECRET_KEY": "sk",
+                },
+                "UnlimitedOCRVendorConfig",
+            ),
+        )
+        for mode, values, expected_type in cases:
+            with self.subTest(mode=mode), patch.dict("os.environ", {
+                "PDF_CRAFT_OCR_MODE": mode,
+            } | values, clear=True):
+                self.assertEqual(type(create_ocr_config_from_env()).__name__, expected_type)
 
     def test_matrix_records_missing_profile_as_skipped_run(self):
         with tempfile.TemporaryDirectory() as directory:


### PR DESCRIPTION
## Summary
- isolate six OCR backend configuration namespaces in runtime parsing
- add explicit CLI and smoke backend selection with six-backend matrix/dry-run support
- add sanitized `.env.template`, tests, and operator documentation

## Verification
- `poetry run pytest -q`
- `poetry run pyright pdf_craft tests`
- `poetry run pylint pdf_craft tests`
- six-backend smoke matrix dry-run
- real deepseek-ocr-vendor and deepseek-ocr2-vendor smoke runs

Local CUDA backends are explicitly deferred/skipped on non-CUDA devices per issue scope.
