### PR TITLE
fix: skip empty chapters during translation

### DIFF
--- a/docs/changelog/v2.0.1.md
+++ b/docs/changelog/v2.0.1.md
@@ -1,0 +1,8 @@
+# PDF Craft v2.0.1
+
+## Fixes
+
+- Skip empty OCR chapters during translation instead of failing with `Translation failed unexpectedly`.
+- Add regression coverage for translating document packages that contain empty pages or chapters.
+
+**Full Changelog**: https://github.com/oomol-lab/pdf-craft/compare/v2.0.0...v2.0.1

--- a/pdf_craft/transformer/chapter_xml.py
+++ b/pdf_craft/transformer/chapter_xml.py
@@ -2,6 +2,7 @@ from typing import Protocol
 from xml.etree.ElementTree import Element
 
 from pdf_craft.extractor.chapter.chapter import Chapter, decode, encode
+from pdf_craft.transformer.xml_translator.segment import search_text_segments
 from .xml_translator.xml_translator import SubmitKind, TranslationTask
 
 
@@ -25,7 +26,13 @@ class ChapterXMLTransformer:
         return ChapterXMLTransformer(self._translator, mode)
 
     def transform(self, chapter: Chapter) -> Chapter:
+        element = encode(chapter)
+        # OCR can produce chapters for pages that contain no translatable text.
+        # Keep those chapters intact instead of asking XMLTranslator to process
+        # an empty stream, which otherwise raises "Translation failed unexpectedly".
+        if not any(segment.text.strip() for segment in search_text_segments(element)):
+            return chapter
         translated, _ = self._translator.translate_element(
-            TranslationTask(element=encode(chapter), action=self._mode, payload=chapter)
+            TranslationTask(element=element, action=self._mode, payload=chapter)
         )
         return decode(translated)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "poetry.core.masonry.api"
 
 [project]
 name = "pdf-craft"
-version = "2.0.0"
+version = "2.0.1"
 description = "PDF craft can convert PDF files into various other formats. This project will focus on processing PDF files of scanned books."
 license = {text = "MIT"}
 authors = [{name = "Tao Zeyu", email = "i@taozeyu.com"}]

--- a/tests/test_composable_boundaries.py
+++ b/tests/test_composable_boundaries.py
@@ -3,15 +3,16 @@ import unittest
 from pathlib import Path
 from unittest.mock import patch
 from typing import cast
+from xml.etree.ElementTree import tostring
 from PIL import Image
 
 from pdf_craft.document import DocumentPackage
 from pdf_craft.extractor import PDFExtractor
 from pdf_craft.pipeline.pdf.pipeline import PDFTranslationPipeline
 from pdf_craft.pipeline.pdf import PDFPatcher
-from pdf_craft.transformer import ChapterXMLTransformer
+from pdf_craft.transformer import ChapterPackageTransformer, ChapterXMLTransformer
 from pdf_craft.renderer import EpubRenderer, MarkdownRenderer
-from pdf_craft.extractor.chapter.chapter import BlockLayout, Chapter, InlineExpression, ParagraphLayout, Reference
+from pdf_craft.extractor.chapter.chapter import BlockLayout, Chapter, InlineExpression, ParagraphLayout, Reference, encode
 from pdf_craft.expression import ExpressionKind
 from pdf_craft.ocr_config import DeepSeekOCRLocalConfig
 from pdf_craft.pdf.ocr import OCR
@@ -79,7 +80,11 @@ class _FakeHandler:
 
 
 class _DeterministicXMLTranslator:
+    def __init__(self):
+        self.calls = 0
+
     def translate_element(self, task, **_kwargs):
+        self.calls += 1
         for node in task.element.iter():
             if node.text:
                 node.text = "T:" + node.text
@@ -89,6 +94,38 @@ class _DeterministicXMLTranslator:
 
 
 class TestComposableBoundaries(unittest.TestCase):
+    def test_package_translation_skips_empty_chapters(self):
+        with tempfile.TemporaryDirectory() as directory:
+            root = Path(directory)
+            source = DocumentPackage.from_path(root / "source")
+            source.chapters_path.mkdir(parents=True)
+            source.assets_path.mkdir()
+            source.write_metadata(page_pixel_sizes={1: (100, 100)})
+            empty = Chapter(None, 0, [])
+            text = Chapter(None, 0, [ParagraphLayout(
+                "text", 0, [BlockLayout(1, 1, (1, 1, 50, 50), ["text"])]
+            )])
+            (source.chapters_path / "chapter_1.xml").write_text(
+                '<?xml version="1.0" encoding="UTF-8"?>\n'
+                + tostring(encode(empty), encoding="unicode")
+            )
+            (source.chapters_path / "chapter_2.xml").write_text(
+                '<?xml version="1.0" encoding="UTF-8"?>\n'
+                + tostring(encode(text), encoding="unicode")
+            )
+
+            translator = _DeterministicXMLTranslator()
+            target = ChapterPackageTransformer(
+                ChapterXMLTransformer(translator)
+            ).transform(source, root / "target")
+
+            self.assertEqual(translator.calls, 1)
+            self.assertEqual(
+                (target.chapters_path / "chapter_1.xml").read_text(),
+                (source.chapters_path / "chapter_1.xml").read_text(),
+            )
+            self.assertIn("T:text", (target.chapters_path / "chapter_2.xml").read_text())
+
     def test_extractor_creates_empty_assets_directory_for_asset_free_pages(self):
         with tempfile.TemporaryDirectory() as directory:
             root = Path(directory)


### PR DESCRIPTION
## Summary

- Skip OCR chapters with no translatable text instead of raising `Translation failed unexpectedly`
- Add a package-level regression test covering an empty chapter alongside a translated chapter
- Bump the package version to `2.0.1`
- Add the `v2.0.1` changelog entry required by the release workflow

## Verification

- `poetry check --lock`
- `poetry run python -m unittest tests.test_composable_boundaries`
- `poetry run pyright pdf_craft tests`
- `poetry run pylint pdf_craft tests`
- `poetry build`
- `git diff --check`
