### PR TITLE
Add atomic DocumentPackage translation and PDF patching

### DIFF
--- a/README.md
+++ b/README.md
@@ -80,6 +80,26 @@ The `transform_markdown` and `transform_epub` functions remain available as
 compatibility convenience wrappers. New integrations should use `PDFCraft` so
 extraction, rendering, and translation workflows share one public facade.
 
+### Reuse a DocumentPackage
+
+PDF extraction produces a reusable `DocumentPackage` directory. It can be
+translated without running OCR again, then written back to the matching source
+PDF:
+
+```python
+from pdf_craft import PDFCraft, PDFOptions, SubmitKind
+
+craft = PDFCraft(pdf=PDFOptions())
+package = craft.extract_pdf("input.pdf", "package")
+translated = craft.translate_package(
+    package, "translated-package", translator, submit=SubmitKind.REPLACE
+)
+craft.patch_pdf_with_package("input.pdf", translated, "translated.pdf")
+```
+
+`patch_pdf_with_package` patches the existing PDF using the package's page
+geometry; it does not perform OCR, translation, or arbitrary PDF re-layout.
+
 ![20251218-162533](https://github.com/user-attachments/assets/7f6df04a-1fa7-48b3-aa5e-d2d056304ad6)
 
 ## Detailed Usage

--- a/README_zh-CN.md
+++ b/README_zh-CN.md
@@ -79,6 +79,25 @@ craft.convert_pdf_to_epub(
 `transform_markdown` 和 `transform_epub` 仍作为兼容性的便利包装保留。新集成建议使用
 `PDFCraft`，这样提取、渲染和翻译流程都通过同一个公共 facade。
 
+### 复用 DocumentPackage
+
+PDF 提取会产生一个可复用的 `DocumentPackage` 文件夹。它可以在不重新 OCR
+的情况下翻译，然后写回对应的原始 PDF：
+
+```python
+from pdf_craft import PDFCraft, PDFOptions, SubmitKind
+
+craft = PDFCraft(pdf=PDFOptions())
+package = craft.extract_pdf("input.pdf", "package")
+translated = craft.translate_package(
+    package, "translated-package", translator, submit=SubmitKind.REPLACE
+)
+craft.patch_pdf_with_package("input.pdf", translated, "translated.pdf")
+```
+
+`patch_pdf_with_package` 使用 package 中的页面几何信息修改已有 PDF；它不会重新
+执行 OCR、翻译，也不会脱离原始 PDF 重新排版生成 PDF。
+
 ![](docs/images/pdf2epub-cn.png)
 
 ## 详细使用

--- a/pdf_craft/craft.py
+++ b/pdf_craft/craft.py
@@ -5,11 +5,14 @@ from dataclasses import dataclass
 from inspect import signature
 from os import PathLike
 from pathlib import Path
+from tempfile import TemporaryDirectory
 from typing import Literal, cast
 
 from epub_generator import BookMeta, LaTeXRender, TableRender
 
 from .document import DocumentPackage
+from .extractor.chapter.chapter import Chapter, ParagraphLayout
+from .extractor.chapter.reader import create_chapters_reader
 from .error import IgnoreOCRErrorsChecker, IgnorePDFErrorsChecker
 from .extractor import PDFExtractor
 from .llm import LLM
@@ -18,6 +21,7 @@ from .ocr_config import OCRConfig
 from .pdf import DeepSeekOCRSize, OCREvent, PDFHandler
 from .pipeline.epub import translate_epub as run_epub_translation
 from .pipeline.pdf import PDFTranslationPipeline
+from .pipeline.pdf.pipeline import _to_patch_text
 from .renderer import EpubRenderer, MarkdownRenderer
 from .transformer import ChapterPackageTransformer, ChapterTransformer, PackageTransformer, SubmitKind
 
@@ -113,16 +117,19 @@ class PDFCraft:
                                   Path(assets_path) if assets_path is not None else None,
                                   aborted=aborted)
 
-    def transform_package(
+    def translate_package(
         self, package: DocumentPackage, output_path: PathLike | str,
-        steps: Sequence[TranslationStep | PackageTransformer],
+        translator: ChapterTransformer,
+        *, submit: SubmitKind = SubmitKind.REPLACE,
     ) -> DocumentPackage:
-        current = package
-        for step in steps:
-            transformer = self._as_package_transformer(step)
-            current = transformer.transform(current, Path(output_path))
-            output_path = Path(output_path).with_name(Path(output_path).name + ".next")
-        return current
+        """Translate one render-ready package into another package.
+
+        The public operation is intentionally singular and translation-focused;
+        arbitrary package transformation chains remain an internal composition
+        detail used by the compatibility workflows.
+        """
+        package_transformer = ChapterPackageTransformer(translator, mode=submit)
+        return package_transformer.transform(package, Path(output_path))
 
     def render_epub(
         self, package: DocumentPackage, output: PathLike | str, *,
@@ -145,10 +152,23 @@ class PDFCraft:
             mode = _step_mode(step, self._as_package_transformer(step))
             if mode == SubmitKind.APPEND_BLOCK:
                 raise ValueError("PDF output does not support APPEND_BLOCK")
-        package = self._apply_steps(package, steps)
+        with TemporaryDirectory(prefix="pdf-craft-translated-package-") as directory:
+            translated = self._translate_for_pdf(package, Path(directory), transformer, steps)
+            self.patch_pdf_with_package(source, translated, output)
+
+    def patch_pdf_with_package(
+        self,
+        source: PathLike | str,
+        package: DocumentPackage | PathLike | str,
+        output: PathLike | str,
+    ) -> None:
+        """Patch an existing PDF with text and geometry from a DocumentPackage."""
+        package = package if isinstance(package, DocumentPackage) else DocumentPackage.from_path(Path(package))
+        package.validate()
+        _validate_package_for_pdf(Path(source), package)
         PDFTranslationPipeline(
             pdf_handler=self._pdf.pdf_handler if self._pdf else None
-        ).translate(Path(source), Path(output), package, transformer)
+        ).patch(Path(source), Path(output), package)
 
     def translate_epub(self, source: PathLike | str, output: PathLike | str, *,
                        target_language: str, submit: SubmitKind,
@@ -194,6 +214,21 @@ class PDFCraft:
             transformer = self._as_package_transformer(step)
             output = package.chapters_path.parent / f"transformed-{index}"
             current = transformer.transform(current, output)
+        return current
+
+    def _translate_for_pdf(
+        self,
+        package: DocumentPackage,
+        output_root: Path,
+        transformer: ChapterTransformer | Callable[[str], str],
+        steps: Sequence[TranslationStep | PackageTransformer],
+    ) -> DocumentPackage:
+        current = package
+        if callable(transformer):
+            transformer = _TextChapterTransformer(transformer)
+        current = self.translate_package(current, output_root / "translated", transformer)
+        if steps:
+            current = self._apply_steps(current, steps)
         return current
 
     @staticmethod
@@ -247,3 +282,52 @@ def _step_mode(step: TranslationStep | PackageTransformer, transformer: PackageT
     if isinstance(step, TranslationStep):
         return step.mode if step.mode != SubmitKind.REPLACE else getattr(transformer, "mode", step.mode)
     return getattr(transformer, "mode", None)
+
+
+class _TextChapterTransformer:
+    """Adapt the legacy block-text callback to the package transformer shape."""
+
+    def __init__(self, callback: Callable[[str], str]) -> None:
+        self._callback = callback
+
+    def transform(self, chapter: Chapter) -> Chapter:
+        for layout in chapter.layouts:
+            if not isinstance(layout, ParagraphLayout):
+                continue
+            for block in layout.blocks:
+                text = _to_patch_text(block.content)
+                translated = self._callback(text)
+                if translated != text:
+                    block.content = [translated]
+        return chapter
+
+
+def _validate_package_for_pdf(source: Path, package: DocumentPackage) -> None:
+    """Fail before patching when package geometry cannot match the PDF."""
+    try:
+        import pypdf
+    except ImportError as error:
+        raise RuntimeError("PDF patching requires the optional 'pypdf' dependency") from error
+    page_sizes = package.page_pixel_sizes()
+    if not page_sizes:
+        raise ValueError("DocumentPackage is missing page geometry metadata required for PDF patching")
+    page_count = len(pypdf.PdfReader(str(source)).pages)
+    chapter_pages = {
+        block.page_index
+        for chapter in create_chapters_reader(package.chapters_path)()
+        for layout in chapter.layouts
+        if isinstance(layout, ParagraphLayout)
+        for block in layout.blocks
+    }
+    invalid = sorted(page for page in set(page_sizes) | chapter_pages if page > page_count)
+    if invalid:
+        raise ValueError(
+            "DocumentPackage page geometry exceeds source PDF page count: "
+            f"pages {invalid} of {page_count}"
+        )
+    missing = sorted(page for page in chapter_pages if page not in page_sizes)
+    if missing:
+        raise ValueError(
+            "DocumentPackage is missing page geometry for chapter pages: "
+            f"{missing}"
+        )

--- a/pdf_craft/pipeline/pdf/pipeline.py
+++ b/pdf_craft/pipeline/pdf/pipeline.py
@@ -44,6 +44,34 @@ class PDFTranslationPipeline:
                 document.close()
         self.patcher.patch(pdf_path, target_path, replacements)
 
+    def patch(
+        self,
+        pdf_path: Path,
+        target_path: Path,
+        package: DocumentPackage | Path,
+    ) -> None:
+        """Write the text already present in ``package`` back to ``pdf_path``.
+
+        This is deliberately separate from :meth:`translate`: the package is
+        already the source of the replacement text, so no OCR or LLM
+        transformer is involved.
+        """
+        package = package if isinstance(package, DocumentPackage) else DocumentPackage.from_path(package)
+        package.validate()
+        document = self.pdf_handler.open(pdf_path) if self.pdf_handler else None
+        replacements: list[PDFReplacement] = []
+        try:
+            pages = package.page_pixel_sizes()
+            reader = create_chapters_reader(package.chapters_path)
+            for chapter in reader():
+                self._collect_chapter(
+                    chapter, lambda text: text, document, pages, replacements, structured=True,
+                )
+        finally:
+            if document:
+                document.close()
+        self.patcher.patch(pdf_path, target_path, replacements)
+
     def _collect_chapter(self, chapter: Chapter, transformer, document, pages, replacements, structured: bool = False) -> None:
         for layout in chapter.layouts:
             if not isinstance(layout, ParagraphLayout) or layout.ref not in {"text", "sub_title"}:

--- a/pdf_craft_tool/README.md
+++ b/pdf_craft_tool/README.md
@@ -54,9 +54,19 @@ run 的 `backend` 字段中选择。local backend 使用自己的模型缓存、
 poetry run python -m pdf_craft_tool pdf extract tests/assets/citation.pdf \
   --ocr-mode deepseek-ocr-vendor --pages 1 --work-dir pdf-craft-output/citation-extract
 
+# DocumentPackage -> 翻译后的 DocumentPackage
+poetry run python -m pdf_craft_tool package translate \
+  pdf-craft-output/citation-extract/package zh \
+  --output-package pdf-craft-output/citation-zh-package
+
 # Package -> Markdown 或 EPUB；此命令不需要 OCR 配置
 poetry run python -m pdf_craft_tool package render pdf-craft-output/citation-extract/package \
   --format markdown --work-dir pdf-craft-output/citation-render
+
+# 原始 PDF + translated DocumentPackage -> patched PDF；此命令不需要 OCR/LLM
+poetry run python -m pdf_craft_tool package patch-pdf \
+  tests/assets/citation.pdf pdf-craft-output/citation-zh-package \
+  --output pdf-craft-output/citation-zh.pdf
 
 # PDF -> Markdown 或 EPUB
 poetry run python -m pdf_craft_tool pdf convert tests/assets/citation.pdf \
@@ -73,6 +83,10 @@ PDF 提取参数可在以上三个 PDF 命令中组合使用：
 
 `--ocr-mode` 覆盖 `.env` 内的 `PDF_CRAFT_OCR_MODE`；不传时使用 `.env` 的默认值。
 它只决定本次运行使用哪个已配置 backend，不会改写 `.env`。
+
+`package translate` 只读取已有 DocumentPackage，不会重新运行 OCR；
+`package patch-pdf` 只把已有 package 的文字按页面几何信息写回指定原始 PDF，
+不会调用 OCR 或 LLM。
 
 ## 翻译
 

--- a/pdf_craft_tool/cli.py
+++ b/pdf_craft_tool/cli.py
@@ -7,7 +7,6 @@ from pathlib import Path
 from typing import Any, cast
 
 from pdf_craft import (
-    ChapterPackageTransformer,
     ChapterXMLTransformer,
     DocumentPackage,
     ExtractionOptions,
@@ -16,7 +15,6 @@ from pdf_craft import (
     PDFCraft,
     PDFOptions,
     SubmitKind,
-    TranslationStep,
     XMLTranslator,
 )
 
@@ -79,6 +77,25 @@ def _parser() -> argparse.ArgumentParser:
 
     package = commands.add_parser("package", help="operate on an existing DocumentPackage")
     package_commands = package.add_subparsers(dest="package_command", required=True)
+    package_translate = package_commands.add_parser(
+        "translate", help="translate an existing DocumentPackage"
+    )
+    package_translate.add_argument("package", type=Path)
+    package_translate.add_argument("target_language")
+    package_translate.add_argument("--output-package", type=Path)
+    _add_work_dir(package_translate, "isolated run directory")
+    _add_translation_options(package_translate)
+    package_translate.set_defaults(handler=_translate_package)
+
+    package_patch = package_commands.add_parser(
+        "patch-pdf", help="patch an original PDF with an existing DocumentPackage"
+    )
+    package_patch.add_argument("source", type=Path)
+    package_patch.add_argument("package", type=Path)
+    package_patch.add_argument("--output", type=Path, help="patched PDF; defaults inside --work-dir")
+    _add_work_dir(package_patch, "isolated run directory")
+    package_patch.set_defaults(handler=_patch_package_pdf)
+
     render = package_commands.add_parser("render", help="DocumentPackage -> Markdown or EPUB")
     render.add_argument("package", type=Path)
     render.add_argument("--format", choices=("markdown", "epub"), required=True)
@@ -217,8 +234,8 @@ def _translate_pdf(args: argparse.Namespace) -> None:
         result.craft.translate_pdf(args.source, result.package, output, transformer)
     else:
         mode = SubmitKind[args.submit.replace("-", "_").upper()]
-        translated = result.craft.transform_package(
-            result.package, work_dir / "translated", (TranslationStep(ChapterPackageTransformer(transformer), mode),)
+        translated = result.craft.translate_package(
+            result.package, work_dir / "translated", transformer, submit=mode,
         )
         output = args.output or work_dir / ("book.md" if args.format == "markdown" else "book.epub")
         output.parent.mkdir(parents=True, exist_ok=True)
@@ -226,6 +243,28 @@ def _translate_pdf(args: argparse.Namespace) -> None:
     print(f"Package: {result.package.chapters_path.parent}")
     print(f"Output: {output}")
     _print_metering(result.metering)
+
+
+def _translate_package(args: argparse.Namespace) -> None:
+    load_project_env(_project_root())
+    work_dir = _work_dir(args.package, args.work_dir, "package-translate")
+    package = DocumentPackage.from_path(args.package).validate()
+    output_package = args.output_package or work_dir / "translated-package"
+    transformer = _xml_transformer(args, work_dir)
+    mode = SubmitKind[args.submit.replace("-", "_").upper()]
+    translated = PDFCraft().translate_package(
+        package, output_package, transformer, submit=mode,
+    )
+    print(f"Package: {translated.chapters_path.parent}")
+
+
+def _patch_package_pdf(args: argparse.Namespace) -> None:
+    work_dir = _work_dir(args.source, args.work_dir, "package-patch")
+    package = DocumentPackage.from_path(args.package).validate()
+    output = args.output or work_dir / f"{args.source.stem}-patched.pdf"
+    output.parent.mkdir(parents=True, exist_ok=True)
+    PDFCraft().patch_pdf_with_package(args.source, package, output)
+    print(f"Output: {output}")
 
 
 def _render_package(args: argparse.Namespace) -> None:
@@ -394,7 +433,7 @@ def _extract(args: argparse.Namespace, package_path: Path) -> _ExtractionResult:
     craft = PDFCraft(pdf=PDFOptions(ocr=create_ocr_config_from_env(ocr_mode)))
     package, metering = craft.extract_pdf_with_metering(
         args.source, package_path, ExtractionOptions(
-            page_indexes=_page_indexes(args.pages), ocr_size=ocr_size, dpi=args.dpi,
+            page_indexes=_page_indexes(args.pages), ocr_size=cast(Any, ocr_size), dpi=args.dpi,
             max_page_image_file_size=args.max_page_image_file_size,
             max_ocr_tokens=args.max_ocr_tokens, max_ocr_output_tokens=args.max_ocr_output_tokens,
             includes_cover=args.cover, includes_footnotes=args.footnotes,

--- a/pdf_craft_tool/smoke/runner.py
+++ b/pdf_craft_tool/smoke/runner.py
@@ -261,7 +261,7 @@ def _run_pdf(
         steps = _package_steps(run, run_path)
         with report.stage("render"):
             if steps:
-                package = craft.transform_package(package, run_path / "translated", steps)
+                package = _translate_package_steps(craft, package, run_path, steps)
             craft.render_markdown(package, markdown, markdown_assets)
         with report.stage("check"):
             errors = check_package(package)
@@ -277,7 +277,7 @@ def _run_pdf(
         steps = _package_steps(run, run_path)
         with report.stage("render"):
             if steps:
-                package = craft.transform_package(package, run_path / "translated", steps)
+                package = _translate_package_steps(craft, package, run_path, steps)
             craft.render_epub(package, epub)
         with report.stage("check"):
             errors = check_package(package)
@@ -385,6 +385,34 @@ def _package_steps(run: SmokeRun, run_path: Path):
         return ()
     mode = SubmitKind[translation.get("package_submit", "REPLACE").upper()]
     return (TranslationStep(ChapterPackageTransformer(_DeterministicChapterTransformer(marker)), mode),)
+
+
+def _translate_package_steps(
+    craft: PDFCraft,
+    package,
+    run_path: Path,
+    steps,
+):
+    """Run smoke package translations through the public facade method."""
+    current = package
+    for index, step in enumerate(steps):
+        if isinstance(step, TranslationStep):
+            transformer = step.transformer
+            mode = step.mode
+        else:
+            transformer = step
+            mode = getattr(step, "mode", SubmitKind.REPLACE)
+        if not isinstance(transformer, ChapterPackageTransformer):
+            raise TypeError("smoke package routes require a ChapterPackageTransformer")
+        if isinstance(step, TranslationStep) and mode == SubmitKind.REPLACE:
+            mode = transformer.mode
+        current = craft.translate_package(
+            current,
+            run_path / f"translated-{index}",
+            transformer.chapter_transformer,
+            submit=mode,
+        )
+    return current
 
 
 def _xml_translation_transformer(run: SmokeRun, run_path: Path) -> ChapterXMLTransformer | None:

--- a/tests/test_craft.py
+++ b/tests/test_craft.py
@@ -32,6 +32,47 @@ class _Engine:
 
 
 class TestPDFCraft(unittest.TestCase):
+    def test_translate_package_is_the_public_package_translation_entry(self):
+        with tempfile.TemporaryDirectory() as directory:
+            root = Path(directory)
+            source = DocumentPackage.from_path(root / "source")
+            source.chapters_path.mkdir(parents=True)
+            source.assets_path.mkdir()
+            source.write_metadata(page_pixel_sizes={1: (10, 10)})
+            chapter = Chapter(
+                None, -1, [ParagraphLayout(
+                    "text", 0, [BlockLayout(1, 1, (1, 1, 5, 5), ["original"])]
+                )]
+            )
+            (source.chapters_path / "chapter_1.xml").write_text(
+                '<?xml version="1.0" encoding="UTF-8"?>\n'
+                + tostring(encode(chapter), encoding="unicode")
+            )
+
+            class Upper:
+                def transform(self, chapter: Chapter) -> Chapter:
+                    layout = chapter.layouts[0]
+                    assert isinstance(layout, ParagraphLayout)
+                    layout.blocks[0].content = ["translated"]
+                    return chapter
+
+            target = PDFCraft().translate_package(source, root / "target", Upper())
+            self.assertEqual(target.page_pixel_sizes(), {1: (10, 10)})
+            self.assertIn("translated", (target.chapters_path / "chapter_1.xml").read_text())
+            self.assertFalse(hasattr(PDFCraft, "transform_package"))
+
+    def test_patch_pdf_with_package_delegates_to_pdf_patch_pipeline(self):
+        with tempfile.TemporaryDirectory() as directory:
+            root = Path(directory)
+            package = DocumentPackage.from_path(root / "package")
+            package.chapters_path.mkdir(parents=True)
+            package.assets_path.mkdir()
+            with patch("pdf_craft.craft._validate_package_for_pdf") as validate, \
+                    patch("pdf_craft.craft.PDFTranslationPipeline.patch") as patch_pdf:
+                PDFCraft().patch_pdf_with_package("source.pdf", package, "target.pdf")
+            validate.assert_called_once()
+            patch_pdf.assert_called_once()
+
     def test_package_step_creates_independent_package(self):
         with tempfile.TemporaryDirectory() as directory:
             root = Path(directory)


### PR DESCRIPTION
## Summary
- add an explicit `PDFCraft.translate_package` workflow for translating an existing DocumentPackage without OCR
- add `PDFCraft.patch_pdf_with_package` for writing a translated package back to its matching source PDF
- compose the existing PDF translation flow from package translation and PDF patching
- expose matching `pdf_craft_tool package translate` and `package patch-pdf` commands, with docs and smoke updates

## Verification
- `poetry run python -m pytest -q` (313 passed)
- `poetry run pyright pdf_craft pdf_craft_tool tests`
- `poetry run pylint pdf_craft pdf_craft_tool tests`
- `git diff --check`
