### PR TITLE
fix: reject extraction with no usable OCR pages

### DIFF
--- a/pdf_craft/__init__.py
+++ b/pdf_craft/__init__.py
@@ -4,6 +4,7 @@ from .error import (
     IgnoreOCRErrorsChecker,
     IgnorePDFErrorsChecker,
     InterruptedError,
+    NoUsableOCRPagesError,
     OCRError,
     PDFError,
 )

--- a/pdf_craft/error.py
+++ b/pdf_craft/error.py
@@ -16,6 +16,18 @@ class OCRError(Exception):
         self.step_index: int = step_index
 
 
+class NoUsableOCRPagesError(Exception):
+    """Raised when every requested OCR page failed after errors were ignored."""
+
+    def __init__(self, failed_page_indexes: tuple[int, ...]) -> None:
+        self.failed_page_indexes = failed_page_indexes
+        pages = ", ".join(str(index) for index in failed_page_indexes)
+        super().__init__(
+            "OCR produced no usable pages; all requested pages failed after "
+            f"errors were ignored: {pages}"
+        )
+
+
 def is_inline_error(error: Exception) -> bool:
     return isinstance(error, (PDFError, OCRError))
 

--- a/pdf_craft/pdf/ocr.py
+++ b/pdf_craft/pdf/ocr.py
@@ -90,7 +90,8 @@ class OCR:
 
         done_path = ocr_path / "done"
         did_ignore_any: bool = False
-        if done_path.exists():
+        did_fail_any: bool = False
+        if done_path.exists() and not any(ocr_path.glob("page_*.failed")):
             return
 
         remain_tokens: int | None = max_tokens
@@ -124,8 +125,9 @@ class OCR:
 
                 filename = f"page_{ref.page_index}.xml"
                 file_path = ocr_path / filename
+                failure_path = ocr_path / f"page_{ref.page_index}.failed"
 
-                if file_path.exists():
+                if file_path.exists() and not failure_path.exists():
                     elapsed_ms = int((time.perf_counter() - start_time) * 1000)
                     yield OCREvent(
                         kind=OCREventKind.SKIP,
@@ -191,6 +193,14 @@ class OCR:
                             image=image,
                         )
 
+                    if recognized_error is not None:
+                        did_fail_any = True
+                        failure_path.write_text(
+                            type(recognized_error).__name__, encoding="utf-8"
+                        )
+                    else:
+                        failure_path.unlink(missing_ok=True)
+
                     save_xml(encode(page), file_path)
                     self._save_page_pixel_sizes(geometry_path)
 
@@ -216,7 +226,7 @@ class OCR:
                     if remain_output_tokens is not None:
                         remain_output_tokens -= page.output_tokens
 
-        if not did_ignore_any:
+        if not did_ignore_any and not did_fail_any:
             done_path.touch()
 
     @property

--- a/pdf_craft/transform.py
+++ b/pdf_craft/transform.py
@@ -3,11 +3,16 @@ from os import PathLike
 from pathlib import Path
 
 from .common import remove_surrogates
-from .error import IgnoreOCRErrorsChecker, IgnorePDFErrorsChecker, PDFError
+from .error import (
+    IgnoreOCRErrorsChecker,
+    IgnorePDFErrorsChecker,
+    NoUsableOCRPagesError,
+    PDFError,
+)
 from .llm import LLM
 from .metering import AbortedCheck, OCRTokensMetering
 from .ocr_config import OCRConfig, ensure_ocr_config
-from .pdf import DeepSeekOCRSize, OCR, OCREvent, PDFHandler
+from .pdf import DeepSeekOCRSize, OCR, OCREvent, OCREventKind, PDFHandler
 from .extractor.chapter import generate_chapter_files
 from .extractor.toc import analyse_toc
 from .document import DocumentPackage
@@ -66,6 +71,8 @@ class PDFExtractionEngine:
         cover_path: Path | None = analysing_path / "cover.png" if includes_cover else None
         plot_path: Path | None = analysing_path / "plots" if generate_plot else None
         metering = OCRTokensMetering(input_tokens=0, output_tokens=0)
