### PR TITLE
docs: complete English advanced guides

### DIFF
--- a/docs/en/API_REFERENCE.md
+++ b/docs/en/API_REFERENCE.md
@@ -1,0 +1,162 @@
+# Public API reference
+
+This reference covers the supported library surface imported from `pdf_craft`. Most applications only need `PDFCraft`, one OCR configuration, and—when translating—an `LLM`. The lower-level rendering, transformation, and PDF patching classes are available for applications that need explicit control.
+
+```python
+from pdf_craft import PDFCraft, PDFOptions
+```
+
+## `PDFCraft`
+
+`PDFCraft` is the public façade for PDF extraction, document rendering, PDF patching, and EPUB translation. Creating it does not initialize OCR, so EPUB-only applications can use `PDFCraft()` with no PDF configuration.
+
+```python
+craft = PDFCraft(pdf=PDFOptions(ocr=your_ocr_config))
+```
+
+### PDF extraction and rendering
+
+| Method | Signature and purpose |
+| --- | --- |
+| `extract_pdf` | `extract_pdf(source, package_path, options=None) -> DocumentPackage` extracts a PDF into a persistent package directory. `package_path` is required. |
+| `extract_pdf_with_metering` | `extract_pdf_with_metering(source, package_path, options=None) -> tuple[DocumentPackage, OCRTokensMetering]` is the same extraction with OCR token accounting. |
+| `render_markdown` | `render_markdown(package, output, assets_path=None, *, aborted=...)` writes Markdown and optional assets. |
+| `render_epub` | `render_epub(package, output, *, book_meta=None, lan="zh", table_render=..., latex_render=..., inline_latex=True, aborted=...)` writes an EPUB. |
+| `convert_pdf_to_markdown` | `convert_pdf_to_markdown(source, output, *, package_path=None, extraction=None, assets_path=None, steps=()) -> OCRTokensMetering` is the one-shot PDF-to-Markdown workflow. |
+| `convert_pdf_to_epub` | `convert_pdf_to_epub(source, output, *, package_path=None, extraction=None, book_meta=None, lan="zh", table_render=..., latex_render=..., inline_latex=True, steps=()) -> OCRTokensMetering` is the one-shot PDF-to-EPUB workflow. |
+
+The two `convert_pdf_to_*` methods clean up their temporary package workspace when `package_path` is omitted. Give `package_path` when you need to retain the package. `render_epub` accepts `epub_generator.BookMeta`, `TableRender`, and `LaTeXRender` values for output customization.
+
+### Package translation and PDF patching
+
+| Method | Signature and purpose |
+| --- | --- |
+| `translate_package` | `translate_package(package, output_path, translator, *, submit=SubmitKind.REPLACE) -> DocumentPackage` translates a package into a new package. `translator` is a chapter transformer. |
+| `translate_pdf` | `translate_pdf(source, package, output, transformer, *, steps=())` translates then patches text onto the source PDF. `transformer` may be a chapter transformer or `Callable[[str], str]`. |
+| `patch_pdf_with_package` | `patch_pdf_with_package(source, package, output)` patches a source PDF from a `DocumentPackage` or package path without OCR or LLM calls. |
+| `translate_epub` | `translate_epub(source, output, *, target_language, submit, **options)` translates an existing EPUB. See [EPUB translation](EPUB_TRANSLATION.md) for its options. |
+
+`translate_pdf` and `patch_pdf_with_package` require a package with page geometry that matches the source PDF. PDF patching rejects `SubmitKind.APPEND_BLOCK`.
+
+## PDF configuration
+
+### `PDFOptions`
+
+`PDFOptions(ocr=None, pdf_handler=None, models_cache_path=None, local_only=False)` holds infrastructure that is reused across PDF extractions.
+
+- `ocr`: one of the local or vendor OCR configuration objects below.
+- `pdf_handler`: an optional `PDFHandler` implementation. Use it only to replace the PDF reading/rendering layer or manage that layer in your application.
+- `models_cache_path` and `local_only`: convenience settings for the default local DeepSeek OCR configuration when `ocr` is not supplied. They must not be combined with an explicit `ocr` configuration.
+
+### `ExtractionOptions`
+
+`ExtractionOptions` controls one extraction operation:
+
+| Field | Default | Meaning |
+| --- | --- | --- |
+| `page_indexes` | `None` | A container of one-based page numbers to process. |
+| `ocr_size` | `"gundam"` | OCR preset; valid values depend on the backend. |
+| `dpi` | `None` | Page-rendering DPI; the underlying default is used when omitted. |
+| `max_page_image_file_size` | `None` | Maximum rendered-image size per page. |
+| `max_ocr_tokens` | `None` | Cumulative OCR input-plus-output token budget. |
+| `max_ocr_output_tokens` | `None` | Cumulative OCR output-token budget. |
+| `includes_cover` | `False` | Retain a recognized cover image. |
+| `includes_footnotes` | `False` | Request and retain footnotes. |
+| `generate_plot` | `False` | Generate plot-related package assets. |
+| `toc_assumed` | `False` | Treat the document as already having usable TOC information. |
+| `toc_llm` | `None` | LLM used when TOC analysis is needed. |
+| `ignore_pdf_errors` | `False` | `True` or a predicate that decides whether a PDF error may be skipped. |
+| `ignore_ocr_errors` | `False` | `True` or a predicate that decides whether an OCR error may be skipped. |
+| `aborted` | a callback returning `False` | A callback checked during processing to request cancellation. |
+| `on_ocr_event` | no-op callback | Receives per-page `OCREvent` updates. |
+
+### OCR configurations
+
+All OCR configuration objects are immutable dataclasses and are passed to `PDFOptions(ocr=...)`.
+
+| Class | Required fields | Optional fields |
+| --- | --- | --- |
+| `DeepSeekOCRLocalConfig` | none | `models_cache_path`, `local_only`, `enable_devices_numbers` |
+| `DeepSeekOCR2LocalConfig` | none | `models_cache_path`, `local_only`, `enable_devices_numbers` |
+| `UnlimitedOCRLocalConfig` | none | `models_cache_path`, `local_only`, `enable_devices_numbers` |
+| `DeepSeekOCRVendorConfig` | `base_url`, `api_key`, `model` | `temperature`, `top_p`, `max_tokens=8000`, `timeout_seconds=180` |
+| `DeepSeekOCR2VendorConfig` | `base_url`, `api_key`, `model` | `temperature`, `top_p`, `max_tokens=8000`, `timeout_seconds=180` |
+| `UnlimitedOCRVendorConfig` | `ak`, `sk` | `base_url="https://aip.baidubce.com"`, `poll_interval_seconds=2.0`, `timeout_seconds=180` |
+
+See [OCR backends](OCR_BACKENDS.md) for model origin, runtime requirements, and selection guidance.
+
+## Transformations and submission modes
+
+`SubmitKind` determines how transformed text is incorporated:
+
+- `SubmitKind.REPLACE`: replace source text.
+- `SubmitKind.APPEND_TEXT`: append translated text to the same text flow.
+- `SubmitKind.APPEND_BLOCK`: append translated content as a separate block. It is not supported for PDF patching.
+
+`TranslationStep(transformer, mode=SubmitKind.REPLACE)` is used in `steps=` for PDF conversion and `translate_pdf()`. A transformer can be a `ChapterTransformer` with `transform(chapter)`, or the public package-transformer shape described below.
+
+The following classes are exposed for applications that need custom structured transformations:
+
+| Type | Role |
+| --- | --- |
+| `ChapterXMLTransformer` | Adapts XML-oriented work to chapter transformation. |
+| `ChapterPackageTransformer` | Applies a chapter transformer across a package and writes a new package. |
+| `PackageTransformer` | Public protocol for `transform(package, output_path) -> DocumentPackage`. |
+| `XMLTranslator` | XML-aware translation engine for integrations that need direct structured translation. |
+| `FillFailedEvent` | Information passed to EPUB XML-repair failure callbacks. |
+
+## `LLM`
+
+`LLM` configures an OpenAI-compatible Chat Completions client used for text translation and TOC analysis:
+
+```python
+LLM(
+    key,
+    url,
+    model,
+    token_encoding,
+    timeout=None,
+    top_p=None,
+    temperature=None,
+    retry_times=5,
+    retry_interval_seconds=6.0,
+    cache_path=None,
+    log_dir_path=None,
+)
+```
+
+`key`, `url`, `model`, and `token_encoding` are required. `temperature` and `top_p` may be numbers or ranges used while retrying. Successful requests can be reused through `cache_path`; `log_dir_path` records request and cache events. OCR credentials do not configure this object.
+
+## PDF patching primitives
+
+For patch layout beyond the convenience methods, use these public types:
+
+```python
+from pdf_craft import PDFPatcher, PDFTranslationPipeline, PatchTextOptions
+
+patcher = PDFPatcher(options=PatchTextOptions(
+    font_name="STSong-Light",
+    max_font_size=14,
+    min_font_size=5,
+    alignment="left",
+    horizontal_padding=1,
+    vertical_padding=1,
+    overflow="error",
+))
+pipeline = PDFTranslationPipeline(patcher=patcher)
+```
+
+`PatchTextOptions` controls text fitting. `overflow="error"` (the default) stops if translated text cannot fit; `overflow="skip"` records skipped replacements in `PDFPatcher.skipped_replacements`. `PDFReplacement` and `PDFSkippedReplacement` describe individual patch outcomes.
+
+`PDFTranslationPipeline` can perform lower-level translation or patching when the application owns the complete layout and output lifecycle. Prefer `PDFCraft.translate_pdf()` and `PDFCraft.patch_pdf_with_package()` when their fixed layout policy is sufficient.
+
+## Other useful exports
+
+- `DocumentPackage` represents a validated extracted or transformed document package; use `DocumentPackage.from_path(path)` to open one saved on disk.
+- `PDFExtractor`, `MarkdownRenderer`, and `EpubRenderer` are the component-level extraction and rendering APIs behind the façade.
+- `OCRTokensMetering` exposes `input_tokens` and `output_tokens`.
+- `OCREvent` and `OCREventKind` support per-page progress and diagnostics.
+- `predownload_models(...)` prepares local OCR models before an offline `local_only=True` run.
+- `PDFError`, `OCRError`, and `InterruptedError` are exported error types for application-level handling.
+
+For complete workflows, start with [PDF conversion and translation](PDF_TRANSLATION.md) or [EPUB translation](EPUB_TRANSLATION.md), rather than composing internal modules.

