### PR TITLE
Close 220 cache recovery and OCR2 local preset gaps

### DIFF
--- a/README.md
+++ b/README.md
@@ -212,7 +212,9 @@ The repository's manual scripts default `DEEPSEEK_LOCAL_ONLY` and
 allow a missing model to download.
 You can control model storage and loading behavior through the local OCR
 configs. Unlimited OCR local supports the `base` and `gundam` `ocr_size`
-presets.
+presets. DeepSeek OCR 2 local is validated with the `base` preset; `tiny` is
+rejected with a clear error because the upstream cached Hugging Face remote
+code fails before extraction for that preset.
 
 #### Pre-download Models
 
@@ -269,6 +271,10 @@ The `ocr_size` parameter accepts a `DeepSeekOCRSize` type:
 - `base` - Base model
 - `large` - Large model
 - `gundam` - Largest model, highest quality (default)
+
+Backend notes: Unlimited OCR local supports only `base` and `gundam`.
+DeepSeek OCR 2 local should use `base`; `tiny` is not treated as a reliable
+local preset.
 
 ### Table Rendering Methods
 

--- a/README_zh-CN.md
+++ b/README_zh-CN.md
@@ -207,7 +207,9 @@ transform_markdown(
 自动从 Hugging Face 下载。本仓库手动脚本中 `DEEPSEEK_LOCAL_ONLY` 和
 `UNLIMITED_LOCAL_ONLY` 默认均为 `true`；要下载缺失模型，请将相应变量设为
 `false`。你可以通过本地 OCR 配置控制模型的存储和加载行为。Unlimited OCR
-local 仅支持 `base` 和 `gundam` 这两个 `ocr_size` preset。
+local 仅支持 `base` 和 `gundam` 这两个 `ocr_size` preset。DeepSeek OCR 2
+local 的已验证本地路径使用 `base` preset；`tiny` 会被明确拒绝，因为上游
+缓存的 Hugging Face remote code 会在该 preset 下于提取前失败。
 
 #### 预下载模型
 
@@ -264,6 +266,9 @@ transform_markdown(
 - `base` - 基础模型
 - `large` - 大型模型
 - `gundam` - 最大模型，质量最高（默认）
+
+后端说明：Unlimited OCR local 仅支持 `base` 和 `gundam`。DeepSeek OCR 2
+local 应使用 `base`；`tiny` 不作为可靠的本地 preset。
 
 ### 表格渲染方式
 

--- a/pdf_craft/llm/runtime.py
+++ b/pdf_craft/llm/runtime.py
@@ -155,7 +155,7 @@ class LLMContext(AbstractContextManager["LLMContext"]):
                    "seed": self.cache_seed_content, "temperature": temperature,
                    "top_p": top_p, "max_tokens": max_tokens,
                    "protocol": self.runtime.protocol_version}
-        return hashlib.sha512(json.dumps(payload, sort_keys=True, ensure_ascii=False).encode()).hexdigest()
+        return hashlib.sha256(json.dumps(payload, sort_keys=True, ensure_ascii=False).encode()).hexdigest()
 
     def _log(self, category: str, attempt: int, *, key: str | None, error: Exception | None = None) -> None:
         self.runtime._logger.info(json.dumps({

--- a/pdf_craft/pdf/page_extractor.py
+++ b/pdf_craft/pdf/page_extractor.py
@@ -158,6 +158,7 @@ class PageExtractorNode:
         device_number: int | None,
         aborted: AbortedCheck,
     ) -> Page:
+        self._validate_ocr_size(ocr_size)
         from doc_page_extractor.extraction_context import AbortError, TokenLimitError
         from doc_page_extractor.plot import plot
         from doc_page_extractor.types import ExtractionContext
@@ -311,6 +312,13 @@ class PageExtractorNode:
         text = remove_surrogates(text)
         text = re.sub(r"\s+", " ", text)
         return text.strip()
+
+    def _validate_ocr_size(self, ocr_size: DeepSeekOCRSize) -> None:
+        if isinstance(self._ocr, DeepSeekOCR2LocalConfig) and ocr_size == "tiny":
+            raise ValueError(
+                "deepseek-ocr2-local is not reliable with ocr_size='tiny'; "
+                "use ocr_size='base' for the validated local OCR2 path."
+            )
 
     def _normalize_layout_det(
         self,

--- a/pdf_craft_tool/README.md
+++ b/pdf_craft_tool/README.md
@@ -31,13 +31,19 @@ backend 时不需要再修改 `.env`。翻译
 run 的 `backend` 字段中选择。local backend 使用自己的模型缓存、offline 和可选 CUDA device
 配置；vendor backend 使用自己的认证和 endpoint 配置。
 
+`deepseek-ocr2-local` 的本地实测路径使用 `--ocr-size base`；不要把 `tiny`
+当作该 backend 的可靠默认 preset。CLI 和库层都会在显式使用
+`deepseek-ocr2-local` + `tiny` 时给出清晰错误。
+
 ## 工作目录
 
 `pdf extract`、`pdf convert` 和 `pdf translate` 每次都会创建独立的工作目录，
 默认位置是 Git 忽略的 `pdf-craft-output/manual/`。目录以来源、操作、日期和当日
 序号命名，例如 `citation-convert-20260822-001/`；同一次调用绝不会覆盖已有目录。
 `package render` 和 `epub translate` 也使用此规则。通过 `--work-dir` 指定位置时，
-目标必须不存在。工作目录保存中间 `package/`、翻译缓存和日志，方便人工检查或后续单独渲染。
+目录不存在则创建，已存在则复用。PDF 命令会在工作目录内记录来源 PDF 和 OCR
+设置，防止不同输入或不同 OCR backend 错误复用已有 OCR 缓存。工作目录保存中间
+`package/`、翻译缓存和日志，方便人工检查、恢复或后续单独渲染。
 
 所有 `--pages` 参数使用从 1 开始的 PDF 页码，例如 `--pages 1,2,3`。
 

--- a/pdf_craft_tool/cli.py
+++ b/pdf_craft_tool/cli.py
@@ -140,7 +140,8 @@ def _add_work_dir(parser: argparse.ArgumentParser, help_text: str) -> None:
 
 def _add_extraction_options(parser: argparse.ArgumentParser) -> None:
     parser.add_argument("--pages", help="comma-separated 1-based PDF page indexes")
-    parser.add_argument("--ocr-size", choices=("tiny", "small", "base", "large", "gundam"), default="gundam")
+    parser.add_argument("--ocr-size", choices=("tiny", "small", "base", "large", "gundam"))
+    parser.set_defaults(default_ocr_size="gundam")
     parser.add_argument("--dpi", type=int)
     parser.add_argument("--max-page-image-file-size", type=int)
     parser.add_argument("--max-ocr-tokens", type=int)
@@ -164,7 +165,8 @@ def _add_translation_options(parser: argparse.ArgumentParser) -> None:
 
 def _add_smoke_options(parser: argparse.ArgumentParser) -> None:
     parser.add_argument("--pages", help="comma-separated 1-based PDF page indexes")
-    parser.add_argument("--ocr-size", choices=("tiny", "small", "base", "large", "gundam"), default="tiny")
+    parser.add_argument("--ocr-size", choices=("tiny", "small", "base", "large", "gundam"))
+    parser.set_defaults(default_ocr_size="tiny")
     parser.add_argument("--dpi", type=int)
     parser.add_argument("--max-page-image-file-size", type=int)
     parser.add_argument("--max-ocr-tokens", type=int)
@@ -277,6 +279,8 @@ def _run_smoke(args: argparse.Namespace) -> int:
     ocr_mode = cast(OCRMode | None, args.ocr_mode)
     if is_pdf_route:
         ocr_mode = ocr_mode or ocr_mode_from_env()
+    ocr_size = _resolve_ocr_size(args.ocr_size, ocr_mode, args.default_ocr_size)
+    _validate_ocr_size(cast(OCRMode | None, ocr_mode), ocr_size)
     if args.route == "epub-translate" or args.translation_llm_profile or args.fill_llm_profile:
         translation_profile = args.translation_llm_profile or "translation"
         fill_profile = args.fill_llm_profile or translation_profile
@@ -294,7 +298,7 @@ def _run_smoke(args: argparse.Namespace) -> int:
             translation = _resolve_translation_profiles(translation, args.output_root) or {}
     run = SmokeRun(
         asset=args.asset, route=args.route, backend=ocr_mode,
-        page_indexes=_page_indexes(args.pages), ocr_size=args.ocr_size, dpi=args.dpi,
+        page_indexes=_page_indexes(args.pages), ocr_size=ocr_size, dpi=args.dpi,
         max_page_image_file_size=args.max_page_image_file_size,
         max_ocr_tokens=args.max_ocr_tokens, max_ocr_output_tokens=args.max_ocr_output_tokens,
         includes_cover=args.cover, includes_footnotes=args.footnotes,
@@ -351,6 +355,7 @@ def _matrix_run_needs_env(run: SmokeRun) -> bool:
 
 
 def _resolve_matrix_runtime(run: SmokeRun, output_root: Path) -> SmokeRun:
+    _validate_ocr_size(run.backend, run.ocr_size)
     ocr = run.ocr
     if run.backend and ocr is None:
         ocr = ocr_values_from_env(run.backend)
@@ -382,10 +387,14 @@ def _resolve_translation_profiles(translation: dict[str, Any] | None, output_roo
 
 def _extract(args: argparse.Namespace, package_path: Path) -> _ExtractionResult:
     load_project_env(_project_root())
-    craft = PDFCraft(pdf=PDFOptions(ocr=create_ocr_config_from_env(cast(OCRMode | None, args.ocr_mode))))
+    ocr_mode = cast(OCRMode | None, args.ocr_mode) or ocr_mode_from_env()
+    ocr_size = _resolve_ocr_size(args.ocr_size, ocr_mode, args.default_ocr_size)
+    _validate_ocr_size(ocr_mode, ocr_size)
+    _record_pdf_cache_owner(package_path.parent, args, ocr_mode, ocr_size)
+    craft = PDFCraft(pdf=PDFOptions(ocr=create_ocr_config_from_env(ocr_mode)))
     package, metering = craft.extract_pdf_with_metering(
         args.source, package_path, ExtractionOptions(
-            page_indexes=_page_indexes(args.pages), ocr_size=args.ocr_size, dpi=args.dpi,
+            page_indexes=_page_indexes(args.pages), ocr_size=ocr_size, dpi=args.dpi,
             max_page_image_file_size=args.max_page_image_file_size,
             max_ocr_tokens=args.max_ocr_tokens, max_ocr_output_tokens=args.max_ocr_output_tokens,
             includes_cover=args.cover, includes_footnotes=args.footnotes,
@@ -422,9 +431,71 @@ def _render(craft: PDFCraft, package: DocumentPackage, format_name: str, output:
 def _work_dir(source: Path, requested: Path | None, operation: str) -> Path:
     if requested is not None:
         path = requested
-        path.mkdir(parents=True, exist_ok=False)
+        if path.exists() and not path.is_dir():
+            raise SystemExit(f"Work directory is not a directory: {path}")
+        path.mkdir(parents=True, exist_ok=True)
         return path
     return create_run_directory(DEFAULT_OUTPUT_ROOT / "manual", f"{source.stem}-{operation}")
+
+
+def _record_pdf_cache_owner(
+    work_dir: Path,
+    args: argparse.Namespace,
+    ocr_mode: OCRMode,
+    ocr_size: str,
+) -> None:
+    """Guard manual PDF work-dir reuse so OCR caches stay tied to one source/backend."""
+    path = work_dir / ".pdf-craft-tool-run.json"
+    source = args.source.resolve()
+    stat = source.stat()
+    current = {
+        "schema": 1,
+        "source": str(source),
+        "source_size": stat.st_size,
+        "source_mtime_ns": stat.st_mtime_ns,
+        "ocr_mode": ocr_mode,
+        "ocr_size": ocr_size,
+        "dpi": args.dpi,
+        "max_page_image_file_size": args.max_page_image_file_size,
+        "includes_footnotes": args.footnotes,
+        "max_ocr_tokens": args.max_ocr_tokens,
+        "max_ocr_output_tokens": args.max_ocr_output_tokens,
+    }
+    if path.exists():
+        previous = json.loads(path.read_text(encoding="utf-8"))
+        mismatched = [
+            key
+            for key, value in current.items()
+            if key != "schema" and previous.get(key) != value
+        ]
+        if mismatched:
+            raise SystemExit(
+                "Work directory already contains OCR cache for different PDF/OCR "
+                f"settings ({', '.join(mismatched)}): {work_dir}"
+            )
+        return
+    if (work_dir / "package" / "ocr").exists():
+        raise SystemExit(
+            "Work directory contains legacy OCR cache without ownership metadata; "
+            f"use a fresh directory or remove the stale cache: {work_dir}"
+        )
+    path.write_text(json.dumps(current, ensure_ascii=False, indent=2, sort_keys=True), encoding="utf-8")
+
+
+def _resolve_ocr_size(value: str | None, ocr_mode: OCRMode | None, default: str) -> str:
+    if value:
+        return value
+    if ocr_mode == "deepseek-ocr2-local":
+        return "base"
+    return default
+
+
+def _validate_ocr_size(ocr_mode: OCRMode | None, ocr_size: str) -> None:
+    if ocr_mode == "deepseek-ocr2-local" and ocr_size == "tiny":
+        raise SystemExit(
+            "deepseek-ocr2-local is not reliable with --ocr-size tiny; "
+            "use --ocr-size base for the validated local OCR2 path."
+        )
 
 
 def _page_indexes(value: str | None) -> tuple[int, ...] | None:

--- a/tests/smoke/all_ocr_backends.json
+++ b/tests/smoke/all_ocr_backends.json
@@ -7,8 +7,8 @@
   },
   "runs": [
     {"backend": "deepseek-ocr-local"},
-    {"backend": "deepseek-ocr2-local"},
-    {"backend": "unlimited-ocr-local"},
+    {"backend": "deepseek-ocr2-local", "ocr_size": "base"},
+    {"backend": "unlimited-ocr-local", "ocr_size": "base"},
     {"backend": "deepseek-ocr-vendor"},
     {"backend": "deepseek-ocr2-vendor"},
     {"backend": "unlimited-ocr-vendor"}

--- a/tests/test_llm_runtime.py
+++ b/tests/test_llm_runtime.py
@@ -32,6 +32,18 @@ class TestLLMRuntime(unittest.TestCase):
             self.assertEqual(calls, 1)
             self.assertTrue(list((root / "logs").glob("*.log")))
 
+    def test_cache_key_is_short_enough_for_deep_windows_work_dirs(self):
+        with tempfile.TemporaryDirectory() as directory:
+            root = Path(directory)
+            deep = root / ("nested-" + "x" * 40) / ("work-" + "y" * 40)
+            runtime = runtime_for(_config(deep))
+            runtime._invoke = lambda *_args: "ok"  # type: ignore[method-assign]
+
+            self.assertEqual(runtime.request("hello", cache_seed_content="seed"), "ok")
+            cached = list((deep / "cache").glob("*.txt"))
+            self.assertEqual(len(cached), 1)
+            self.assertLessEqual(len(cached[0].stem), 64)
+
     def test_empty_response_is_typed_after_retries(self):
         with tempfile.TemporaryDirectory() as directory:
             runtime = runtime_for(_config(Path(directory)))

--- a/tests/test_ocr_config.py
+++ b/tests/test_ocr_config.py
@@ -4,6 +4,7 @@ from pathlib import Path
 from unittest.mock import Mock, patch
 
 import pdf_craft
+from PIL import Image
 from pdf_craft import (
     DeepSeekOCR2LocalConfig,
     DeepSeekOCR2VendorConfig,
@@ -144,6 +145,23 @@ class TestOCRConfig(unittest.TestCase):
             enable_devices_numbers=(0, 1),
         )
         extractor.load_ocr_model.assert_called_once_with()
+
+    def test_local_deepseek_ocr2_rejects_tiny_before_upstream_model_code(self):
+        node = PageExtractorNode(DeepSeekOCR2LocalConfig(models_cache_path="models"))
+        with self.assertRaisesRegex(ValueError, "deepseek-ocr2-local.*tiny.*base"):
+            node.image2page(
+                image=Image.new("RGB", (10, 10)),
+                page_index=1,
+                asset_hub=Mock(),
+                ocr_size="tiny",
+                includes_footnotes=False,
+                includes_raw_image=False,
+                plot_path=None,
+                max_tokens=None,
+                max_output_tokens=None,
+                device_number=None,
+                aborted=lambda: False,
+            )
 
     def test_vendor_deepseek_ocr_uses_doc_page_extractor_factory(self):
         extractor = Mock()

--- a/tests/test_tool.py
+++ b/tests/test_tool.py
@@ -6,7 +6,16 @@ from pathlib import Path
 import tempfile
 from unittest.mock import patch
 
-from pdf_craft_tool.cli import _page_indexes, _parser, _run_matrix, _smoke_exit_code, _work_dir
+from pdf_craft_tool.cli import (
+    _page_indexes,
+    _parser,
+    _record_pdf_cache_owner,
+    _resolve_ocr_size,
+    _run_matrix,
+    _smoke_exit_code,
+    _validate_ocr_size,
+    _work_dir,
+)
 from pdf_craft_tool.paths import create_run_directory
 from pdf_craft_tool.runtime import create_llm_from_env, create_ocr_config_from_env, ocr_mode_from_env
 
@@ -58,7 +67,13 @@ class TestPDFCraftTool(unittest.TestCase):
         with tempfile.TemporaryDirectory() as directory:
             path = Path(directory) / "chosen-output"
             self.assertEqual(_work_dir(Path("citation.pdf"), path, "convert"), path)
-            with self.assertRaises(FileExistsError):
+            self.assertEqual(_work_dir(Path("citation.pdf"), path, "convert"), path)
+
+    def test_explicit_work_directory_rejects_files(self):
+        with tempfile.TemporaryDirectory() as directory:
+            path = Path(directory) / "chosen-output"
+            path.write_text("not a directory", encoding="utf-8")
+            with self.assertRaisesRegex(SystemExit, "not a directory"):
                 _work_dir(Path("citation.pdf"), path, "convert")
 
     def test_page_indexes_are_explicitly_one_based(self):
@@ -103,7 +118,7 @@ class TestPDFCraftTool(unittest.TestCase):
             }, clear=True):
                 config = create_ocr_config_from_env()
                 self.assertEqual(type(config).__name__, expected_type)
-                self.assertEqual(str(getattr(config, "models_cache_path")), f"/{mode}")
+                self.assertEqual(getattr(config, "models_cache_path"), Path(f"/{mode}").resolve())
                 self.assertFalse(getattr(config, "local_only"))
                 self.assertEqual(getattr(config, "enable_devices_numbers"), (1, 3))
 
@@ -114,8 +129,64 @@ class TestPDFCraftTool(unittest.TestCase):
             "PDF_CRAFT_DEEPSEEK_LOCAL_ONLY": "false",
         }, clear=True):
             config = create_ocr_config_from_env()
-        self.assertEqual(str(getattr(config, "models_cache_path")), "/legacy-cache")
+        self.assertEqual(getattr(config, "models_cache_path"), Path("/legacy-cache").resolve())
         self.assertFalse(getattr(config, "local_only"))
+
+    def test_deepseek_ocr2_local_defaults_to_base_when_ocr_size_is_omitted(self):
+        self.assertEqual(_resolve_ocr_size(None, "deepseek-ocr2-local", "tiny"), "base")
+        self.assertEqual(_resolve_ocr_size(None, "deepseek-ocr-local", "tiny"), "tiny")
+        self.assertEqual(_resolve_ocr_size("tiny", "deepseek-ocr2-local", "base"), "tiny")
+
+    def test_deepseek_ocr2_local_rejects_tiny_with_clear_error(self):
+        with self.assertRaisesRegex(SystemExit, "deepseek-ocr2-local.*tiny.*base"):
+            _validate_ocr_size("deepseek-ocr2-local", "tiny")
+        _validate_ocr_size("deepseek-ocr2-local", "base")
+
+    def test_pdf_work_directory_records_and_validates_cache_owner(self):
+        with tempfile.TemporaryDirectory() as directory:
+            root = Path(directory)
+            source = root / "source.pdf"
+            source.write_bytes(b"%PDF source")
+            other = root / "other.pdf"
+            other.write_bytes(b"%PDF other")
+            work_dir = root / "work"
+            work_dir.mkdir()
+            args = Namespace(
+                source=source,
+                dpi=None,
+                max_page_image_file_size=None,
+                footnotes=False,
+                max_ocr_tokens=None,
+                max_ocr_output_tokens=None,
+            )
+
+            _record_pdf_cache_owner(work_dir, args, "deepseek-ocr-local", "tiny")
+            _record_pdf_cache_owner(work_dir, args, "deepseek-ocr-local", "tiny")
+
+            changed_source = Namespace(**(args.__dict__ | {"source": other}))
+            with self.assertRaisesRegex(SystemExit, "different PDF/OCR settings.*source"):
+                _record_pdf_cache_owner(work_dir, changed_source, "deepseek-ocr-local", "tiny")
+            with self.assertRaisesRegex(SystemExit, "different PDF/OCR settings.*ocr_mode"):
+                _record_pdf_cache_owner(work_dir, args, "unlimited-ocr-local", "tiny")
+
+    def test_pdf_work_directory_rejects_legacy_ocr_cache_without_owner(self):
+        with tempfile.TemporaryDirectory() as directory:
+            root = Path(directory)
+            source = root / "source.pdf"
+            source.write_bytes(b"%PDF source")
+            work_dir = root / "work"
+            (work_dir / "package" / "ocr").mkdir(parents=True)
+            args = Namespace(
+                source=source,
+                dpi=None,
+                max_page_image_file_size=None,
+                footnotes=False,
+                max_ocr_tokens=None,
+                max_ocr_output_tokens=None,
+            )
+
+            with self.assertRaisesRegex(SystemExit, "legacy OCR cache"):
+                _record_pdf_cache_owner(work_dir, args, "deepseek-ocr-local", "tiny")
 
     def test_each_vendor_backend_requires_only_its_own_environment_namespace(self):
         cases = (


### PR DESCRIPTION
## Summary
- Allow explicit PDF CLI `--work-dir` reuse while recording source/OCR ownership metadata and rejecting unsafe cache reuse across different inputs or OCR settings.
- Treat DeepSeek OCR2 local `base` as the validated default when `--ocr-size` is omitted, reject explicit `tiny` early in CLI/library paths, and update docs plus smoke matrix presets.
- Shorten LLM cache filenames from sha512 to sha256 after real `pdf translate --format pdf` hit a Windows path-length failure in `translation-cache`.

## Tests
- `poetry run python -m pytest` => 311 passed, with WinGet Poppler bin prepended to PATH.
- `poetry run pyright pdf_craft tests` => 0 errors, 0 warnings, 0 informations.
- `poetry run pylint pdf_craft tests` => 10.00/10.
- `git diff --check` => clean.

## Real-run evidence
Prior CUDA/local OCR baseline, retained and not rerun: `C:\Users\i\codes\github.com\oomol-lab\pdf-craft\pdf-craft-output\local-ocr-validation-20260824`.

Current 220 cache/recovery evidence root: `C:\Users\i\codes\github.com\oomol-lab\pdf-craft\pdf-craft-output\220-cache-recovery-20260824`; summary: `validation-summary.json`.

### OCR cache and recovery
- `deepseek-ocr-local` first partial run pages 1,2: `page_1.xml` and `page_2.xml` complete, `page_3.xml` ignored, `ocr/done` absent.
- Same work-dir rerun pages 1,2: existing page XML skipped, OCR tokens 0/0.
- Isolated missing `page_2.xml` and reran: page 1 skipped, missing page 2 regenerated, page 3 ignored.
- Full run without `--pages`: page 1/page 2 skipped, page 3 completed, `ocr/done` created.
- Full rerun after `ocr/done`: no OCR events, OCR tokens 0/0.
- Same work-dir guards reject different source PDF and different OCR backend with exit 1.

### Package and translation cache
- Existing `DocumentPackage` rendered Markdown and EPUB via CLI without OCR events: `package-render-markdown\book.md`, `package-render-epub\book.epub`.
- `pdf translate --format pdf` passed through the real CLI path using a local OpenAI-compatible streaming test server: zh first run created cache, zh rerun hit translation cache, fr target produced a new cache key/output.
- Different input and different OCR backend were rejected for the reused translate work-dir.

### 219 legacy paths
- `smoke run --route pdf-patch` passed with manifest/checks/output under `smoke-pdf-patch\citation-pdf-patch-20260824-001`.
- `pdf translate --format pdf` passed and produced `pdf-translate-format-pdf\citation-zh.pdf`.
- `package render` CLI passed for Markdown and EPUB outputs.

### OCR2 preset closeout
- Explicit `deepseek-ocr2-local --ocr-size tiny` now fails fast with clear guidance to use `base`; no attempt to patch upstream remote code.
- Smoke path with `deepseek-ocr2-local` and omitted `--ocr-size` defaulted to `base` and passed real local GPU OCR; manifest/checks/log saved under `ocr2-smoke-default-base\citation-markdown-20260824-001`.

Generated logs, manifests, timelines, checks, OCR events, and outputs remain in ignored `pdf-craft-output/` and are not committed.