### PR TITLE
Prepare pdf-craft 2.0.0 release packaging

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@ This project is based on [DeepSeek OCR](https://github.com/deepseek-ai/DeepSeek-
 
 ## Lightweight and Fast
 
-Starting from the official v1.0.0 release, pdf-craft fully embraces [DeepSeek OCR](https://github.com/deepseek-ai/DeepSeek-OCR) and no longer relies on LLM for text correction. This change brings significant performance improvements: the entire conversion process is completed locally without network requests, eliminating the long waits and occasional network failures of the old version.
+Starting from the official v1.0.0 release, pdf-craft fully embraces [DeepSeek OCR](https://github.com/deepseek-ai/DeepSeek-OCR) and no longer relies on an LLM for text correction. Local OCR conversion can run without network requests after models are cached; vendor OCR remains available when a remote backend is preferred.
 
 However, the new version has also removed the LLM text correction feature. If your use case still requires this functionality, you can continue using the old version [v0.2.8](https://github.com/oomol-lab/pdf-craft/tree/v0.2.8).
 
@@ -35,11 +35,18 @@ If you'd like to explore pdf-craft without setting it up locally, you can try [I
 ### Installation
 
 ```bash
-pip install torch torchvision --index-url https://download.pytorch.org/whl/cpu
 pip install pdf-craft
 ```
 
-The above commands are for quick setup only. To actually use pdf-craft, you need to **install Poppler** for PDF parsing. Local OCR also requires a CUDA-capable PyTorch environment; vendor OCR does not. Please refer to the [Installation Guide](docs/INSTALLATION.md) for detailed instructions.
+The default installation supports vendor OCR and does not install the local
+model runtime. To actually use PDF conversion, install **Poppler** for PDF
+parsing. For local OCR, install a CUDA-compatible PyTorch build first, then:
+
+```bash
+pip install "pdf-craft[local]"
+```
+
+Please refer to the [Installation Guide](docs/INSTALLATION.md) for details.
 
 ### Quick Start
 

--- a/README_zh-CN.md
+++ b/README_zh-CN.md
@@ -20,7 +20,7 @@ pdf-craft 可以将 PDF 文件转换为各种其他格式，本项目专注于�
 
 ## 轻装上阵
 
-从 v1.0.0 正式版开始，pdf-craft 全面拥抱 [DeepSeek OCR](https://github.com/deepseek-ai/DeepSeek-OCR)，不再依赖 LLM 进行文本矫正。这一改变带来了显著的性能提升：整个转换流程在本地完成，无需网络请求，告别了旧版本中漫长的等待和偶发的网络失败。
+从 v1.0.0 正式版开始，pdf-craft 全面拥抱 [DeepSeek OCR](https://github.com/deepseek-ai/DeepSeek-OCR)，不再依赖 LLM 进行文本矫正。本地 OCR 在模型缓存完成后可以无需网络请求；如果更适合使用远程服务，也可以选择供应商 OCR。
 
 不过，新版本也移除了 LLM 文本矫正功能。如果你的使用场景仍然需要这一特性，可以继续使用 [v0.2.8](https://github.com/oomol-lab/pdf-craft/tree/v0.2.8) 旧版本。
 
@@ -35,11 +35,17 @@ pdf-craft 可以将 PDF 文件转换为各种其他格式，本项目专注于�
 ### 安装
 
 ```bash
-pip install torch torchvision --index-url https://download.pytorch.org/whl/cpu
 pip install pdf-craft
 ```
 
-上述命令仅用于快速安装。要真正使用 pdf-craft，你需要**安装 Poppler** 用于 PDF 解析。本地 OCR 还需要支持 CUDA 的 PyTorch 环境；供应商 OCR 不需要本地 CUDA。详细说明请参考[安装指南](docs/INSTALLATION_zh-CN.md)。
+默认安装支持供应商 OCR，不会安装本地模型运行时。要真正进行 PDF 转换，仍需**安装 Poppler**
+用于 PDF 解析。若要使用本地 OCR，请先安装与 CUDA 匹配的 PyTorch，再执行：
+
+```bash
+pip install "pdf-craft[local]"
+```
+
+详细说明请参考[安装指南](docs/INSTALLATION_zh-CN.md)。
 
 ### 快速开始
 

--- a/docs/DEVELOPMENT.md
+++ b/docs/DEVELOPMENT.md
@@ -7,10 +7,12 @@ This guide is for human contributors. Agent-facing project routing lives in `AGE
 - Python >= 3.11, < 3.14 (3.11.16 recommended)
 - Poetry 2.x
 - Poppler, only when running PDF rendering or conversion checks
-- PyTorch, installed through `doc-page-extractor[local]` for local OCR conversion
 - CUDA-capable PyTorch and an NVIDIA GPU, only when running real local OCR conversion
 
-pdf-craft depends on `doc-page-extractor[local]`, so installs include the upstream local OCR runtime stack. pdf-craft still does not declare `torch` or `torchvision` directly; reinstall or override the PyTorch wheel when you need a specific CPU or CUDA build.
+Ordinary installs use the vendor-capable base `doc-page-extractor` runtime. The
+optional `local` extra adds the upstream Hugging Face local OCR runtime.
+pdf-craft does not declare `torch` or `torchvision` directly; install or
+override the PyTorch wheel for the CUDA build you need before enabling local OCR.
 
 ## Setup For Ordinary Development
 
@@ -37,21 +39,17 @@ is not valid for this project and must be recreated with a supported Python.
 
 For code reading, type checking, and the lightweight unit tests, this is usually enough.
 
-If a task needs a specific CPU PyTorch wheel, reinstall it explicitly:
-
-```shell
-poetry run pip install --force-reinstall torch torchvision --index-url https://download.pytorch.org/whl/cpu
-```
-
 ## Setup For Real OCR Conversion
 
 Real PDF conversion can run through either a local CUDA model or vendor OCR.
 
-Local OCR requires CUDA-capable PyTorch. Reinstall the PyTorch build that matches your system before running conversion scripts if the installed wheel does not match your CUDA environment.
+Local OCR requires the optional runtime and CUDA-capable PyTorch. Install the
+project extra, then install or reinstall the PyTorch build that matches your system.
 
 Examples:
 
 ```shell
+poetry install --with dev --extras local
 poetry run pip install --force-reinstall torch torchvision --index-url https://download.pytorch.org/whl/cu118
 poetry run pip install --force-reinstall torch torchvision --index-url https://download.pytorch.org/whl/cu121
 poetry run pip install --force-reinstall torch torchvision --index-url https://download.pytorch.org/whl/cu124
@@ -68,7 +66,7 @@ sudo apt-get install poppler-utils
 brew install poppler
 ```
 
-Verify the environment:
+Verify a local OCR environment:
 
 ```shell
 poetry run python -c "import torch; print(f'PyTorch version: {torch.__version__}'); print(f'CUDA available: {torch.cuda.is_available()}')"

--- a/docs/DEVELOPMENT_zh-CN.md
+++ b/docs/DEVELOPMENT_zh-CN.md
@@ -7,10 +7,11 @@
 - Python >= 3.11, < 3.14（推荐 3.11.16）
 - Poetry 2.x
 - Poppler，仅在运行 PDF 渲染或转换检查时需要
-- PyTorch，通过 `doc-page-extractor[local]` 安装，用于本地 OCR 转换
 - 支持 CUDA 的 PyTorch 和 NVIDIA GPU，仅在运行真实本地 OCR 转换时需要
 
-pdf-craft 依赖 `doc-page-extractor[local]`，因此安装时会包含上游本地 OCR 运行时栈。pdf-craft 仍不会直接声明 `torch` 或 `torchvision`；当你需要指定 CPU 或 CUDA 构建时，再重装或覆盖 PyTorch wheel。
+普通安装使用支持供应商 OCR 的基础 `doc-page-extractor` 运行时。可选的 `local`
+extra 才会安装上游 Hugging Face 本地 OCR 运行时。pdf-craft 不会直接声明 `torch` 或
+`torchvision`；启用本地 OCR 前，请安装或覆盖为所需的 CUDA PyTorch wheel。
 
 ## 普通开发环境
 
@@ -23,21 +24,17 @@ poetry install --with dev
 
 对于阅读代码、类型检查和轻量单元测试，通常这就足够了。
 
-如果任务需要指定 CPU 版 PyTorch wheel，可以显式重装：
-
-```shell
-poetry run pip install --force-reinstall torch torchvision --index-url https://download.pytorch.org/whl/cpu
-```
-
 ## 真实 OCR 转换环境
 
 真实 PDF 转换可以使用本地 CUDA 模型，也可以使用供应商 OCR。
 
-本地 OCR 需要支持 CUDA 的 PyTorch。如果已安装的 wheel 与当前 CUDA 环境不匹配，运行转换脚本前请重装与系统匹配的 PyTorch 版本。
+本地 OCR 需要可选运行时和支持 CUDA 的 PyTorch。先安装项目 extra，再安装或重装与系统
+匹配的 PyTorch wheel。
 
 示例：
 
 ```shell
+poetry install --with dev --extras local
 poetry run pip install --force-reinstall torch torchvision --index-url https://download.pytorch.org/whl/cu118
 poetry run pip install --force-reinstall torch torchvision --index-url https://download.pytorch.org/whl/cu121
 poetry run pip install --force-reinstall torch torchvision --index-url https://download.pytorch.org/whl/cu124
@@ -54,7 +51,7 @@ sudo apt-get install poppler-utils
 brew install poppler
 ```
 
-验证环境：
+验证本地 OCR 环境：
 
 ```shell
 poetry run python -c "import torch; print(f'PyTorch version: {torch.__version__}'); print(f'CUDA available: {torch.cuda.is_available()}')"

--- a/docs/INSTALLATION.md
+++ b/docs/INSTALLATION.md
@@ -13,6 +13,18 @@ pdf-craft uses `doc-page-extractor` for document recognition. Vendor OCR backend
 
 CPU environments cannot run local OCR. They can run vendor OCR when network access, valid credentials, and Poppler are available.
 
+### Vendor OCR Installation
+
+Vendor OCR is the default installation path and does not install PyTorch, Hugging
+Face Transformers, or CUDA runtime dependencies:
+
+```bash
+pip install pdf-craft
+```
+
+Install Poppler as described below, then configure a vendor OCR backend in your
+application (or in `.env` when using the repository-local `pdf_craft_tool`).
+
 ### CUDA Environment Installation
 
 #### 1. Configure CUDA Environment
@@ -35,10 +47,10 @@ Please visit the [PyTorch official installation page](https://pytorch.org/get-st
 pip install torch torchvision --index-url https://download.pytorch.org/whl/cu121
 ```
 
-#### 3. Install pdf-craft
+#### 3. Install pdf-craft local runtime
 
 ```bash
-pip install pdf-craft
+pip install "pdf-craft[local]"
 ```
 
 #### 4. Install Poppler
@@ -75,14 +87,16 @@ pdfinfo -v
 
 Should output Poppler version information. If the command is not found, please check the Poppler installation steps above.
 
-### CPU Environment Installation (Development Only)
+### CPU Environment Installation
 
 ```bash
-pip install torch torchvision --index-url https://download.pytorch.org/whl/cpu
 pip install pdf-craft
 ```
 
-**Note:** Even for development-only setups, you still need to install Poppler following step 4 above if you want to test PDF-related functionality. For the repository's manual scripts, copy `.env.template` to `.env`, populate a vendor OCR configuration, and then run the script.
+This installation can run vendor OCR but not local OCR. You still need to install
+Poppler following step 4 above if you want to process PDFs. For the repository's
+manual scripts, copy `.env.template` to `.env`, populate a vendor OCR
+configuration, and then run the script.
 
 ## Troubleshooting
 

--- a/docs/INSTALLATION_zh-CN.md
+++ b/docs/INSTALLATION_zh-CN.md
@@ -13,6 +13,18 @@ pdf-craft 使用 `doc-page-extractor` 进行文档识别。供应商 OCR 后端�
 
 CPU 环境无法运行本地 OCR；在具备网络、有效凭据和 Poppler 时，仍可运行供应商 OCR。
 
+### 供应商 OCR 安装
+
+供应商 OCR 是默认安装路径，不会安装 PyTorch、Hugging Face Transformers 或 CUDA
+运行时依赖：
+
+```bash
+pip install pdf-craft
+```
+
+按下文安装 Poppler，然后在应用中配置供应商 OCR 后端（使用仓库内
+`pdf_craft_tool` 时在 `.env` 中配置）。
+
 ### CUDA 环境安装
 
 #### 1. 配置 CUDA 环境
@@ -35,10 +47,10 @@ nvidia-smi
 pip install torch torchvision --index-url https://download.pytorch.org/whl/cu121
 ```
 
-#### 3. 安装 pdf-craft
+#### 3. 安装 pdf-craft 本地运行时
 
 ```bash
-pip install pdf-craft
+pip install "pdf-craft[local]"
 ```
 
 #### 4. 安装 Poppler
@@ -75,14 +87,15 @@ pdfinfo -v
 
 应输出 Poppler 版本信息。如果命令未找到，请检查上述 Poppler 安装步骤。
 
-### CPU 环境安装（仅开发）
+### CPU 环境安装
 
 ```bash
-pip install torch torchvision --index-url https://download.pytorch.org/whl/cpu
 pip install pdf-craft
 ```
 
-**注意：** 即使是仅用于开发的环境，如果你想测试与 PDF 相关的功能，仍需按照上述步骤 4 安装 Poppler。使用仓库中的手动脚本时，请将 `.env.template` 复制为 `.env`，填写供应商 OCR 配置后再运行脚本。
+此安装可以运行供应商 OCR，但不能运行本地 OCR。如果需要处理 PDF，仍需按照上述步骤 4
+安装 Poppler。使用仓库中的手动脚本时，请将 `.env.template` 复制为 `.env`，填写供应商
+OCR 配置后再运行脚本。
 
 ## 常见问题
 

--- a/docs/RELEASE.md
+++ b/docs/RELEASE.md
@@ -16,10 +16,10 @@ Configure the PyPI trusted publisher for this repository:
 
 ## 2. Prepare a release PR
 
-For a target version such as `1.0.14`, prepare and merge a PR that includes:
+For a target version such as `2.0.0`, prepare and merge a PR that includes:
 
-- `pyproject.toml` version set to `1.0.14`
-- `docs/changelog/v1.0.14.md` with the release notes
+- `pyproject.toml` version set to `2.0.0`
+- `docs/changelog/v2.0.0.md` with the release notes
 
 Use the existing files in `docs/changelog/` as the changelog style reference.
 

--- a/docs/changelog/v2.0.0.md
+++ b/docs/changelog/v2.0.0.md
@@ -1,0 +1,39 @@
+# PDF Craft v2.0.0
+
+PDF Craft 2.0 introduces a composable public facade for extraction, package
+translation, rendering, and PDF patching.
+
+## Highlights
+
+- Added `PDFCraft` workflows for extracting and reusing `DocumentPackage`
+  directories.
+- Added explicit `translate_package` and `patch_pdf_with_package` operations.
+- Refactored PDF translation and rendering conveniences to compose the atomic
+  package workflows.
+- Added matching `pdf_craft_tool` commands for translating and patching existing
+  packages.
+- Added six selectable OCR backends with independent CLI/smoke configuration.
+- Separated vendor-capable default installation from the optional local OCR
+  runtime: install `pdf-craft[local]` only when using local Hugging Face OCR.
+- Added cache ownership, recovery, and translation-cache safeguards for repeat
+  and interrupted conversions.
+
+## Compatibility
+
+The 2.0 API recommends `PDFCraft` as the public facade. The legacy
+`transform_markdown` and `transform_epub` convenience wrappers remain available
+for compatibility, while package transformation is exposed through the explicit
+translation operation.
+
+Local OCR still requires a CUDA-capable PyTorch environment. Vendor OCR does
+not require local CUDA or the optional local extra.
+
+## Related work
+
+- [#395](https://github.com/oomol-lab/pdf-craft/pull/395)
+- [#396](https://github.com/oomol-lab/pdf-craft/pull/396)
+- [#397](https://github.com/oomol-lab/pdf-craft/pull/397)
+- [#398](https://github.com/oomol-lab/pdf-craft/pull/398)
+- [#399](https://github.com/oomol-lab/pdf-craft/pull/399)
+
+**Full Changelog**: https://github.com/oomol-lab/pdf-craft/compare/v1.0.14...v2.0.0

--- a/pdf_craft/pdf/page_extractor.py
+++ b/pdf_craft/pdf/page_extractor.py
@@ -39,6 +39,17 @@ _LOCAL_OCR_CONFIG_TYPES = (
 )
 
 
+def _create_local_page_extractor(factory):
+    """Turn a missing optional local runtime into an actionable package error."""
+    try:
+        return factory()
+    except ModuleNotFoundError as error:
+        raise RuntimeError(
+            "Local OCR requires the optional local runtime. "
+            "Install it with: pip install 'pdf-craft[local]'"
+        ) from error
+
+
 class PageExtractorNode:
     def __init__(self, ocr: OCRConfig) -> None:
         self._ocr = ocr
@@ -52,30 +63,39 @@ class PageExtractorNode:
     def _create_page_extractor(self):
         # 尽可能推迟 doc-page-extractor 的加载时间
         if isinstance(self._ocr, DeepSeekOCRLocalConfig):
+            ocr = self._ocr
             from doc_page_extractor.extractor import create_deepseek_ocr_page_extractor
 
-            return create_deepseek_ocr_page_extractor(
-                ocr_model="deepseek-ocr",
-                model_path=self._ocr.models_cache_path,
-                local_only=self._ocr.local_only,
-                enable_devices_numbers=self._ocr.enable_devices_numbers,
+            return _create_local_page_extractor(
+                lambda: create_deepseek_ocr_page_extractor(
+                    ocr_model="deepseek-ocr",
+                    model_path=ocr.models_cache_path,
+                    local_only=ocr.local_only,
+                    enable_devices_numbers=ocr.enable_devices_numbers,
+                )
             )
         if isinstance(self._ocr, DeepSeekOCR2LocalConfig):
+            ocr = self._ocr
             from doc_page_extractor.extractor import create_deepseek_ocr_page_extractor
 
-            return create_deepseek_ocr_page_extractor(
-                ocr_model="deepseek-ocr2",
-                model_path=self._ocr.models_cache_path,
-                local_only=self._ocr.local_only,
-                enable_devices_numbers=self._ocr.enable_devices_numbers,
+            return _create_local_page_extractor(
+                lambda: create_deepseek_ocr_page_extractor(
+                    ocr_model="deepseek-ocr2",
+                    model_path=ocr.models_cache_path,
+                    local_only=ocr.local_only,
+                    enable_devices_numbers=ocr.enable_devices_numbers,
+                )
             )
         if isinstance(self._ocr, UnlimitedOCRLocalConfig):
+            ocr = self._ocr
             from doc_page_extractor.extractor import create_unlimited_ocr_page_extractor
 
-            return create_unlimited_ocr_page_extractor(
-                model_path=self._ocr.models_cache_path,
-                local_only=self._ocr.local_only,
-                enable_devices_numbers=self._ocr.enable_devices_numbers,
+            return _create_local_page_extractor(
+                lambda: create_unlimited_ocr_page_extractor(
+                    model_path=ocr.models_cache_path,
+                    local_only=ocr.local_only,
+                    enable_devices_numbers=ocr.enable_devices_numbers,
+                )
             )
         if isinstance(self._ocr, DeepSeekOCRVendorConfig):
             from doc_page_extractor.adapters.deepseek import (

--- a/poetry.lock
+++ b/poetry.lock
@@ -4,9 +4,10 @@
 name = "accelerate"
 version = "1.12.0"
 description = "Accelerate"
-optional = false
+optional = true
 python-versions = ">=3.10.0"
 groups = ["main"]
+markers = "extra == \"local\""
 files = [
     {file = "accelerate-1.12.0-py3-none-any.whl", hash = "sha256:3e2091cd341423207e2f084a6654b1efcd250dc326f2a37d6dde446e07cabb11"},
     {file = "accelerate-1.12.0.tar.gz", hash = "sha256:70988c352feb481887077d2ab845125024b2a137a5090d6d7a32b57d03a45df6"},
@@ -37,9 +38,10 @@ testing = ["bitsandbytes", "datasets", "diffusers", "evaluate", "parameterized",
 name = "addict"
 version = "2.4.0"
 description = "Addict is a dictionary whose items can be set using both attribute and item syntax."
-optional = false
+optional = true
 python-versions = "*"
 groups = ["main"]
+markers = "extra == \"local\""
 files = [
     {file = "addict-2.4.0-py3-none-any.whl", hash = "sha256:249bb56bbfd3cdc2a004ea0ff4c2b6ddc84d53bc2194761636eb314d5cfa5dfc"},
     {file = "addict-2.4.0.tar.gz", hash = "sha256:b3b2210e0e067a281f5646c8c5db92e99b7231ea8b0eb5f74dbdf9e259d4e494"},
@@ -531,9 +533,10 @@ local = ["accelerate (>=0.26.0)", "addict (>=2.4.0)", "easydict (>=1.13)", "eino
 name = "easydict"
 version = "1.13"
 description = "Access dict values as attributes (works recursively)."
-optional = false
+optional = true
 python-versions = "*"
 groups = ["main"]
+markers = "extra == \"local\""
 files = [
     {file = "easydict-1.13-py3-none-any.whl", hash = "sha256:6b787daf4dcaf6377b4ad9403a5cee5a86adbc0ca9a5bcf5410e9902002aeac2"},
     {file = "easydict-1.13.tar.gz", hash = "sha256:b1135dedbc41c8010e2bc1f77ec9744c7faa42bce1a1c87416791449d6c87780"},
@@ -543,9 +546,10 @@ files = [
 name = "einops"
 version = "0.8.1"
 description = "A new flavour of deep learning operations"
-optional = false
+optional = true
 python-versions = ">=3.8"
 groups = ["main"]
+markers = "extra == \"local\""
 files = [
     {file = "einops-0.8.1-py3-none-any.whl", hash = "sha256:919387eb55330f5757c6bea9165c5ff5cfe63a642682ea788a6d472576d81737"},
     {file = "einops-0.8.1.tar.gz", hash = "sha256:de5d960a7a761225532e0f1959e5315ebeafc0cd43394732f103ca44b9837e84"},
@@ -572,9 +576,10 @@ matplotlib = ">=3.10.1,<3.11.0"
 name = "filelock"
 version = "3.20.0"
 description = "A platform independent file lock."
-optional = false
+optional = true
 python-versions = ">=3.10"
 groups = ["main"]
+markers = "extra == \"local\""
 files = [
     {file = "filelock-3.20.0-py3-none-any.whl", hash = "sha256:339b4732ffda5cd79b13f4e2711a31b0365ce445d95d243bb996273d072546a2"},
     {file = "filelock-3.20.0.tar.gz", hash = "sha256:711e943b4ec6be42e1d4e6690b48dc175c822967466bb31c0c293f34334c13f4"},
@@ -665,9 +670,10 @@ woff = ["brotli (>=1.0.1) ; platform_python_implementation == \"CPython\"", "bro
 name = "fsspec"
 version = "2025.10.0"
 description = "File-system specification"
-optional = false
+optional = true
 python-versions = ">=3.9"
 groups = ["main"]
+markers = "extra == \"local\""
 files = [
     {file = "fsspec-2025.10.0-py3-none-any.whl", hash = "sha256:7c7712353ae7d875407f97715f0e1ffcc21e33d5b24556cb1e090ae9409ec61d"},
     {file = "fsspec-2025.10.0.tar.gz", hash = "sha256:b6789427626f068f9a83ca4e8a3cc050850b6c0f71f99ddb4f542b8266a26a59"},
@@ -717,9 +723,10 @@ files = [
 name = "hf-transfer"
 version = "0.1.9"
 description = "Speed up file transfers with the Hugging Face Hub."
-optional = false
+optional = true
 python-versions = ">=3.7"
 groups = ["main"]
+markers = "extra == \"local\""
 files = [
     {file = "hf_transfer-0.1.9-cp313-cp313t-macosx_10_12_x86_64.whl", hash = "sha256:6e94e8822da79573c9b6ae4d6b2f847c59a7a06c5327d7db20751b68538dc4f6"},
     {file = "hf_transfer-0.1.9-cp313-cp313t-macosx_11_0_arm64.whl", hash = "sha256:3ebc4ab9023414880c8b1d3c38174d1c9989eb5022d37e814fa91a3060123eb0"},
@@ -752,10 +759,10 @@ files = [
 name = "hf-xet"
 version = "1.2.0"
 description = "Fast transfer of large files with the Hugging Face Hub."
-optional = false
+optional = true
 python-versions = ">=3.8"
 groups = ["main"]
-markers = "platform_machine == \"x86_64\" or platform_machine == \"amd64\" or platform_machine == \"arm64\" or platform_machine == \"aarch64\""
+markers = "extra == \"local\" and (platform_machine == \"x86_64\" or platform_machine == \"amd64\" or platform_machine == \"arm64\" or platform_machine == \"aarch64\")"
 files = [
     {file = "hf_xet-1.2.0-cp313-cp313t-macosx_10_12_x86_64.whl", hash = "sha256:ceeefcd1b7aed4956ae8499e2199607765fbd1c60510752003b6cc0b8413b649"},
     {file = "hf_xet-1.2.0-cp313-cp313t-macosx_11_0_arm64.whl", hash = "sha256:b70218dd548e9840224df5638fdc94bd033552963cfa97f9170829381179c813"},
@@ -835,9 +842,10 @@ zstd = ["zstandard (>=0.18.0)"]
 name = "huggingface-hub"
 version = "0.36.0"
 description = "Client library to download and publish models, datasets and other repos on the huggingface.co hub"
-optional = false
+optional = true
 python-versions = ">=3.8.0"
 groups = ["main"]
+markers = "extra == \"local\""
 files = [
     {file = "huggingface_hub-0.36.0-py3-none-any.whl", hash = "sha256:7bcc9ad17d5b3f07b57c78e79d527102d08313caa278a641993acddcb894548d"},
     {file = "huggingface_hub-0.36.0.tar.gz", hash = "sha256:47b3f0e2539c39bf5cde015d63b72ec49baff67b6931c3d97f3f84532e2b8d25"},
@@ -1402,9 +1410,10 @@ files = [
 name = "mpmath"
 version = "1.3.0"
 description = "Python library for arbitrary-precision floating-point arithmetic"
-optional = false
+optional = true
 python-versions = "*"
 groups = ["main"]
+markers = "extra == \"local\""
 files = [
     {file = "mpmath-1.3.0-py3-none-any.whl", hash = "sha256:a0b2b9fe80bbcd81a6647ff13108738cfb482d481d826cc0e02f5b35e5c88d2c"},
     {file = "mpmath-1.3.0.tar.gz", hash = "sha256:7a28eb2a9774d00c7bc92411c19a89209d5da7c4c9a9e227be8330a23a25b91f"},
@@ -1420,9 +1429,10 @@ tests = ["pytest (>=4.6)"]
 name = "networkx"
 version = "3.6"
 description = "Python package for creating and manipulating graphs and networks"
-optional = false
+optional = true
 python-versions = ">=3.11"
 groups = ["main"]
+markers = "extra == \"local\""
 files = [
     {file = "networkx-3.6-py3-none-any.whl", hash = "sha256:cdb395b105806062473d3be36458d8f1459a4e4b98e236a66c3a48996e07684f"},
     {file = "networkx-3.6.tar.gz", hash = "sha256:285276002ad1f7f7da0f7b42f004bcba70d381e936559166363707fdad3d72ad"},
@@ -1539,10 +1549,10 @@ files = [
 name = "nvidia-cublas-cu12"
 version = "12.8.4.1"
 description = "CUBLAS native runtime libraries"
-optional = false
+optional = true
 python-versions = ">=3"
 groups = ["main"]
-markers = "platform_system == \"Linux\" and platform_machine == \"x86_64\""
+markers = "platform_system == \"Linux\" and platform_machine == \"x86_64\" and extra == \"local\""
 files = [
     {file = "nvidia_cublas_cu12-12.8.4.1-py3-none-manylinux_2_27_aarch64.whl", hash = "sha256:b86f6dd8935884615a0683b663891d43781b819ac4f2ba2b0c9604676af346d0"},
     {file = "nvidia_cublas_cu12-12.8.4.1-py3-none-manylinux_2_27_x86_64.whl", hash = "sha256:8ac4e771d5a348c551b2a426eda6193c19aa630236b418086020df5ba9667142"},
@@ -1553,10 +1563,10 @@ files = [
 name = "nvidia-cuda-cupti-cu12"
 version = "12.8.90"
 description = "CUDA profiling tools runtime libs."
-optional = false
+optional = true
 python-versions = ">=3"
 groups = ["main"]
-markers = "platform_system == \"Linux\" and platform_machine == \"x86_64\""
+markers = "platform_system == \"Linux\" and platform_machine == \"x86_64\" and extra == \"local\""
 files = [
     {file = "nvidia_cuda_cupti_cu12-12.8.90-py3-none-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:4412396548808ddfed3f17a467b104ba7751e6b58678a4b840675c56d21cf7ed"},
     {file = "nvidia_cuda_cupti_cu12-12.8.90-py3-none-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:ea0cb07ebda26bb9b29ba82cda34849e73c166c18162d3913575b0c9db9a6182"},
@@ -1567,10 +1577,10 @@ files = [
 name = "nvidia-cuda-nvrtc-cu12"
 version = "12.8.93"
 description = "NVRTC native runtime libraries"
-optional = false
+optional = true
 python-versions = ">=3"
 groups = ["main"]
-markers = "platform_system == \"Linux\" and platform_machine == \"x86_64\""
+markers = "platform_system == \"Linux\" and platform_machine == \"x86_64\" and extra == \"local\""
 files = [
     {file = "nvidia_cuda_nvrtc_cu12-12.8.93-py3-none-manylinux2010_x86_64.manylinux_2_12_x86_64.whl", hash = "sha256:a7756528852ef889772a84c6cd89d41dfa74667e24cca16bb31f8f061e3e9994"},
     {file = "nvidia_cuda_nvrtc_cu12-12.8.93-py3-none-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:fc1fec1e1637854b4c0a65fb9a8346b51dd9ee69e61ebaccc82058441f15bce8"},
@@ -1581,10 +1591,10 @@ files = [
 name = "nvidia-cuda-runtime-cu12"
 version = "12.8.90"
 description = "CUDA Runtime native Libraries"
-optional = false
+optional = true
 python-versions = ">=3"
 groups = ["main"]
-markers = "platform_system == \"Linux\" and platform_machine == \"x86_64\""
+markers = "platform_system == \"Linux\" and platform_machine == \"x86_64\" and extra == \"local\""
 files = [
     {file = "nvidia_cuda_runtime_cu12-12.8.90-py3-none-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:52bf7bbee900262ffefe5e9d5a2a69a30d97e2bc5bb6cc866688caa976966e3d"},
     {file = "nvidia_cuda_runtime_cu12-12.8.90-py3-none-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:adade8dcbd0edf427b7204d480d6066d33902cab2a4707dcfc48a2d0fd44ab90"},
@@ -1595,10 +1605,10 @@ files = [
 name = "nvidia-cudnn-cu12"
 version = "9.10.2.21"
 description = "cuDNN runtime libraries"
-optional = false
+optional = true
 python-versions = ">=3"
 groups = ["main"]
-markers = "platform_system == \"Linux\" and platform_machine == \"x86_64\""
+markers = "platform_system == \"Linux\" and platform_machine == \"x86_64\" and extra == \"local\""
 files = [
     {file = "nvidia_cudnn_cu12-9.10.2.21-py3-none-manylinux_2_27_aarch64.whl", hash = "sha256:c9132cc3f8958447b4910a1720036d9eff5928cc3179b0a51fb6d167c6cc87d8"},
     {file = "nvidia_cudnn_cu12-9.10.2.21-py3-none-manylinux_2_27_x86_64.whl", hash = "sha256:949452be657fa16687d0930933f032835951ef0892b37d2d53824d1a84dc97a8"},
@@ -1612,10 +1622,10 @@ nvidia-cublas-cu12 = "*"
 name = "nvidia-cufft-cu12"
 version = "11.3.3.83"
 description = "CUFFT native runtime libraries"
-optional = false
+optional = true
 python-versions = ">=3"
 groups = ["main"]
-markers = "platform_system == \"Linux\" and platform_machine == \"x86_64\""
+markers = "platform_system == \"Linux\" and platform_machine == \"x86_64\" and extra == \"local\""
 files = [
     {file = "nvidia_cufft_cu12-11.3.3.83-py3-none-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:848ef7224d6305cdb2a4df928759dca7b1201874787083b6e7550dd6765ce69a"},
     {file = "nvidia_cufft_cu12-11.3.3.83-py3-none-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:4d2dd21ec0b88cf61b62e6b43564355e5222e4a3fb394cac0db101f2dd0d4f74"},
@@ -1629,10 +1639,10 @@ nvidia-nvjitlink-cu12 = "*"
 name = "nvidia-cufile-cu12"
 version = "1.13.1.3"
 description = "cuFile GPUDirect libraries"
-optional = false
+optional = true
 python-versions = ">=3"
 groups = ["main"]
-markers = "platform_system == \"Linux\" and platform_machine == \"x86_64\""
+markers = "platform_system == \"Linux\" and platform_machine == \"x86_64\" and extra == \"local\""
 files = [
     {file = "nvidia_cufile_cu12-1.13.1.3-py3-none-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:1d069003be650e131b21c932ec3d8969c1715379251f8d23a1860554b1cb24fc"},
     {file = "nvidia_cufile_cu12-1.13.1.3-py3-none-manylinux_2_27_aarch64.whl", hash = "sha256:4beb6d4cce47c1a0f1013d72e02b0994730359e17801d395bdcbf20cfb3bb00a"},
@@ -1642,10 +1652,10 @@ files = [
 name = "nvidia-curand-cu12"
 version = "10.3.9.90"
 description = "CURAND native runtime libraries"
-optional = false
+optional = true
 python-versions = ">=3"
 groups = ["main"]
-markers = "platform_system == \"Linux\" and platform_machine == \"x86_64\""
+markers = "platform_system == \"Linux\" and platform_machine == \"x86_64\" and extra == \"local\""
 files = [
     {file = "nvidia_curand_cu12-10.3.9.90-py3-none-manylinux_2_27_aarch64.whl", hash = "sha256:dfab99248034673b779bc6decafdc3404a8a6f502462201f2f31f11354204acd"},
     {file = "nvidia_curand_cu12-10.3.9.90-py3-none-manylinux_2_27_x86_64.whl", hash = "sha256:b32331d4f4df5d6eefa0554c565b626c7216f87a06a4f56fab27c3b68a830ec9"},
@@ -1656,10 +1666,10 @@ files = [
 name = "nvidia-cusolver-cu12"
 version = "11.7.3.90"
 description = "CUDA solver native runtime libraries"
-optional = false
+optional = true
 python-versions = ">=3"
 groups = ["main"]
-markers = "platform_system == \"Linux\" and platform_machine == \"x86_64\""
+markers = "platform_system == \"Linux\" and platform_machine == \"x86_64\" and extra == \"local\""
 files = [
     {file = "nvidia_cusolver_cu12-11.7.3.90-py3-none-manylinux_2_27_aarch64.whl", hash = "sha256:db9ed69dbef9715071232caa9b69c52ac7de3a95773c2db65bdba85916e4e5c0"},
     {file = "nvidia_cusolver_cu12-11.7.3.90-py3-none-manylinux_2_27_x86_64.whl", hash = "sha256:4376c11ad263152bd50ea295c05370360776f8c3427b30991df774f9fb26c450"},
@@ -1675,10 +1685,10 @@ nvidia-nvjitlink-cu12 = "*"
 name = "nvidia-cusparse-cu12"
 version = "12.5.8.93"
 description = "CUSPARSE native runtime libraries"
-optional = false
+optional = true
 python-versions = ">=3"
 groups = ["main"]
-markers = "platform_system == \"Linux\" and platform_machine == \"x86_64\""
+markers = "platform_system == \"Linux\" and platform_machine == \"x86_64\" and extra == \"local\""
 files = [
     {file = "nvidia_cusparse_cu12-12.5.8.93-py3-none-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:9b6c161cb130be1a07a27ea6923df8141f3c295852f4b260c65f18f3e0a091dc"},
     {file = "nvidia_cusparse_cu12-12.5.8.93-py3-none-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:1ec05d76bbbd8b61b06a80e1eaf8cf4959c3d4ce8e711b65ebd0443bb0ebb13b"},
@@ -1692,10 +1702,10 @@ nvidia-nvjitlink-cu12 = "*"
 name = "nvidia-cusparselt-cu12"
 version = "0.7.1"
 description = "NVIDIA cuSPARSELt"
-optional = false
+optional = true
 python-versions = "*"
 groups = ["main"]
-markers = "platform_system == \"Linux\" and platform_machine == \"x86_64\""
+markers = "platform_system == \"Linux\" and platform_machine == \"x86_64\" and extra == \"local\""
 files = [
     {file = "nvidia_cusparselt_cu12-0.7.1-py3-none-manylinux2014_aarch64.whl", hash = "sha256:8878dce784d0fac90131b6817b607e803c36e629ba34dc5b433471382196b6a5"},
     {file = "nvidia_cusparselt_cu12-0.7.1-py3-none-manylinux2014_x86_64.whl", hash = "sha256:f1bb701d6b930d5a7cea44c19ceb973311500847f81b634d802b7b539dc55623"},
@@ -1706,10 +1716,10 @@ files = [
 name = "nvidia-nccl-cu12"
 version = "2.27.5"
 description = "NVIDIA Collective Communication Library (NCCL) Runtime"
-optional = false
+optional = true
 python-versions = ">=3"
 groups = ["main"]
-markers = "platform_system == \"Linux\" and platform_machine == \"x86_64\""
+markers = "platform_system == \"Linux\" and platform_machine == \"x86_64\" and extra == \"local\""
 files = [
     {file = "nvidia_nccl_cu12-2.27.5-py3-none-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:31432ad4d1fb1004eb0c56203dc9bc2178a1ba69d1d9e02d64a6938ab5e40e7a"},
     {file = "nvidia_nccl_cu12-2.27.5-py3-none-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:ad730cf15cb5d25fe849c6e6ca9eb5b76db16a80f13f425ac68d8e2e55624457"},
@@ -1719,10 +1729,10 @@ files = [
 name = "nvidia-nvjitlink-cu12"
 version = "12.8.93"
 description = "Nvidia JIT LTO Library"
-optional = false
+optional = true
 python-versions = ">=3"
 groups = ["main"]
-markers = "platform_system == \"Linux\" and platform_machine == \"x86_64\""
+markers = "platform_system == \"Linux\" and platform_machine == \"x86_64\" and extra == \"local\""
 files = [
     {file = "nvidia_nvjitlink_cu12-12.8.93-py3-none-manylinux2010_x86_64.manylinux_2_12_x86_64.whl", hash = "sha256:81ff63371a7ebd6e6451970684f916be2eab07321b73c9d244dc2b4da7f73b88"},
     {file = "nvidia_nvjitlink_cu12-12.8.93-py3-none-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:adccd7161ace7261e01bb91e44e88da350895c270d23f744f0820c818b7229e7"},
@@ -1733,10 +1743,10 @@ files = [
 name = "nvidia-nvshmem-cu12"
 version = "3.3.20"
 description = "NVSHMEM creates a global address space that provides efficient and scalable communication for NVIDIA GPU clusters."
-optional = false
+optional = true
 python-versions = ">=3"
 groups = ["main"]
-markers = "platform_system == \"Linux\" and platform_machine == \"x86_64\""
+markers = "platform_system == \"Linux\" and platform_machine == \"x86_64\" and extra == \"local\""
 files = [
     {file = "nvidia_nvshmem_cu12-3.3.20-py3-none-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:0b0b960da3842212758e4fa4696b94f129090b30e5122fea3c5345916545cff0"},
     {file = "nvidia_nvshmem_cu12-3.3.20-py3-none-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:d00f26d3f9b2e3c3065be895e3059d6479ea5c638a3f38c9fec49b1b9dd7c1e5"},
@@ -1746,10 +1756,10 @@ files = [
 name = "nvidia-nvtx-cu12"
 version = "12.8.90"
 description = "NVIDIA Tools Extension"
-optional = false
+optional = true
 python-versions = ">=3"
 groups = ["main"]
-markers = "platform_system == \"Linux\" and platform_machine == \"x86_64\""
+markers = "platform_system == \"Linux\" and platform_machine == \"x86_64\" and extra == \"local\""
 files = [
     {file = "nvidia_nvtx_cu12-12.8.90-py3-none-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:d7ad891da111ebafbf7e015d34879f7112832fc239ff0d7d776b6cb685274615"},
     {file = "nvidia_nvtx_cu12-12.8.90-py3-none-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:5b17e2001cc0d751a5bc2c6ec6d26ad95913324a4adb86788c944f8ce9ba441f"},
@@ -1957,9 +1967,10 @@ testing = ["coverage", "pytest", "pytest-benchmark"]
 name = "psutil"
 version = "7.1.3"
 description = "Cross-platform lib for process and system monitoring."
-optional = false
+optional = true
 python-versions = ">=3.6"
 groups = ["main"]
+markers = "extra == \"local\""
 files = [
     {file = "psutil-7.1.3-cp313-cp313t-macosx_10_13_x86_64.whl", hash = "sha256:0005da714eee687b4b8decd3d6cc7c6db36215c9e74e5ad2264b90c3df7d92dc"},
     {file = "psutil-7.1.3-cp313-cp313t-macosx_11_0_arm64.whl", hash = "sha256:19644c85dcb987e35eeeaefdc3915d059dac7bd1167cdcdbf27e0ce2df0c08c0"},
@@ -2352,9 +2363,10 @@ six = ">=1.5"
 name = "pyyaml"
 version = "6.0.3"
 description = "YAML parser and emitter for Python"
-optional = false
+optional = true
 python-versions = ">=3.8"
 groups = ["main"]
+markers = "extra == \"local\""
 files = [
     {file = "PyYAML-6.0.3-cp38-cp38-macosx_10_13_x86_64.whl", hash = "sha256:c2514fceb77bc5e7a2f7adfaa1feb2fb311607c9cb518dbc378688ec73d8292f"},
     {file = "PyYAML-6.0.3-cp38-cp38-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:9c57bb8c96f6d1808c030b1687b9b5fb476abaa47f0db9c0101f5e9f394e97f4"},
@@ -2435,9 +2447,10 @@ files = [
 name = "readerwriterlock"
 version = "1.0.9"
 description = "A python implementation of the three Reader-Writer problems."
-optional = false
+optional = true
 python-versions = ">=3.6"
 groups = ["main"]
+markers = "extra == \"local\""
 files = [
     {file = "readerwriterlock-1.0.9-py3-none-any.whl", hash = "sha256:8c4b704e60d15991462081a27ef46762fea49b478aa4426644f2146754759ca7"},
     {file = "readerwriterlock-1.0.9.tar.gz", hash = "sha256:b7c4cc003435d7a8ff15b312b0a62a88d9800ba6164af88991f87f8b748f9bea"},
@@ -2661,9 +2674,10 @@ files = [
 name = "safetensors"
 version = "0.7.0"
 description = ""
-optional = false
+optional = true
 python-versions = ">=3.9"
 groups = ["main"]
+markers = "extra == \"local\""
 files = [
     {file = "safetensors-0.7.0-cp38-abi3-macosx_10_12_x86_64.whl", hash = "sha256:c82f4d474cf725255d9e6acf17252991c3c8aac038d6ef363a4bf8be2f6db517"},
     {file = "safetensors-0.7.0-cp38-abi3-macosx_11_0_arm64.whl", hash = "sha256:94fd4858284736bb67a897a41608b5b0c2496c9bdb3bf2af1fa3409127f20d57"},
@@ -2708,10 +2722,10 @@ torch = ["packaging", "safetensors[numpy]", "torch (>=1.10)"]
 name = "setuptools"
 version = "80.9.0"
 description = "Easily download, build, install, upgrade, and uninstall Python packages"
-optional = false
+optional = true
 python-versions = ">=3.9"
 groups = ["main"]
-markers = "python_version >= \"3.12\""
+markers = "python_version >= \"3.12\" and extra == \"local\""
 files = [
     {file = "setuptools-80.9.0-py3-none-any.whl", hash = "sha256:062d34222ad13e0cc312a4c02d73f059e86a4acbfbdea8f8f76b28c99f306922"},
     {file = "setuptools-80.9.0.tar.gz", hash = "sha256:f36b47402ecde768dbfafc46e8e4207b4360c654f1f3bb84475f0a28628fb19c"},
@@ -2766,9 +2780,10 @@ files = [
 name = "sympy"
 version = "1.14.0"
 description = "Computer algebra system (CAS) in Python"
-optional = false
+optional = true
 python-versions = ">=3.9"
 groups = ["main"]
+markers = "extra == \"local\""
 files = [
     {file = "sympy-1.14.0-py3-none-any.whl", hash = "sha256:e091cc3e99d2141a0ba2847328f5479b05d94a6635cb96148ccb3f34671bd8f5"},
     {file = "sympy-1.14.0.tar.gz", hash = "sha256:d3d3fe8df1e5a0b42f0e7bdf50541697dbe7d23746e894990c030e2b05e72517"},
@@ -2858,9 +2873,10 @@ blobfile = ["blobfile (>=2)"]
 name = "tokenizers"
 version = "0.21.4"
 description = ""
-optional = false
+optional = true
 python-versions = ">=3.9"
 groups = ["main"]
+markers = "extra == \"local\""
 files = [
     {file = "tokenizers-0.21.4-cp39-abi3-macosx_10_12_x86_64.whl", hash = "sha256:2ccc10a7c3bcefe0f242867dc914fc1226ee44321eb618cfe3019b5df3400133"},
     {file = "tokenizers-0.21.4-cp39-abi3-macosx_11_0_arm64.whl", hash = "sha256:5e2f601a8e0cd5be5cc7506b20a79112370b9b3e9cb5f13f68ab11acd6ca7d60"},
@@ -2903,9 +2919,10 @@ files = [
 name = "torch"
 version = "2.9.1"
 description = "Tensors and Dynamic neural networks in Python with strong GPU acceleration"
-optional = false
+optional = true
 python-versions = ">=3.10"
 groups = ["main"]
+markers = "extra == \"local\""
 files = [
     {file = "torch-2.9.1-cp310-cp310-manylinux_2_28_aarch64.whl", hash = "sha256:1cc208435f6c379f9b8fdfd5ceb5be1e3b72a6bdf1cb46c0d2812aa73472db9e"},
     {file = "torch-2.9.1-cp310-cp310-manylinux_2_28_x86_64.whl", hash = "sha256:9fd35c68b3679378c11f5eb73220fdcb4e6f4592295277fbb657d31fd053237c"},
@@ -2993,9 +3010,10 @@ telegram = ["requests"]
 name = "transformers"
 version = "4.47.1"
 description = "State-of-the-art Machine Learning for JAX, PyTorch and TensorFlow"
-optional = false
+optional = true
 python-versions = ">=3.9.0"
 groups = ["main"]
+markers = "extra == \"local\""
 files = [
     {file = "transformers-4.47.1-py3-none-any.whl", hash = "sha256:d2f5d19bb6283cd66c893ec7e6d931d6370bbf1cc93633326ff1f41a40046c9c"},
     {file = "transformers-4.47.1.tar.gz", hash = "sha256:6c29c05a5f595e278481166539202bf8641281536df1c42357ee58a45d0a564a"},
@@ -3063,10 +3081,10 @@ vision = ["Pillow (>=10.0.1,<=15.0)"]
 name = "triton"
 version = "3.5.1"
 description = "A language and compiler for custom Deep Learning operations"
-optional = false
+optional = true
 python-versions = "<3.15,>=3.10"
 groups = ["main"]
-markers = "platform_system == \"Linux\" and platform_machine == \"x86_64\""
+markers = "platform_system == \"Linux\" and platform_machine == \"x86_64\" and extra == \"local\""
 files = [
     {file = "triton-3.5.1-cp310-cp310-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:f63e34dcb32d7bd3a1d0195f60f30d2aee8b08a69a0424189b71017e23dfc3d2"},
     {file = "triton-3.5.1-cp310-cp310-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:5fc53d849f879911ea13f4a877243afc513187bc7ee92d1f2c0f1ba3169e3c94"},
@@ -3134,7 +3152,10 @@ h2 = ["h2 (>=4,<5)"]
 socks = ["pysocks (>=1.5.6,!=1.5.7,<2.0)"]
 zstd = ["zstandard (>=0.18.0)"]
 
+[extras]
+local = ["doc-page-extractor"]
+
 [metadata]
 lock-version = "2.1"
 python-versions = ">=3.11,<3.14"
-content-hash = "265500f345430c982fa5bdfd609b6a67762b542328b91fff4e73b485c1f04131"
+content-hash = "a032a51042a5e392e8f3c31170f3a9ab85876e0a09ec9643b58ebbc71bc0dd02"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -2,20 +2,15 @@
 requires = ["poetry-core>=2.0.0,<3.0.0"]
 build-backend = "poetry.core.masonry.api"
 
-[tool.poetry]
+[project]
 name = "pdf-craft"
-version = "1.0.14"
+version = "2.0.0"
 description = "PDF craft can convert PDF files into various other formats. This project will focus on processing PDF files of scanned books."
-license = "MIT"
-authors = ["Tao Zeyu <i@taozeyu.com>"]
-maintainers = ["Tao Zeyu <i@taozeyu.com>"]
+license = {text = "MIT"}
+authors = [{name = "Tao Zeyu", email = "i@taozeyu.com"}]
+maintainers = [{name = "Tao Zeyu", email = "i@taozeyu.com"}]
 readme = "README.md"
-homepage = "https://hub.oomol.com/package/pdf-craft"
-repository = "https://github.com/oomol-lab/pdf-craft"
 keywords = ["pdf", "epub", "markdown"]
-packages = [
-    {include = "pdf_craft" }
-]
 classifiers = [
     "Development Status :: 4 - Beta",
     "Intended Audience :: Developers",
@@ -27,24 +22,36 @@ classifiers = [
     "Topic :: Software Development :: Libraries :: Python Modules",
     "Topic :: Text Processing",
 ]
+requires-python = ">=3.11,<3.14"
+dependencies = [
+    "pdf2image>=1.17.0,<2.0.0",
+    "pypdf>=6.6.0,<7.0.0",
+    "tiktoken>=0.12.0,<1.0.0",
+    "openai>=2.14.0,<3.0.0",
+    "json-repair>=0.55.0,<0.56.0",
+    "pydantic>=2.12.5,<3.0.0",
+    "doc-page-extractor>=1.2.0,<2.0.0",
+    "epub-generator==0.1.7",
+    "pylatexenc>=2.10,<3.0.0",
+    "pyahocorasick>=2.2.0,<3.0.0",
+    "markdownify>=1.2.2,<2.0.0",
+    "reportlab>=4.4.0,<5.0.0",
+    "jinja2>=3.1.6,<4.0.0",
+    "resource-segmentation>=0.0.7,<0.1.0",
+    "mathml2latex>=0.2.12,<0.3.0",
+]
 
-[tool.poetry.dependencies]
-python = ">=3.11,<3.14"
-pdf2image = "^1.17.0"
-pypdf = "^6.6.0"
-tiktoken = ">=0.12.0,<1.0.0"
-openai = ">=2.14.0,<3.0.0"
-json-repair = ">=0.55.0,<0.56.0"
-pydantic = ">=2.12.5,<3.0.0"
-doc-page-extractor = {version = "1.2.0", extras = ["local"]}
-epub-generator = "==0.1.7"
-pylatexenc = "^2.10"
-pyahocorasick = "^2.2.0"
-markdownify = "^1.2.2"
-reportlab = "^4.4.0"
-jinja2 = ">=3.1.6,<4.0.0"
-resource-segmentation = ">=0.0.7,<0.1.0"
-mathml2latex = ">=0.2.12,<0.3.0"
+[project.urls]
+Homepage = "https://hub.oomol.com/package/pdf-craft"
+Repository = "https://github.com/oomol-lab/pdf-craft"
+
+[project.optional-dependencies]
+# Keep the upstream local runtime as one dependency declaration so its
+# transformer/CUDA-related requirements remain owned by doc-page-extractor.
+local = ["doc-page-extractor[local]>=1.2.0,<2.0.0"]
+
+[tool.poetry]
+packages = [{include = "pdf_craft"}]
 
 [tool.poetry.group.dev.dependencies]
 pylint = "^3.3.7"

--- a/tests/test_ocr_config.py
+++ b/tests/test_ocr_config.py
@@ -146,6 +146,15 @@ class TestOCRConfig(unittest.TestCase):
         )
         extractor.load_ocr_model.assert_called_once_with()
 
+    def test_local_ocr_missing_optional_runtime_has_install_hint(self):
+        with patch(
+            "doc_page_extractor.extractor.create_deepseek_ocr_page_extractor",
+            side_effect=ModuleNotFoundError("No module named 'transformers'"),
+        ):
+            node = PageExtractorNode(DeepSeekOCRLocalConfig())
+            with self.assertRaisesRegex(RuntimeError, "pdf-craft\\[local\\]"):
+                node.load_models()
+
     def test_local_deepseek_ocr2_rejects_tiny_before_upstream_model_code(self):
         node = PageExtractorNode(DeepSeekOCR2LocalConfig(models_cache_path="models"))
         with self.assertRaisesRegex(ValueError, "deepseek-ocr2-local.*tiny.*base"):


### PR DESCRIPTION
## Summary

- migrate packaging metadata to PEP 621 and release version 2.0.0
- make local OCR runtime opt-in via `pdf-craft[local]`
- improve missing-local-runtime diagnostics
- update installation/development/release docs and add the v2.0.0 changelog

## Verification

- `poetry install --with dev` in a clean Python 3.13.14 macOS environment
- default install has no torch/transformers/accelerate/nvidia packages
- `poetry install --extras local --dry-run` includes the expected local runtime
- `poetry build`
- `pytest`: 314 passed
- `pyright pdf_craft tests`: 0 errors
- `pylint pdf_craft tests`: 10.00/10
- real vendor OCR conversion with `.env`: passed

CUDA/local OCR inference is intentionally not run on this device.