--- a/docs/en/EPUB_TRANSLATION.md
+++ b/docs/en/EPUB_TRANSLATION.md
@@ -1,0 +1,170 @@
+# EPUB translation
+
+pdf-craft can translate an existing EPUB directly. This workflow reads the book's chapters, table of contents, and translatable metadata, then writes a new EPUB. It does not use OCR and does not require a PDF configuration.
+
+Use it for either a target-language edition or a bilingual edition that retains the original text.
+
+## Minimal example
+
+Configure a text LLM that exposes an OpenAI-compatible Chat Completions endpoint, then choose a target language and submission mode.
+
+```python
+from pdf_craft import LLM, PDFCraft, SubmitKind
+
+llm = LLM(
+    key="your-api-key",
+    url="https://api.openai.com/v1",
+    model="gpt-4.1-mini",
+    token_encoding="o200k_base",
+)
+
+PDFCraft().translate_epub(
+    "source.epub",
+    "translated.epub",
+    target_language="zh",
+    submit=SubmitKind.APPEND_BLOCK,
+    llm=llm,
+)
+```
+
+`target_language` accepts a language code or a language name, such as `"zh"`, `"en"`, or `"Japanese"`. `LLM` holds the endpoint, model, credential, and token-encoding details for the text service. It is separate from the OCR configuration used by PDF workflows.
+
+## Pick the reading experience first
+
+`submit` controls how translated chapter text is incorporated into the book.
+
+| Mode | Result | Best for |
+| --- | --- | --- |
+| `SubmitKind.REPLACE` | Replaces the original with the translation. | A target-language-only edition. |
+| `SubmitKind.APPEND_TEXT` | Adds the translation directly after the original in the same text flow. | Compact bilingual reading. |
+| `SubmitKind.APPEND_BLOCK` | Adds the translation as a separate block after the original. | Side-by-side-in-sequence bilingual reading; usually the clearest choice. |
+
+For example:
+
+```python
+# A Chinese-only edition.
+PDFCraft().translate_epub(
+    "source.epub", "book.zh.epub",
+    target_language="zh", submit=SubmitKind.REPLACE, llm=llm,
+)
+
+# A bilingual edition with visibly separate original and translated paragraphs.
+PDFCraft().translate_epub(
+    "source.epub", "book.bilingual.zh.epub",
+    target_language="zh", submit=SubmitKind.APPEND_BLOCK, llm=llm,
+)
+```
+
+The table of contents and translatable book metadata are translated too. Their structure cannot safely gain separate blocks, so `APPEND_BLOCK` is treated as inline append for those two areas while chapter bodies retain the requested block layout.
+
+## Configure the text LLM
+
+`LLM` is a declarative configuration object. Common options are:
+
+| Field | Meaning |
+| --- | --- |
+| `key` | Provider API key. |
+| `url` | OpenAI-compatible base URL. |
+| `model` | Model identifier accepted by that endpoint. |
+| `token_encoding` | Encoding used to count input tokens, for example `o200k_base`. |
+| `timeout` | Per-request timeout in seconds. |
+| `temperature`, `top_p` | Sampling controls. |
+| `retry_times`, `retry_interval_seconds` | Retry policy for transport failures or empty replies. |
+| `cache_path` | Directory for successful text-request cache entries. |
+| `log_dir_path` | Directory for request and cache logs. |
+
+```python
+llm = LLM(
+    key="your-api-key",
+    url="https://your-provider.example/v1",
+    model="your-translation-model",
+    token_encoding="o200k_base",
+    timeout=120,
+    retry_times=5,
+    retry_interval_seconds=6,
+    cache_path="translation-cache",
+)
+```
+
+The default `retry_times=5` means up to five retries after the first request. Cache entries are retained only for successful requests, allowing a rerun to reuse finished translation work. Give unrelated books or translation jobs separate cache directories so they are easier to inspect and discard.
+
+## Tune translation behavior
+
+`translate_epub()` accepts the following options in addition to the required paths, language, and submission mode:
+
+```python
+PDFCraft().translate_epub(
+    "source.epub",
+    "translated.epub",
+    target_language="fr",
+    submit=SubmitKind.APPEND_BLOCK,
+    llm=llm,
+    user_prompt=(
+        "Use formal written French. Preserve proper names, technical terms, "
+        "and footnote numbers."
+    ),
+    max_group_tokens=2600,
+    concurrency=4,
+)
+```
+
+- `user_prompt` adds project-specific requirements such as terminology or tone. It supplements rather than replaces pdf-craft's structural instructions.
+- `max_group_tokens` defaults to `2600`. Larger groups make fewer, larger requests and increase the cost of retrying a failed request.
+- `concurrency` defaults to `1`. Increase it gradually only after confirming the provider's rate limits and cost behavior. Output order remains stable.
+- `max_retries` controls XML structure-repair attempts and defaults to `5`. It is distinct from `LLM.retry_times`, which controls text-request retries.
+
+### Use separate translation and repair models
+
+The same LLM handles prose translation and XML structure repair when only `llm` is provided. If those jobs need different models or sampling settings, provide `translation_llm` and `fill_llm` instead:
+
+```python
+translation_llm = LLM(
+    key="your-api-key", url="https://example.com/v1",
+    model="translation-model", token_encoding="o200k_base", temperature=0.7,
+)
+fill_llm = LLM(
+    key="your-api-key", url="https://example.com/v1",
+    model="structure-model", token_encoding="o200k_base", temperature=0.2,
+)
+
+PDFCraft().translate_epub(
+    "source.epub", "translated.epub",
+    target_language="zh", submit=SubmitKind.APPEND_BLOCK,
+    translation_llm=translation_llm, fill_llm=fill_llm,
+)
+```
+
+Supply `llm`, or supply both specialized configurations. A translation-only configuration is not enough because the pipeline must also be able to repair malformed translated XML.
+
+## Observe progress and structural failures
+
+`on_progress` receives a value from `0.0` to `1.0` as work completes. Chapter work receives most of the weight; a present table of contents and translatable metadata each receive five percent.
+
+`on_fill_failed` receives `FillFailedEvent` when an XML repair attempt fails. The final event with `over_maximum_retries=True` signals that no repair attempts remain and the output may need inspection.
+
+```python
+from pdf_craft import FillFailedEvent
+
+def show_progress(value: float) -> None:
+    print(f"{value:.0%}")
+
+def report_fill_failure(event: FillFailedEvent) -> None:
+    if event.over_maximum_retries:
+        print(f"Unrecovered EPUB structure error: {event.error_message}")
+
+PDFCraft().translate_epub(
+    "source.epub", "translated.epub",
+    target_language="zh", submit=SubmitKind.APPEND_BLOCK,
+    llm=llm, on_progress=show_progress, on_fill_failed=report_fill_failure,
+)
+```
+
+## Input and output expectations
+
+- Use a readable EPUB input and a different output path.
+- The pipeline follows the EPUB spine and preserves the package's required `mimetype` entry.
+- Technical metadata such as identifiers, dates, language markers, `meta`, and contributor fields is not sent to the LLM. Other text metadata may be translated.
+- The current implementation requires a recognizable table-of-contents file. An EPUB with a TOC file but no entries can proceed; one with no recognizable TOC fails instead of silently skipping that stage.
+- An unrecoverable error means the destination should not be treated as a complete translation. Inspect the callback report and any `log_dir_path` output, then rerun to a fresh output path.
+
+For endpoint, cache, or empty-response errors, see [Troubleshooting](TROUBLESHOOTING.md).