+        usable_pages = 0
+        failed_page_indexes: list[int] = []
         existing_page_pixel_sizes = DocumentPackage.from_path(analysing_path).page_pixel_sizes()
 
         for event in self._ocr.recognize(
@@ -88,6 +95,13 @@ class PDFExtractionEngine:
             on_ocr_event(event)
             metering.input_tokens += event.input_tokens
             metering.output_tokens += event.output_tokens
+            if event.kind in (OCREventKind.COMPLETE, OCREventKind.SKIP):
+                usable_pages += 1
+            elif event.kind == OCREventKind.FAILED:
+                failed_page_indexes.append(event.page_index)
+
+        if failed_page_indexes and usable_pages == 0:
+            raise NoUsableOCRPagesError(tuple(failed_page_indexes))
 
         toc = analyse_toc(
             pages_path=pages_path,

--- a/tests/test_composable_boundaries.py
+++ b/tests/test_composable_boundaries.py
@@ -7,6 +7,7 @@ from xml.etree.ElementTree import tostring
 from PIL import Image
 
 from pdf_craft.document import DocumentPackage
+from pdf_craft.error import NoUsableOCRPagesError, OCRError
 from pdf_craft.extractor import PDFExtractor
 from pdf_craft.pipeline.pdf.pipeline import PDFTranslationPipeline
 from pdf_craft.pipeline.pdf import PDFPatcher
@@ -15,9 +16,10 @@ from pdf_craft.renderer import EpubRenderer, MarkdownRenderer
 from pdf_craft.extractor.chapter.chapter import BlockLayout, Chapter, InlineExpression, ParagraphLayout, Reference, encode
 from pdf_craft.expression import ExpressionKind
 from pdf_craft.ocr_config import DeepSeekOCRLocalConfig
-from pdf_craft.pdf.ocr import OCR
+from pdf_craft.pdf.ocr import OCR, OCREvent, OCREventKind
 from pdf_craft.pdf.handler import PDFHandler
 from pdf_craft.pdf.types import Page
+from pdf_craft.transform import PDFExtractionEngine
 
 
 class _FakeTransform:
@@ -46,6 +48,19 @@ class _CapturePatcher:
 
     def patch(self, _source, _target, replacements):
         self.replacements = list(replacements)
+
+
+class _AllPagesFailOCR:
+    last_page_pixel_sizes: dict[int, tuple[int, int]] = {}
+
+    def recognize(self, **_kwargs):
+        for page_index in (1, 2):
+            yield OCREvent(
+                OCREventKind.FAILED,
+                page_index,
+                2,
+                error=OCRError("vendor rejected the request", page_index, 0),
+            )
 
 
 class _FakeDocument:
@@ -94,6 +109,37 @@ class _DeterministicXMLTranslator:
 
 
 class TestComposableBoundaries(unittest.TestCase):
+    def test_extraction_rejects_all_pages_ignored_after_ocr_failures(self):
+        with tempfile.TemporaryDirectory() as directory:
+            root = Path(directory)
+            engine = object.__new__(PDFExtractionEngine)
+            setattr(engine, "_ocr", cast(OCR, _AllPagesFailOCR()))
+
+            with patch("pdf_craft.transform.analyse_toc") as analyse_toc, self.assertRaisesRegex(
+                NoUsableOCRPagesError, "no usable pages"
+            ) as raised:
+                engine.extract_package(
+                    pdf_path=root / "input.pdf",
+                    analysing_path=root / "package",
+                    ocr_size="gundam",
+                    dpi=None,
+                    max_page_image_file_size=None,
+                    includes_cover=False,
+                    includes_footnotes=False,
+                    ignore_pdf_errors=False,
+                    ignore_ocr_errors=True,
+                    generate_plot=False,
+                    toc_llm=None,
+                    toc_assumed=False,
+                    aborted=lambda: False,
+                    max_tokens=None,
+                    max_output_tokens=None,
+                    on_ocr_event=lambda _: None,
+                )
+
+            self.assertEqual(raised.exception.failed_page_indexes, (1, 2))
+            analyse_toc.assert_not_called()
+
     def test_package_translation_skips_empty_chapters(self):
         with tempfile.TemporaryDirectory() as directory:
             root = Path(directory)
@@ -212,6 +258,32 @@ class TestComposableBoundaries(unittest.TestCase):
             list(resumed.recognize(root / "input.pdf", root / "assets", root / "ocr"))
             self.assertEqual(resumed.last_page_pixel_sizes, {1: (100, 100)})
             self.assertEqual(handler.document.render_count, 1)
+
+    def test_ignored_ocr_failure_is_retried_instead_of_cached_as_success(self):
+        with tempfile.TemporaryDirectory() as directory:
+            root = Path(directory)
+            handler = _FakeHandler()
+            first = OCR(DeepSeekOCRLocalConfig(local_only=True), cast(PDFHandler, handler))
+            error = OCRError("vendor rejected the request", 1, 0)
+            with patch(
+                "pdf_craft.pdf.ocr.PageExtractorNode.image2page", side_effect=error
+            ):
+                events = list(first.recognize(
+                    root / "input.pdf", root / "assets", root / "ocr", ignore_ocr_errors=True
+                ))
+            self.assertEqual(events[-1].kind, OCREventKind.FAILED)
+            self.assertTrue((root / "ocr" / "page_1.failed").exists())
+            self.assertFalse((root / "ocr" / "done").exists())
+
+            page = Page(1, None, [], [], 0, 0)
+            resumed = OCR(DeepSeekOCRLocalConfig(local_only=True), cast(PDFHandler, handler))
+            with patch("pdf_craft.pdf.ocr.PageExtractorNode.image2page", return_value=page):
+                events = list(resumed.recognize(
+                    root / "input.pdf", root / "assets", root / "ocr", ignore_ocr_errors=True
+                ))
+            self.assertEqual(events[-1].kind, OCREventKind.COMPLETE)
+            self.assertFalse((root / "ocr" / "page_1.failed").exists())
+            self.assertTrue((root / "ocr" / "done").exists())
 
     def test_package_rejects_malformed_page_geometry(self):
         with tempfile.TemporaryDirectory() as directory:


### PR DESCRIPTION
## Summary

- Raise `NoUsableOCRPagesError` when ignored OCR failures leave an extraction with no usable pages
- Stop before TOC analysis, chapter generation, translation, or rendering in that case
- Keep ignored failed pages out of the successful OCR cache so a later run retries them
- Add regression coverage for all-pages-failed extraction and recovery after an ignored failure

## Verification

- `poetry run python -m unittest tests.test_composable_boundaries`
- `poetry run pyright pdf_craft tests`
- `poetry run pylint pdf_craft tests`
- `git diff --check`