--- a/docs/en/INSTALLATION.md
+++ b/docs/en/INSTALLATION.md
@@ -1,0 +1,79 @@
+# Installation Guide
+
+This guide is for users of the Python library. Start with the standard package unless you deliberately want OCR models to run on your own NVIDIA GPU.
+
+## Choose an installation
+
+For vendor OCR, install:
+
+```bash
+python -m pip install pdf-craft
+```
+
+Vendor OCR uses a remote service, so CUDA is not required locally. You will still need the provider URL, model name, and credentials in your Python configuration.
+
+For local OCR on a CUDA-capable NVIDIA GPU, install the local extra instead:
+
+```bash
+python -m pip install "pdf-craft[local]"
+```
+
+The extra supplies the Python runtime for local models. It does not choose a PyTorch wheel for your platform. Install a CUDA-compatible PyTorch build that matches your Python version, driver, and operating system. If you are unsure, use vendor OCR.
+
+## Requirements
+
+- Python `>=3.11,<3.14`
+- Poppler for PDF conversion and the standard PDF translation/patch workflow
+- Network and valid credentials for vendor OCR
+- A CUDA-capable NVIDIA GPU, matching PyTorch, model storage, and adequate VRAM for local OCR
+
+Using a virtual environment is recommended:
+
+```bash
+python3.11 -m venv .venv
+source .venv/bin/activate  # macOS / Linux
+# Windows PowerShell: .venv\Scripts\Activate.ps1
+python -m pip install --upgrade pip
+python -m pip install pdf-craft
+```
+
+## Install Poppler
+
+```bash
+# macOS
+brew install poppler
+
+# Debian / Ubuntu
+sudo apt-get update && sudo apt-get install poppler-utils
+```
+
+On Windows, install a Poppler binary distribution and add its `bin` directory to `PATH`. Alternatively, configure `DefaultPDFHandler(poppler_path="C:/tools/poppler/bin")` through `PDFOptions`.
+
+Check the installation with `pdfinfo -v`.
+
+## Local OCR setup
+
+Run `nvidia-smi` to confirm that the NVIDIA driver and GPU are visible. Then use the [PyTorch installation selector](https://pytorch.org/get-started/locally/) to install an appropriate CUDA build. Confirm it with:
+
+```bash
+python -c "import torch; print(torch.__version__); print(torch.cuda.is_available())"
+```
+
+Local OCR requires `True`. Models download on first use by default. To pre-download a model and later run without downloads:
+
+```python
+from pdf_craft import DeepSeekOCRLocalConfig, PDFCraft, PDFOptions, predownload_models
+
+predownload_models(ocr=DeepSeekOCRLocalConfig(models_cache_path="models"))
+craft = PDFCraft(pdf=PDFOptions(ocr=DeepSeekOCRLocalConfig(
+    models_cache_path="models", local_only=True,
+)))
+```
+
+## Verify the package
+
+```bash
+python -c "import pdf_craft; print(pdf_craft.__file__)"
+```
+
+This verifies installation only; it does not download a model or call an OCR service. See the [OCR Backend Guide](OCR_BACKENDS.md) for runtime configuration and [Troubleshooting](TROUBLESHOOTING.md) for common setup failures.

--- a/docs/en/OCR_BACKENDS.md
+++ b/docs/en/OCR_BACKENDS.md
@@ -1,0 +1,61 @@
+# OCR Backend Guide
+
+Choose one OCR configuration for each PDF extraction. Local backends run models on a CUDA-capable NVIDIA GPU; vendor backends send pages to a remote service. Use local OCR for local or offline processing after models are cached. Use vendor OCR when you do not have CUDA or prefer managed compute.
+
+DeepSeek OCR and DeepSeek OCR 2 are from [DeepSeek](https://github.com/deepseek-ai/DeepSeek-OCR); [Unlimited OCR](https://github.com/baidu/Unlimited-OCR) is from Baidu.
+
+| Configuration | Model | Runtime |
+| --- | --- | --- |
+| `DeepSeekOCRLocalConfig` | DeepSeek OCR | Local GPU |
+| `DeepSeekOCR2LocalConfig` | DeepSeek OCR 2 | Local GPU |
+| `UnlimitedOCRLocalConfig` | Unlimited OCR | Local GPU |
+| `DeepSeekOCRVendorConfig` | DeepSeek OCR | OpenAI-compatible remote service |
+| `DeepSeekOCR2VendorConfig` | DeepSeek OCR 2 | OpenAI-compatible remote service |
+| `UnlimitedOCRVendorConfig` | Unlimited OCR | Baidu remote service |
+
+Pass a configuration through `PDFOptions(ocr=...)`; the library does not load `.env` files.
+
+## Local backends
+
+All three local configurations accept `models_cache_path`, `local_only`, and `enable_devices_numbers`.
+
+```python
+from pdf_craft import DeepSeekOCRLocalConfig, PDFCraft, PDFOptions
+
+craft = PDFCraft(pdf=PDFOptions(ocr=DeepSeekOCRLocalConfig(
+    models_cache_path="models-cache",
+    enable_devices_numbers=[0],
+)))
+```
+
+`local_only=True` prevents a missing model from downloading. Use it only after the model is present in the selected cache. Device numbers are interpreted by the upstream OCR runtime and normally correspond to CUDA devices visible to the process.
+
+`ocr_size` belongs to `ExtractionOptions`, not the OCR configuration. Unlimited OCR local supports `base` and `gundam`. DeepSeek OCR 2 local is validated with `base`; explicit `tiny` is rejected before extraction.
+
+## Vendor backends
+
+DeepSeek vendor configurations take `base_url`, `api_key`, and `model`; they also accept `temperature`, `top_p`, `max_tokens` (default `8000`), and `timeout_seconds` (default `180`).
+
+```python
+from pdf_craft import DeepSeekOCRVendorConfig, PDFCraft, PDFOptions
+
+craft = PDFCraft(pdf=PDFOptions(ocr=DeepSeekOCRVendorConfig(
+    base_url="https://example.com/v1",
+    api_key="your-api-key",
+    model="deepseek-ocr",
+)))
+```
+
+`UnlimitedOCRVendorConfig` takes Baidu `ak` and `sk`; its `base_url` defaults to `https://aip.baidubce.com`. It also accepts `poll_interval_seconds` and `timeout_seconds`.
+
+```python
+from pdf_craft import UnlimitedOCRVendorConfig
+
+ocr = UnlimitedOCRVendorConfig(ak="your-access-key", sk="your-secret-key")
+```
+
+## Convenience defaults
+
+When `PDFOptions` has no explicit `ocr`, `models_cache_path` and `local_only` configure the default local DeepSeek OCR setup. Do not combine either convenience field with an explicit `ocr` configuration; that is rejected because the ownership of those settings would be ambiguous.
+
+OCR recognizes pages only. Text translation uses a separate LLM configuration; see the PDF and EPUB guides.

--- a/docs/en/PDF_TRANSLATION.md
+++ b/docs/en/PDF_TRANSLATION.md
@@ -1,0 +1,175 @@
+# PDF conversion and translation
+
+This guide covers workflows that start with a PDF: converting it to Markdown or EPUB, translating while converting, and placing translated text back onto the pages of the original PDF. For translating an EPUB you already have, see [EPUB translation](EPUB_TRANSLATION.md).
+
+## Choose the workflow that fits the result you need
+
+| Goal | Start here | What it produces |
+| --- | --- | --- |
+| Convert a PDF once | `convert_pdf_to_markdown()` or `convert_pdf_to_epub()` | Markdown or EPUB |
+| Translate as the PDF is converted | Pass `TranslationStep` items to either conversion method | Translated Markdown or EPUB |
+| Keep, inspect, or reuse OCR output | `extract_pdf()`, then render or translate the returned package | A durable `DocumentPackage` directory |
+| Produce a translated PDF | `translate_pdf()` or `patch_pdf_with_package()` | A new PDF with translated text over the source pages |
+
+For a one-off conversion, use the two `convert_pdf_to_*` methods. They extract the PDF, apply any requested transformation, and render the final file. Use the lower-level steps only when you need a persistent intermediate package or need to control each stage separately.
+
+All PDF extraction requires a configured `PDFCraft` instance. The OCR configuration is independent of the text LLM used for translation.
+
+```python
+from pdf_craft import DeepSeekOCRVendorConfig, PDFCraft, PDFOptions
+
+craft = PDFCraft(pdf=PDFOptions(
+    ocr=DeepSeekOCRVendorConfig(
+        base_url="https://example.com/v1",
+        api_key="your-api-key",
+        model="deepseek-ocr",
+    ),
+))
+```
+
+See [OCR backends](OCR_BACKENDS.md) for choosing and configuring an OCR backend.
+
+## Convert a PDF to Markdown
+
+```python
+metering = craft.convert_pdf_to_markdown("book.pdf", "book.md")
+print(metering.input_tokens, metering.output_tokens)
+```
+
+The return value records OCR input and output tokens for the run. By default, pdf-craft creates a temporary `DocumentPackage` workspace and removes it on success or failure. If you want to inspect OCR XML, reuse it for another output format, or retain it after an error, provide `package_path` yourself:
+
+```python
+craft.convert_pdf_to_markdown(
+    "book.pdf",
+    "book.md",
+    package_path="work/book-package",
+    assets_path="output/assets",
+)
+```
+
+`assets_path` controls where Markdown images and other extracted assets are written. A caller-supplied package directory is persistent and is the caller's responsibility to manage.
+
+## Convert a PDF to EPUB
+
+The EPUB conversion path uses the same extraction pipeline and adds EPUB metadata and rendering choices.
+
+```python
+from epub_generator import BookMeta
+
+craft.convert_pdf_to_epub(
+    "book.pdf",
+    "book.epub",
+    book_meta=BookMeta(title="A Book", authors=["Author"]),
+    lan="en",
+)
+```
+
+If `book_meta` is omitted, pdf-craft attempts to read metadata from the source PDF. The remaining EPUB options are useful when the default rendering is not appropriate:
+
+| Option | Purpose |
+| --- | --- |
+| `lan` | Content language: `"zh"` or `"en"`. |
+| `table_render` | An `epub_generator.TableRender` mode such as `HTML` or `CLIPPING`. |
+| `latex_render` | An `epub_generator.LaTeXRender` mode such as `MATHML`, `SVG`, or `CLIPPING`. |
+| `inline_latex` | Keep inline LaTeX expressions; defaults to `True`. |
+
+## Translate during conversion
+
+`TranslationStep` inserts a chapter transformation before Markdown or EPUB rendering. The transformer is supplied by your application; it is responsible for calling a text model and returning the transformed chapter.
+
+```python
+from pdf_craft import SubmitKind, TranslationStep
+
+# translator implements transform(chapter).
+translation = TranslationStep(translator, mode=SubmitKind.REPLACE)
+
+craft.convert_pdf_to_markdown(
+    "book.pdf",
+    "book.zh.md",
+    steps=[translation],
+)
+```
+
+Use `SubmitKind.REPLACE` for a target-language-only document. `APPEND_TEXT` appends translated text to the same text flow, while `APPEND_BLOCK` adds separate translated blocks, which is generally the clearer bilingual layout for Markdown and EPUB. Multiple steps run in list order. Advanced applications may also pass a public `PackageTransformer` as a step.
+
+## Work explicitly with a DocumentPackage
+
+A `DocumentPackage` is pdf-craft's on-disk, render-ready representation of an extracted document: chapters, assets, OCR metadata, and page geometry live together in one directory. It is intended for durable intermediate results, not as a separate plugin protocol.
+
+Use an explicit package when the same extraction must feed more than one output, or when translation is a distinct operation:
+
+```python
+package = craft.extract_pdf("book.pdf", "work/book-package")
+
+translated = craft.translate_package(
+    package,
+    "work/book-package-zh",
+    translator,
+    submit=SubmitKind.REPLACE,
+)
+craft.render_markdown(translated, "book.zh.md", assets_path="output/assets")
+craft.render_epub(translated, "book.zh.epub", lan="zh")
+```
+
+`extract_pdf()` deliberately requires a package path: its result is meant to survive after the method returns. `translate_package()` creates a new package at `output_path`; it does not overwrite the source package.
+
+## Translate and patch a PDF
+
+To create a translated PDF, first extract the source and then ask pdf-craft to translate and patch it:
+
+```python
+package = craft.extract_pdf("book.pdf", "work/book-package")
+
+craft.translate_pdf(
+    "book.pdf",
+    package,
+    "book.zh.pdf",
+    translator,
+)
+```
+
+The `transformer` may be a chapter transformer or a simple `Callable[[str], str]` for text-only translation:
+
+```python
+def translate_text(text: str) -> str:
+    return call_your_llm(text)
+
+craft.translate_pdf("book.pdf", package, "book.zh.pdf", translate_text)
+```
+
+If translation happened elsewhere, call `patch_pdf_with_package()` instead. It runs neither OCR nor an LLM; it uses the translated package's page geometry to patch the source PDF.
+
+```python
+craft.patch_pdf_with_package(
+    "book.pdf",
+    "work/book-package-zh",
+    "book.zh.pdf",
+)
+```
+
+### What PDF patching can and cannot preserve
+
+PDF patching is a page-overlay workflow, not a general-purpose PDF layout engine. Each source page is rendered as an image and translated text is placed over its OCR bounding boxes. The output therefore does not retain the source PDF's selectable vector text, links, annotations, or other page objects. It replaces text and subtitle layouts only; tables and images are not translated in place.
+
+The source PDF and package must match. The package needs page geometry for every chapter page and its page numbers must be valid for the source file. `APPEND_BLOCK` is rejected for PDF output because new block-level content cannot safely be added to a fixed page. Text that cannot fit its original bounding box fails before a partial output PDF is left behind.
+
+For custom fonts, fit rules, alignment, padding, or overflow handling, use the lower-level public `PDFPatcher`, `PatchTextOptions`, and `PDFTranslationPipeline` APIs described in the [API reference](API_REFERENCE.md).
+
+## Extraction controls
+
+Pass `ExtractionOptions` through the `extraction=` argument to tune a single extraction run:
+
+```python
+from pdf_craft import ExtractionOptions
+
+options = ExtractionOptions(
+    page_indexes={1, 2, 3},
+    dpi=250,
+    includes_cover=True,
+)
+craft.convert_pdf_to_markdown("book.pdf", "sample.md", extraction=options)
+```
+
+Useful controls include `page_indexes` (one-based page numbers), `dpi`, `ocr_size`, OCR token limits, cover and footnote inclusion, and `on_ocr_event` for per-page observability. `ignore_pdf_errors` and `ignore_ocr_errors` can allow a long document to continue past selected failures, but a completed run still needs output review: skipped pages are not successfully recognized pages.
+
+For errors involving Poppler, cache paths, local CUDA, or vendor credentials, see [Troubleshooting](TROUBLESHOOTING.md).

--- a/docs/en/TROUBLESHOOTING.md
+++ b/docs/en/TROUBLESHOOTING.md
@@ -1,0 +1,105 @@
+# Troubleshooting
+
+When a real conversion fails, first identify the layer: PDF reading and rendering, OCR, text LLM translation, output rendering, or PDF/EPUB patching. OCR configuration and text-LLM configuration are separate; a working OCR service does not prove that translation credentials are valid.
+
+## Quick diagnosis
+
+| Symptom | Check first |
+| --- | --- |
+| `Poppler not found in PATH` | Install Poppler and make its commands visible to the process. |
+| Local OCR cannot use CUDA | NVIDIA driver, CUDA-enabled PyTorch, visible GPU, and `pdf-craft[local]`. |
+| Local OCR cannot find a model | Cache path, disk space, and `local_only`. |
+| Vendor OCR returns an error | Endpoint, model, credential, network access, quota, and rate limits. |
+| EPUB/PDF translation reports an LLM error | Text LLM URL, model, key, and token encoding. |
+| No output file appears | Parent-directory permissions and the earlier exception. |
+| PDF patching rejects a package | The original PDF, page geometry, and translated package must correspond. |
+
+## PDF and Poppler
+
+### `Poppler not found in PATH`
+
+pdf-craft uses Poppler to render PDF pages as images before OCR. This is required for both local and vendor OCR, so changing OCR backends does not solve the error.
+
+Run `pdfinfo -v` in the same environment that runs Python. If it is unavailable, install Poppler, add its executable directory to `PATH`, and restart the shell or process. The [installation guide](INSTALLATION.md) includes platform-specific commands.
+
+If a PDF fails to open or only selected pages fail, verify that it opens in an ordinary PDF reader and that the current user can read it. Password protection, corrupt cross-reference data, unusual page dimensions, and malformed PDFs can all fail during rendering.
+
+`ExtractionOptions(ignore_pdf_errors=True)` can let a long job continue past individual PDF errors. A predicate can make that decision selectively. It is a recovery tool, not proof that skipped pages were processed correctly; inspect the resulting document.
+
+## Local OCR
+
+### Missing local runtime or no CUDA
+
+The base package intentionally does not install local GPU dependencies. Install the local extra in the environment that runs the code:
+
+```bash
+python -m pip install 'pdf-craft[local]'
+```
+
+Then check the GPU in that same interpreter:
+
+```bash
+nvidia-smi
+python -c "import torch; print(torch.cuda.is_available())"
+```
+
+`torch.cuda.is_available()` must be true for local OCR. If it is false, verify that you installed a CUDA-enabled PyTorch build rather than a CPU-only wheel, that the NVIDIA driver sees the GPU, and that the process/container has access to it. On a machine without usable CUDA, switch to a vendor configuration rather than repeatedly changing local OCR parameters.
+
+### Model download, cache, and offline use
+
+The first local run may download a model. Confirm that `models_cache_path` is writable, the machine has sufficient disk space, and the process can reach the model host. `local_only=True` forbids downloads; it is valid only after the entire model already exists in the selected cache.
+
+If a download was interrupted, remove or isolate the incomplete model cache entry and download again, or use a new cache directory. Use `predownload_models(...)` before deploying an offline environment. Do not combine `PDFOptions(models_cache_path=..., local_only=...)` with an explicit `ocr=` configuration; put those settings on the local OCR config instead.
+
+### Preset, memory, and page scope
+
+OCR presets differ by backend. Unlimited OCR local supports `base` and `gundam`. DeepSeek OCR 2 local is validated with `base`; an explicit `tiny` preset is rejected before model execution and should be changed to `base`.
+
+For out-of-memory errors or very slow runs, first process a small sample with `ExtractionOptions(page_indexes={1})`, then lower `dpi` or choose a suitable OCR preset. `page_indexes` uses one-based page numbers. Reducing the page range is usually a better diagnostic than assuming the input file is damaged.
+
+`max_ocr_tokens` limits cumulative OCR input and output tokens; `max_ocr_output_tokens` limits output tokens only. Hitting either limit stops later pages rather than producing a complete document. Higher limits can increase vendor charges or local resource use.
+
+### Find the page that failed
+
+Use `on_ocr_event` to record the page index, event kind, timing, and tokens. `START`, `RENDERED`, `COMPLETE`, `FAILED`, `SKIP`, and `IGNORE` distinguish a page that was not selected, reused from cache, failed to render, or failed in OCR.
+
+`ignore_ocr_errors=True` (or a predicate) permits later pages to continue after an OCR failure. Check the corresponding output pages afterward. If an `aborted` callback requests cancellation, the underlying extraction aborts; a token budget is a separate interruption condition. Capture the actual exception and the recent OCR events when diagnosing either case.
+
+## Vendor OCR
+
+Vendor OCR consumes remote provider resources and does not require a local GPU. Authentication errors such as 401 or 403 usually mean the endpoint, model, and credential do not belong to the same provider account, or the key lacks permission. Do not substitute a text-LLM key for an OCR credential.
+
+For timeouts, rate limits, or quota failures, verify endpoint reachability and check the provider account's balance, quota, and rate-limit status. Start with a one-page extraction to distinguish a bad page from a service-wide issue.
+
+DeepSeek OCR vendor configurations use OpenAI-compatible `base_url`, `api_key`, and `model` fields. Baidu Unlimited OCR uses `ak` and `sk`, with its own polling and timeout settings. Those credential formats are not interchangeable. See [OCR backends](OCR_BACKENDS.md) for the exact configuration fields.
+
+## Text LLM and translation
+
+Existing-EPUB translation needs `llm`, or both `translation_llm` and `fill_llm`. PDF OCR credentials do not automatically provide a text translation model. `translation_llm` produces translated text; `fill_llm` repairs EPUB XML when necessary.
+
+`LLM` expects an OpenAI-compatible Chat Completions endpoint. Check that `url` is the provider's base URL, `model` is available to the key, and `token_encoding` matches the model. Empty model replies are retried and eventually raise an empty-response error; correcting an invalid model name or endpoint is more useful than simply increasing retries.
+
+For EPUB XML-repair problems, register `on_fill_failed` and pay particular attention to an event with `over_maximum_retries=True`. Lowering concurrency, shortening a custom prompt, or choosing a model that reliably returns structured content is often more effective than unlimited retries. See [EPUB translation](EPUB_TRANSLATION.md) for the callback API.
+
+When `LLM(cache_path=...)` is used, successful requests can be reused after an interruption. Use separate cache directories for unrelated books or jobs, particularly while they may be writing concurrently. A rerun still creates a new EPUB output; it does not resume by appending to an incomplete destination file.
+
+## Outputs, package paths, and PDF patching
+
+`convert_pdf_to_markdown()` and `convert_pdf_to_epub()` use a temporary package directory when `package_path` is omitted, and clean it up in both success and exception paths. Pass a writable package path if you need OCR artifacts for debugging or reuse; pdf-craft will not delete that caller-owned directory.
+
+If an output is absent, make sure its parent directory exists and is writable, then work backward to the first OCR, translation, or renderer exception. A partially created output is not a successful conversion.
+
+PDF patching requires the original PDF plus a package extracted from that same document. The package must include the relevant page geometry, and translated text must fit the original OCR bounding boxes. Patch output is rendered from page images, so it does not preserve source vector text, annotations, or links. `APPEND_BLOCK` is unsupported for PDF patching because it cannot add free-flowing content to a fixed page.
+
+## What to include in a bug report
+
+Provide enough context to reproduce the failure without exposing secrets:
+
+- operating system, Python version, and pdf-craft version;
+- OCR backend and whether it is local or vendor;
+- for local OCR: GPU model and `torch.cuda.is_available()` result;
+- input page or chapter count, and the workflow stage that failed;
+- full exception type and message, redacted of credentials and private content;
+- relevant `package_path`, model-cache path, or LLM-cache path choices.
+
+Do not attach API keys, complete private documents, model caches, or unredacted logs to a public issue.

--- a/references/release-workflow.md
+++ b/references/release-workflow.md
@@ -12,7 +12,7 @@ Agent 的工作应聚焦于准备仓库内的发版前置条件。发版准备�
 
 对于目标版本 `X.Y.Z`，准备仓库时要确保以下事实成立：
 
-- [pyproject.toml](../pyproject.toml) 中有 `tool.poetry.version = "X.Y.Z"`。
+- [pyproject.toml](../pyproject.toml) 中的 `[project].version` 为 `"X.Y.Z"`。
 - `docs/changelog/vX.Y.Z.md` 存在，并包含发布说明。
 - 变更日志应包含简洁摘要；在有帮助时按类别组织变更；在可取得时链接相关 PR 或 issue；并包含完整变更日志的 compare 链接。
 - 发版准备变更应先通过普通 PR 流程审查，再从 `main` 运行手动发版工作流。


### PR DESCRIPTION
## Summary

- Complete all six English advanced guides under `docs/en/`
- Rewrite the documentation for native English readers rather than translating sentence by sentence
- Cover installation, OCR backend selection, PDF conversion and translation, EPUB translation, public API usage, and troubleshooting
- Align the release workflow reference with the current `[project].version` field in `pyproject.toml`

## Verification

- `git diff --check`
- Cross-checked public API names and signatures against `pdf_craft`
- Verified internal documentation links between the English guides
