### PR TITLE
收敛翻译 API：移除 on_progress 与 steps

### DIFF
--- a/README.md
+++ b/README.md
@@ -107,16 +107,16 @@ If `book_meta` is omitted, pdf-craft tries to read the metadata from the source 
 
 ### PDF → translated Markdown or EPUB
 
-To translate while converting, pass a `TranslationStep` to either conversion method.
-The `translator` is a chapter transformer: it sends chapter text to your text LLM and
-returns the translated chapter. The same step can be used for Markdown and EPUB output.
+To translate while converting, pass one chapter `translator` to either conversion method.
+The translator sends chapter text to your text LLM and returns the translated chapter.
 
 ```python
-from pdf_craft import TranslationStep
-
-translation = TranslationStep(translator)
-craft.convert_pdf_to_markdown("input.pdf", "translated.md", steps=[translation])
-craft.convert_pdf_to_epub("input.pdf", "translated.epub", steps=[translation])
+craft.convert_pdf_to_markdown(
+    "input.pdf", "translated.md", translator=translator,
+)
+craft.convert_pdf_to_epub(
+    "input.pdf", "translated.epub", translator=translator,
+)
 ```
 
 ### PDF → translated PDF

--- a/README_zh-CN.md
+++ b/README_zh-CN.md
@@ -112,20 +112,15 @@ craft.convert_pdf_to_epub(
 
 ### 转换 PDF 时同时翻译
 
-如果你希望 PDF 在转换为 Markdown 或 EPUB 的同时完成翻译，可以给转换方法增加翻译步骤。
-`translator` 是一个章节翻译器，负责把章节文字交给文本 LLM 并返回译文；准备好它以后，
-用 `TranslationStep` 将翻译步骤传给转换方法。同一个翻译步骤可以用于两种输出格式：
+如果你希望 PDF 在转换为 Markdown 或 EPUB 的同时完成翻译，可以直接传入一个章节翻译器。
+`translator` 负责把章节文字交给文本 LLM 并返回译文：
 
 ~~~python
-from pdf_craft import TranslationStep
-
-translation = TranslationStep(translator)
-
 craft.convert_pdf_to_markdown(
-    "input.pdf", "translated.md", steps=[translation],
+    "input.pdf", "translated.md", translator=translator,
 )
 craft.convert_pdf_to_epub(
-    "input.pdf", "translated.epub", steps=[translation],
+    "input.pdf", "translated.epub", translator=translator,
 )
 ~~~
 

--- a/docs/en/API_REFERENCE.md
+++ b/docs/en/API_REFERENCE.md
@@ -22,8 +22,8 @@ craft = PDFCraft(pdf=PDFOptions(ocr=your_ocr_config))
 | `extract_pdf_with_metering` | `extract_pdf_with_metering(source, package_path, options=None) -> tuple[DocumentPackage, OCRTokensMetering]` is the same extraction with OCR token accounting. |
 | `render_markdown` | `render_markdown(package, output, assets_path=None, *, aborted=...)` writes Markdown and optional assets. |
 | `render_epub` | `render_epub(package, output, *, book_meta=None, lan="zh", table_render=..., latex_render=..., inline_latex=True, aborted=...)` writes an EPUB. |
-| `convert_pdf_to_markdown` | `convert_pdf_to_markdown(source, output, *, package_path=None, extraction=None, assets_path=None, steps=(), on_translation_event=None) -> OCRTokensMetering` is the one-shot PDF-to-Markdown workflow. |
-| `convert_pdf_to_epub` | `convert_pdf_to_epub(source, output, *, package_path=None, extraction=None, book_meta=None, lan="zh", table_render=..., latex_render=..., inline_latex=True, steps=(), on_translation_event=None) -> OCRTokensMetering` is the one-shot PDF-to-EPUB workflow. |
+| `convert_pdf_to_markdown` | `convert_pdf_to_markdown(source, output, *, package_path=None, extraction=None, assets_path=None, translator=None, submit=SubmitKind.REPLACE, on_translation_event=None) -> OCRTokensMetering` is the one-shot PDF-to-Markdown workflow. |
+| `convert_pdf_to_epub` | `convert_pdf_to_epub(source, output, *, package_path=None, extraction=None, book_meta=None, lan="zh", table_render=..., latex_render=..., inline_latex=True, translator=None, submit=SubmitKind.REPLACE, on_translation_event=None) -> OCRTokensMetering` is the one-shot PDF-to-EPUB workflow. |
 
 The two `convert_pdf_to_*` methods clean up their temporary package workspace when `package_path` is omitted. Give `package_path` when you need to retain the package. `render_epub` accepts `epub_generator.BookMeta`, `TableRender`, and `LaTeXRender` values for output customization.
 
@@ -32,7 +32,7 @@ The two `convert_pdf_to_*` methods clean up their temporary package workspace wh
 | Method | Signature and purpose |
 | --- | --- |
 | `translate_package` | `translate_package(package, output_path, translator, *, submit=SubmitKind.REPLACE, on_translation_event=None) -> DocumentPackage` translates a package into a new package. `translator` is a chapter transformer. |
-| `translate_pdf` | `translate_pdf(source, package, output, transformer, *, steps=(), on_translation_event=None)` translates then patches text onto the source PDF. `transformer` may be a chapter transformer or `Callable[[str], str]`. |
+| `translate_pdf` | `translate_pdf(source, package, output, transformer, *, on_translation_event=None)` translates then patches text onto the source PDF. `transformer` may be a chapter transformer or `Callable[[str], str]`. |
 | `patch_pdf_with_package` | `patch_pdf_with_package(source, package, output)` patches a source PDF from a `DocumentPackage` or package path without OCR or LLM calls. |
 | `translate_epub` | `translate_epub(source, output, *, target_language, submit, **options)` translates an existing EPUB. See [EPUB translation](EPUB_TRANSLATION.md) for its options. |
 
@@ -93,8 +93,6 @@ See [OCR backends](OCR_BACKENDS.md) for model origin, runtime requirements, and 
 - `SubmitKind.APPEND_TEXT`: append translated text to the same text flow.
 - `SubmitKind.APPEND_BLOCK`: append translated content as a separate block. It is not supported for PDF patching.
 
-`TranslationStep(transformer, mode=SubmitKind.REPLACE)` is used in `steps=` for PDF conversion and `translate_pdf()`. A transformer can be a `ChapterTransformer` with `transform(chapter)`, or the public package-transformer shape described below.
-
 The following classes are exposed for applications that need custom structured transformations:
 
 | Type | Role |
@@ -110,7 +108,7 @@ Translation workflows also accept `on_translation_event`, a callback receiving
 `ITEM_COMPLETE`, `PROGRESS`, and `COMPLETE`; `TranslationItemKind` identifies TOC,
 metadata, or chapter items. Character counts are source-text character counts and
 are not token counts or percentages. The same event callback is available for
-EPUB translation, package translation, PDF translation, and PDF conversion steps.
+EPUB translation, package translation, PDF translation, and PDF conversion.
 
 ## `LLM`
 

--- a/docs/en/EPUB_TRANSLATION.md
+++ b/docs/en/EPUB_TRANSLATION.md
@@ -141,16 +141,16 @@ Supply `llm`, or supply both specialized configurations. A translation-only conf
 `on_translation_event` receives low-level `TranslationEvent` values as the translation
 scope and its TOC, metadata, and chapter items progress. Character counts are based on
 source text and are not token-based percentages. The same callback is supported by
-package and PDF translation workflows. The legacy `on_progress` float callback is kept
-only for compatibility.
+package and PDF translation workflows.
 
 `on_fill_failed` receives `FillFailedEvent` when an XML repair attempt fails. The final event with `over_maximum_retries=True` signals that no repair attempts remain and the output may need inspection.
 
 ```python
-from pdf_craft import FillFailedEvent
+from pdf_craft import FillFailedEvent, TranslationEventKind
 
-def show_progress(value: float) -> None:
-    print(f"{value:.0%}")
+def on_translation_event(event):
+    if event.kind == TranslationEventKind.PROGRESS:
+        print(event.completed_characters, event.total_characters)
 
 def report_fill_failure(event: FillFailedEvent) -> None:
     if event.over_maximum_retries:
@@ -159,7 +159,8 @@ def report_fill_failure(event: FillFailedEvent) -> None:
 PDFCraft().translate_epub(
     "source.epub", "translated.epub",
     target_language="zh", submit=SubmitKind.APPEND_BLOCK,
-    llm=llm, on_progress=show_progress, on_fill_failed=report_fill_failure,
+    llm=llm, on_translation_event=on_translation_event,
+    on_fill_failed=report_fill_failure,
 )
 ```
 

--- a/docs/en/PDF_TRANSLATION.md
+++ b/docs/en/PDF_TRANSLATION.md
@@ -7,11 +7,11 @@ This guide covers workflows that start with a PDF: converting it to Markdown or 
 | Goal | Start here | What it produces |
 | --- | --- | --- |
 | Convert a PDF once | `convert_pdf_to_markdown()` or `convert_pdf_to_epub()` | Markdown or EPUB |
-| Translate as the PDF is converted | Pass `TranslationStep` items to either conversion method | Translated Markdown or EPUB |
+| Translate as the PDF is converted | Pass one `translator` to either conversion method | Translated Markdown or EPUB |
 | Keep, inspect, or reuse OCR output | `extract_pdf()`, then render or translate the returned package | A durable `DocumentPackage` directory |
 | Produce a translated PDF | `translate_pdf()` or `patch_pdf_with_package()` | A new PDF with translated text over the source pages |
 
-For a one-off conversion, use the two `convert_pdf_to_*` methods. They extract the PDF, apply any requested transformation, and render the final file. Use the lower-level steps only when you need a persistent intermediate package or need to control each stage separately.
+For a one-off conversion, use the two `convert_pdf_to_*` methods. They extract the PDF, optionally translate it once, and render the final file. Use the lower-level package APIs only when you need a persistent intermediate package or need to control each stage separately.
 
 All PDF extraction requires a configured `PDFCraft` instance. The OCR configuration is independent of the text LLM used for translation.
 
@@ -75,22 +75,21 @@ If `book_meta` is omitted, pdf-craft attempts to read metadata from the source P
 
 ## Translate during conversion
 
-`TranslationStep` inserts a chapter transformation before Markdown or EPUB rendering. The transformer is supplied by your application; it is responsible for calling a text model and returning the transformed chapter.
+Pass one chapter translator before Markdown or EPUB rendering. The translator is supplied by your application; it is responsible for calling a text model and returning the transformed chapter.
 
 ```python
-from pdf_craft import SubmitKind, TranslationStep
+from pdf_craft import SubmitKind
 
 # translator implements transform(chapter).
-translation = TranslationStep(translator, mode=SubmitKind.REPLACE)
-
 craft.convert_pdf_to_markdown(
     "book.pdf",
     "book.zh.md",
-    steps=[translation],
+    translator=translator,
+    submit=SubmitKind.REPLACE,
 )
 ```
 
-Use `SubmitKind.REPLACE` for a target-language-only document. `APPEND_TEXT` appends translated text to the same text flow, while `APPEND_BLOCK` adds separate translated blocks, which is generally the clearer bilingual layout for Markdown and EPUB. Multiple steps run in list order. Advanced applications may also pass a public `PackageTransformer` as a step.
+Use `SubmitKind.REPLACE` for a target-language-only document. `APPEND_TEXT` appends translated text to the same text flow, while `APPEND_BLOCK` adds separate translated blocks, which is generally the clearer bilingual layout for Markdown and EPUB. The high-level conversion methods perform at most one translation; advanced applications that need additional package transformations should compose the lower-level package APIs explicitly.
 
 ## Work explicitly with a DocumentPackage
 

--- a/docs/zh-CN/API_REFERENCE.md
+++ b/docs/zh-CN/API_REFERENCE.md
@@ -12,7 +12,7 @@ from pdf_craft import PDFCraft, PDFOptions
 `pdf_craft` 包顶层导出常用类型。最主要的入口是 `PDFCraft`，它把 PDF 提取、渲染、
 翻译和 PDF 写回组合成一组方法。下面这些对象可直接从 `pdf_craft` 导入：
 
-- `PDFCraft`、`PDFOptions`、`ExtractionOptions`、`TranslationStep`
+- `PDFCraft`、`PDFOptions`、`ExtractionOptions`
 - `DocumentPackage`、`PDFExtractor`
 - 六种 OCR 配置对象和 `OCRConfig`
 - `predownload_models`
@@ -165,7 +165,7 @@ craft.convert_pdf_to_epub(
 两个方法都返回 `OCRTokensMetering`。`convert_pdf_to_markdown` 另接受 `assets_path`，
 用于把渲染出的图片资源写到指定目录；EPUB 的 `lan`、`table_render`、`latex_render` 和
 `inline_latex` 控制 EPUB 输出格式。
-两个方法都可以通过 `on_translation_event` 接收 `steps` 中翻译变换产生的底层事件。
+两个方法都可以通过 `translator` 和 `on_translation_event` 在转换时完成一次翻译。
 
 ### 从已有 package 渲染
 
@@ -183,13 +183,15 @@ craft.render_epub(
 章节、目录、封面和调用时提供的 `book_meta`。`document.json` 的页面几何元数据不参与 EPUB
 渲染，但 PDF 写回需要它。
 
-### PDF 转换时应用翻译步骤
+### PDF 转换时翻译
 
-`TranslationStep` 把章节级或 package 级变换插入渲染前：
+PDF 转换入口可以传入一个章节翻译器和提交模式，在渲染前完成一次翻译：
 
 ```python
-translation = TranslationStep(translator, mode=SubmitKind.REPLACE)
-craft.convert_pdf_to_markdown("input.pdf", "translated.md", steps=[translation])
+craft.convert_pdf_to_markdown(
+    "input.pdf", "translated.md", translator=translator,
+    submit=SubmitKind.REPLACE,
+)
 ```
 
 自定义章节变换器可以实现 `ChapterTransformer` 协议：
@@ -203,10 +205,8 @@ def accepts_transformer(transformer: ChapterTransformer) -> None:
 
 这是低层协议：章节的具体 XML/布局对象不从包顶层导出。需要由文本 LLM 完成章节翻译时，
 请使用下一节的 `XMLTranslator` 和 `ChapterXMLTransformer` 组合，而不是自行猜测章节内部
-结构。也可以传入实现 `transform(package, output_path) -> DocumentPackage` 的 package
-transformer。多个步骤按列表顺序执行，每一步产生新的 package。`SubmitKind.REPLACE`、
-`SubmitKind.APPEND_TEXT` 和 `SubmitKind.APPEND_BLOCK` 的含义取决于变换器；PDF 写回仅拒绝
-`APPEND_BLOCK`。
+结构。`SubmitKind.REPLACE`、`SubmitKind.APPEND_TEXT` 和 `SubmitKind.APPEND_BLOCK` 的
+含义取决于变换器；PDF 写回仅拒绝 `APPEND_BLOCK`。
 
 ### 翻译并写回 PDF
 
@@ -258,7 +258,7 @@ package 可以重复渲染、翻译或写回；使用一键 `convert_pdf_to_*` �
 ### ChapterTransformer
 
 章节变换器实现一个 `transform(chapter) -> chapter` 方法。它可以修改章节文本、段落或布局，
-并被 `TranslationStep`、`translate_package` 和 `translate_pdf` 使用。实现该低层协议时，需从
+并被 `translate_package` 和 `translate_pdf` 使用。实现该低层协议时，需从
 它的实际定义处导入 `Chapter`：
 
 ```python
@@ -292,14 +292,13 @@ def transform(package: DocumentPackage, output_path: Path) -> DocumentPackage:
 
 `XMLTranslator` 是包顶层导出的结构化文本翻译器。它需要分别提供翻译文本和修复 XML
 结构的 LLM；同一个 `LLM` 可以同时承担两项工作。将它包装为 `ChapterXMLTransformer` 后，
-即可作为 `TranslationStep` 的 `transformer`：
+即可作为 `translator` 传给 PDF 转换或 package 翻译入口：
 
 ```python
 from pdf_craft import (
     ChapterXMLTransformer,
     LLM,
     SubmitKind,
-    TranslationStep,
     XMLTranslator,
 )
 
@@ -319,15 +318,15 @@ xml_translator = XMLTranslator(
     max_fill_displaying_errors=10,
     max_group_score=2600,
 )
-translation = TranslationStep(
-    ChapterXMLTransformer(xml_translator),
-    mode=SubmitKind.REPLACE,
+translator = ChapterXMLTransformer(xml_translator)
+craft.convert_pdf_to_markdown(
+    "input.pdf", "translated.md", translator=translator,
+    submit=SubmitKind.REPLACE,
 )
-craft.convert_pdf_to_markdown("input.pdf", "translated.md", steps=[translation])
 ```
 
 `translation_llm` 负责生成译文，`fill_llm` 负责在必要时修复 XML 结构。两个 LLM 可以使用
-不同的模型、提示参数、缓存或重试策略。若目标是双语 Markdown 或 EPUB，可把步骤模式设为
+不同的模型、提示参数、缓存或重试策略。若目标是双语 Markdown 或 EPUB，可把提交模式设为
 `APPEND_TEXT` 或 `APPEND_BLOCK`；PDF 不支持 `APPEND_BLOCK`，而 `APPEND_TEXT` 虽可使用，
 但需要为双语文本的版面溢出承担处理成本，因此通常推荐 `REPLACE`。
 
@@ -361,7 +360,7 @@ PDFCraft().translate_epub(
 
 `REPLACE` 只输出译文，`APPEND_TEXT` 在原文后追加内联译文，`APPEND_BLOCK` 追加独立译文
 块，适合双语阅读。`translate_epub` 还支持 `user_prompt`、`max_retries`、`max_group_tokens`、
-`concurrency`、`translation_llm`、`fill_llm`、`on_progress` 和 `on_fill_failed`；完整行为
+`concurrency`、`translation_llm`、`fill_llm`、`on_translation_event` 和 `on_fill_failed`；完整行为
 和回调字段请参阅 EPUB 翻译专题文档。
 
 对于不需要保留 `PDFCraft` 实例的 EPUB-only 程序，也可直接从顶层导入同一能力：

--- a/docs/zh-CN/EPUB_TRANSLATION.md
+++ b/docs/zh-CN/EPUB_TRANSLATION.md
@@ -190,7 +190,7 @@ llm = LLM(
 
 `on_translation_event` 接收底层 `TranslationEvent` 事件，报告翻译范围以及 TOC、metadata、
 chapter item 的开始、完成和源文本字符统计。字符统计不是 token，也不是固定比例。相同回调
-也适用于 package 和 PDF 翻译流程。旧的 `on_progress` 浮点回调仅为兼容保留。
+也适用于 package 和 PDF 翻译流程。
 
 `on_fill_failed` 接收 `FillFailedEvent`。它描述 XML 结构修复过程中发生的错误：
 
@@ -201,10 +201,11 @@ chapter item 的开始、完成和源文本字符统计。字符统计不是 tok
   并检查输出。
 
 ~~~python
-from pdf_craft import FillFailedEvent
+from pdf_craft import FillFailedEvent, TranslationEventKind
 
-def on_progress(progress: float) -> None:
-    print(f"翻译进度：{progress:.0%}")
+def on_translation_event(event) -> None:
+    if event.kind == TranslationEventKind.PROGRESS:
+        print(event.completed_characters, event.total_characters)
 
 def on_fill_failed(event: FillFailedEvent) -> None:
     if event.over_maximum_retries:
@@ -215,7 +216,7 @@ PDFCraft().translate_epub(
     target_language="zh",
     submit=SubmitKind.APPEND_BLOCK,
     llm=llm,
-    on_progress=on_progress,
+    on_translation_event=on_translation_event,
     on_fill_failed=on_fill_failed,
 )
 ~~~

--- a/docs/zh-CN/PDF_TRANSLATION.md
+++ b/docs/zh-CN/PDF_TRANSLATION.md
@@ -10,7 +10,7 @@ pdf-craft 的 PDF 能力可以按使用目标分成三类：
 | 目标 | 入口 | 结果 |
 | --- | --- | --- |
 | 直接转换 | `convert_pdf_to_markdown` / `convert_pdf_to_epub` | Markdown 或 EPUB |
-| 转换时翻译 | 在上述入口传入 `steps` | 翻译后的 Markdown 或 EPUB |
+| 转换时翻译 | 在上述入口传入一个 `translator` | 翻译后的 Markdown 或 EPUB |
 | 翻译并写回 PDF | `translate_pdf` | 以源页渲染图为背景、覆盖译文的新 PDF |
 
 如果只是想完成一次转换，优先使用两个 `convert_pdf_to_*` 方法。它们会在内部完成提取、
@@ -88,17 +88,16 @@ craft.convert_pdf_to_markdown(
 
 ### 转换时翻译
 
-通过 `steps` 可以在渲染前对章节内容执行变换。`TranslationStep` 包装一个章节变换器，
-并决定译文以替换方式还是追加方式提交：
+可以在渲染前传入一个章节翻译器，完成一次翻译，并决定译文以替换方式还是追加方式提交：
 
 ```python
-from pdf_craft import SubmitKind, TranslationStep
+from pdf_craft import SubmitKind
 
-translation = TranslationStep(translator, mode=SubmitKind.REPLACE)
 craft.convert_pdf_to_markdown(
     "input.pdf",
     "translated.md",
-    steps=[translation],
+    translator=translator,
+    submit=SubmitKind.REPLACE,
 )
 ```
 
@@ -106,8 +105,8 @@ craft.convert_pdf_to_markdown(
 文本 LLM 并返回修改后的章节。本文只说明 pdf-craft 如何接入变换器；LLM 客户端和具体
 提示词由你的应用负责准备。
 
-`steps` 也可以传入实现 `PackageTransformer` 的变换器。多个步骤会按列表顺序执行；每个
-步骤都会生成独立的变换结果，最后一个结果交给 Markdown 或 EPUB 渲染器。
+高层转换方法只执行一次翻译。需要额外 package 变换或更细粒度控制时，可以使用
+`extract_pdf()`、`translate_package()` 和 `render_*()` 自行组合。
 
 ## PDF 转换为 EPUB
 
@@ -136,7 +135,7 @@ craft.convert_pdf_to_epub(
   `LaTeXRender.CLIPPING`。
 - `inline_latex`：是否保留行内 LaTeX 表达式，默认值为 `True`。
 
-转换时翻译 EPUB 的方式与 Markdown 相同：将 `TranslationStep` 放入 `steps`。已有 EPUB
+转换时翻译 EPUB 的方式与 Markdown 相同：传入一个 `translator`。已有 EPUB
 文件的翻译属于另一条流程，请参考 EPUB 翻译指南。
 
 ## 翻译并写回 PDF
@@ -166,23 +165,7 @@ def translator(text: str) -> str:
 craft.translate_pdf("input.pdf", package, "translated.pdf", translator)
 ```
 
-还可以通过 `steps` 在主翻译完成后继续应用额外的章节或结果目录变换：
-
-```python
-from pdf_craft import TranslationStep
-
-craft.translate_pdf(
-    "input.pdf",
-    package,
-    "translated.pdf",
-    translator,
-    steps=[TranslationStep(additional_transformer)],
-)
-```
-
-步骤按列表顺序执行。PDF 输出不接受 `APPEND_BLOCK` 模式；如果某个 `TranslationStep` 或
-`PackageTransformer` 的模式为 `APPEND_BLOCK`，`translate_pdf` 会在变换开始前抛出
-`ValueError`。
+PDF 输出不接受 `APPEND_BLOCK` 模式，因为 PDF pipeline 不能在原页面中安全追加新的块级内容。
 
 ### PDF 输出的限制
 

--- a/pdf_craft/__init__.py
+++ b/pdf_craft/__init__.py
@@ -9,7 +9,7 @@ from .error import (
     PDFError,
 )
 from .functions import predownload_models
-from .craft import ExtractionOptions, PDFCraft, PDFOptions, TranslationStep
+from .craft import ExtractionOptions, PDFCraft, PDFOptions
 from .pipeline.epub import translate_epub
 from .pipeline.pdf import PDFPatcher, PDFReplacement, PDFSkippedReplacement, PDFTranslationPipeline, PatchTextOptions
 from .transformer import (

--- a/pdf_craft/craft.py
+++ b/pdf_craft/craft.py
@@ -123,7 +123,8 @@ class PDFCraft:
         """
         package_transformer = ChapterPackageTransformer(translator, mode=submit)
         return package_transformer.transform(
-            package, Path(output_path), on_translation_event=on_translation_event
+            package, Path(output_path), on_translation_event=on_translation_event,
+            emit_translation_events=True,
         )
 
     def render_epub(

--- a/pdf_craft/craft.py
+++ b/pdf_craft/craft.py
@@ -1,13 +1,12 @@
 """Public facade that composes pdf-craft's independent components."""
 
-from collections.abc import Callable, Container, Sequence
+from collections.abc import Callable, Container
 from contextlib import contextmanager
 from dataclasses import dataclass
-from inspect import signature
 from os import PathLike
 from pathlib import Path
 from tempfile import TemporaryDirectory
-from typing import Iterator, Literal, cast
+from typing import Iterator, Literal
 
 from epub_generator import BookMeta, LaTeXRender, TableRender
 
@@ -24,18 +23,7 @@ from .pipeline.epub import translate_epub as run_epub_translation
 from .pipeline.pdf import PDFTranslationPipeline
 from .pipeline.pdf.pipeline import _to_patch_text
 from .renderer import EpubRenderer, MarkdownRenderer
-from .transformer import (
-    ChapterPackageTransformer, ChapterTransformer, PackageTransformer, SubmitKind,
-    TranslationEvent,
-)
-
-
-@dataclass(frozen=True)
-class TranslationStep:
-    """A user-requested content transformation inserted before rendering."""
-
-    transformer: ChapterTransformer | PackageTransformer
-    mode: SubmitKind = SubmitKind.REPLACE
+from .transformer import ChapterPackageTransformer, ChapterTransformer, SubmitKind, TranslationEvent
 
 
 @dataclass(frozen=True)
@@ -153,16 +141,11 @@ class PDFCraft:
     def translate_pdf(
         self, source: PathLike | str, package: DocumentPackage,
         output: PathLike | str, transformer: ChapterTransformer | Callable[[str], str],
-        *, steps: Sequence[TranslationStep | PackageTransformer] = (),
-        on_translation_event: Callable[[TranslationEvent], None] | None = None,
+        *, on_translation_event: Callable[[TranslationEvent], None] | None = None,
     ) -> None:
-        for step in steps:
-            mode = _step_mode(step, self._as_package_transformer(step))
-            if mode == SubmitKind.APPEND_BLOCK:
-                raise ValueError("PDF output does not support APPEND_BLOCK")
         with TemporaryDirectory(prefix="pdf-craft-translated-package-") as directory:
             translated = self._translate_for_pdf(
-                package, Path(directory), transformer, steps,
+                package, Path(directory), transformer,
                 on_translation_event=on_translation_event,
             )
             self.patch_pdf_with_package(source, translated, output)
@@ -190,14 +173,17 @@ class PDFCraft:
         self, source: PathLike | str, output: PathLike | str, *,
         package_path: PathLike | str | None = None, extraction: ExtractionOptions | None = None,
         assets_path: PathLike | str | None = None,
-        steps: Sequence[TranslationStep | PackageTransformer] = (),
+        translator: ChapterTransformer | None = None,
+        submit: SubmitKind = SubmitKind.REPLACE,
         on_translation_event: Callable[[TranslationEvent], None] | None = None,
     ) -> OCRTokensMetering:
         with _package_workspace(package_path) as workspace:
             package, metering = self.extract_pdf_with_metering(source, workspace, extraction)
-            package = self._apply_steps(
-                package, steps, on_translation_event=on_translation_event
-            )
+            if translator is not None:
+                package = self.translate_package(
+                    package, workspace / "translated", translator,
+                    submit=submit, on_translation_event=on_translation_event,
+                )
             self.render_markdown(package, output, assets_path,
                                  aborted=(extraction or ExtractionOptions()).aborted)
             return metering
@@ -209,15 +195,18 @@ class PDFCraft:
         table_render: TableRender = TableRender.HTML,
         latex_render: LaTeXRender = LaTeXRender.MATHML,
         inline_latex: bool = True,
-        steps: Sequence[TranslationStep | PackageTransformer] = (),
+        translator: ChapterTransformer | None = None,
+        submit: SubmitKind = SubmitKind.REPLACE,
         on_translation_event: Callable[[TranslationEvent], None] | None = None,
     ) -> OCRTokensMetering:
         extraction = extraction or ExtractionOptions()
         with _package_workspace(package_path) as workspace:
             package, metering = self.extract_pdf_with_metering(source, workspace, extraction)
-            package = self._apply_steps(
-                package, steps, on_translation_event=on_translation_event
-            )
+            if translator is not None:
+                package = self.translate_package(
+                    package, workspace / "translated", translator,
+                    submit=submit, on_translation_event=on_translation_event,
+                )
             if book_meta is None:
                 book_meta = self._extract_book_meta(Path(source))
             self.render_epub(package, output, book_meta=book_meta, lan=lan,
@@ -225,29 +214,11 @@ class PDFCraft:
                              inline_latex=inline_latex, aborted=extraction.aborted)
             return metering
 
-    def _apply_steps(
-        self, package: DocumentPackage,
-        steps: Sequence[TranslationStep | PackageTransformer],
-        *, on_translation_event: Callable[[TranslationEvent], None] | None = None,
-    ) -> DocumentPackage:
-        current = package
-        for index, step in enumerate(steps):
-            transformer = self._as_package_transformer(step)
-            output = package.chapters_path.parent / f"transformed-{index}"
-            if isinstance(transformer, ChapterPackageTransformer):
-                current = transformer.transform(
-                    current, output, on_translation_event=on_translation_event
-                )
-            else:
-                current = transformer.transform(current, output)
-        return current
-
     def _translate_for_pdf(
         self,
         package: DocumentPackage,
         output_root: Path,
         transformer: ChapterTransformer | Callable[[str], str],
-        steps: Sequence[TranslationStep | PackageTransformer],
         *, on_translation_event: Callable[[TranslationEvent], None] | None = None,
     ) -> DocumentPackage:
         current = package
@@ -257,26 +228,7 @@ class PDFCraft:
             current, output_root / "translated", transformer,
             on_translation_event=on_translation_event,
         )
-        if steps:
-            current = self._apply_steps(
-                current, steps, on_translation_event=on_translation_event
-            )
         return current
-
-    @staticmethod
-    def _as_package_transformer(step: TranslationStep | PackageTransformer) -> PackageTransformer:
-        if not isinstance(step, TranslationStep):
-            return step
-        transformer = step.transformer
-        if isinstance(transformer, ChapterPackageTransformer):
-            if step.mode != SubmitKind.REPLACE and transformer.mode != step.mode:
-                return ChapterPackageTransformer(
-                    transformer.chapter_transformer, mode=step.mode
-                )
-            return transformer
-        if _accepts_package(transformer):
-            return cast(PackageTransformer, transformer)
-        return ChapterPackageTransformer(cast(ChapterTransformer, transformer), mode=step.mode)
 
     def _pdf_engine(self):
         if self._engine is not None:
@@ -303,27 +255,6 @@ def _package_workspace(package_path: PathLike | str | None) -> Iterator[Path]:
         return
     with TemporaryDirectory(prefix="pdf-craft-package-") as directory:
         yield Path(directory)
-
-
-def _accepts_package(transformer: ChapterTransformer | PackageTransformer) -> bool:
-    """Recognise the public PackageTransformer method shape explicitly."""
-    try:
-        parameters = list(signature(transformer.transform).parameters.values())
-    except (TypeError, ValueError):
-        return False
-    positional = [
-        parameter for parameter in parameters
-        if parameter.kind in (parameter.POSITIONAL_ONLY, parameter.POSITIONAL_OR_KEYWORD)
-    ]
-    return len(positional) == 2 and [parameter.name for parameter in positional] == [
-        "package", "output_path"
-    ]
-
-
-def _step_mode(step: TranslationStep | PackageTransformer, transformer: PackageTransformer) -> SubmitKind | None:
-    if isinstance(step, TranslationStep):
-        return step.mode if step.mode != SubmitKind.REPLACE else getattr(transformer, "mode", step.mode)
-    return getattr(transformer, "mode", None)
 
 
 class _TextChapterTransformer:

--- a/pdf_craft/pipeline/epub/translation/translator.py
+++ b/pdf_craft/pipeline/epub/translation/translator.py
@@ -51,7 +51,6 @@ def translate(
     llm: LLM | None = None,
     translation_llm: LLM | None = None,
     fill_llm: LLM | None = None,
-    on_progress: Callable[[float], None] | None = None,
     on_translation_event: Callable[[TranslationEvent], None] | None = None,
     on_fill_failed: Callable[[FillFailedEvent], None] | None = None,
 ) -> None:
@@ -90,19 +89,7 @@ def translate(
             metadata_context=metadata_context,
             submit=submit,
         ))
-        total_chapters = sum(
-            task.item_kind == TranslationItemKind.CHAPTER for task in tasks
-        )
-
-        # Calculate weights: TOC (5%), Metadata (5%), Chapters (90%)
-        toc_has_items = len(toc_list) > 0
-        metadata_has_items = len(metadata_fields) > 0
         interrupter = XMLInterrupter()
-        toc_weight = 0.05 if toc_has_items else 0
-        metadata_weight = 0.05 if metadata_has_items else 0
-        chapters_weight = 1.0 - toc_weight - metadata_weight
-        progress_per_chapter = chapters_weight / total_chapters if total_chapters > 0 else 0
-        current_progress = 0.0
 
         for translated_elem, context in translator.translate_elements(
             concurrency=concurrency,
@@ -119,19 +106,11 @@ def translate(
                 if context.toc_context is not None:
                     write_toc(zip, decoded_toc, context.toc_context)
 
-                current_progress += toc_weight
-                if on_progress:
-                    on_progress(current_progress)
-
             elif context.element_type == _ElementType.METADATA:
                 translated_elem = unwrap_french_quotes(translated_elem)
                 decoded_metadata = decode_metadata(translated_elem)
                 if context.metadata_context is not None:
                     write_metadata(zip, decoded_metadata, context.metadata_context)
-
-                current_progress += metadata_weight
-                if on_progress:
-                    on_progress(current_progress)
 
             elif context.element_type == _ElementType.CHAPTER:
                 if context.chapter_data is not None:
@@ -139,10 +118,6 @@ def translate(
                     deduplicate_ids_in_element(xml.element)
                     with zip.replace(chapter_path) as target_file:
                         xml.save(target_file)
-
-                current_progress += progress_per_chapter
-                if on_progress:
-                    on_progress(current_progress)
 
 
 def _generate_tasks_from_book(

--- a/pdf_craft/transformer/package.py
+++ b/pdf_craft/transformer/package.py
@@ -44,6 +44,7 @@ class ChapterPackageTransformer:
         output_path: Path,
         *,
         on_translation_event: Callable[[TranslationEvent], None] | None = None,
+        emit_translation_events: bool = False,
     ) -> DocumentPackage:
         package.validate()
         if output_path.exists():
@@ -66,7 +67,7 @@ class ChapterPackageTransformer:
                 chapter_tasks.append((path, chapter, item_id, character_count))
 
         total_characters = sum(item[3] for item in chapter_tasks)
-        if on_translation_event is not None:
+        if emit_translation_events and on_translation_event is not None:
             on_translation_event(TranslationEvent(
                 kind=TranslationEventKind.START,
                 chapter_count=len(chapter_tasks),
@@ -79,7 +80,7 @@ class ChapterPackageTransformer:
         completed_characters = 0
         for path, chapter, item_id, character_count in chapter_tasks:
             is_xml_transformer = isinstance(self.chapter_transformer, ChapterXMLTransformer)
-            if on_translation_event is not None and not is_xml_transformer:
+            if emit_translation_events and on_translation_event is not None and not is_xml_transformer:
                 on_translation_event(TranslationEvent(
                     kind=TranslationEventKind.ITEM_START,
                     item_kind=TranslationItemKind.CHAPTER,
@@ -88,7 +89,7 @@ class ChapterPackageTransformer:
             if is_xml_transformer:
                 transformed = cast(ChapterXMLTransformer, self.chapter_transformer).transform(
                     chapter,
-                    on_translation_event=on_translation_event,
+                    on_translation_event=on_translation_event if emit_translation_events else None,
                     item_id=item_id,
                     completed_characters=completed_characters,
                     total_characters=total_characters,
@@ -98,7 +99,7 @@ class ChapterPackageTransformer:
                 transformed = self.chapter_transformer.transform(chapter)
             save_xml(encode(transformed), path)
             completed_characters += character_count
-            if on_translation_event is not None and not is_xml_transformer:
+            if emit_translation_events and on_translation_event is not None and not is_xml_transformer:
                 on_translation_event(TranslationEvent(
                     kind=TranslationEventKind.PROGRESS,
                     completed_characters=completed_characters,
@@ -114,7 +115,7 @@ class ChapterPackageTransformer:
 
         if self.toc_transformer is not None and package.toc_path is not None and package.toc_path.exists():
             save_xml(self.toc_transformer(read_xml(output_path / package.toc_path.name)), output_path / package.toc_path.name)
-        if on_translation_event is not None:
+        if emit_translation_events and on_translation_event is not None:
             on_translation_event(TranslationEvent(
                 kind=TranslationEventKind.COMPLETE,
                 completed_characters=completed_characters,

--- a/pdf_craft_tool/smoke/runner.py
+++ b/pdf_craft_tool/smoke/runner.py
@@ -22,7 +22,6 @@ from pdf_craft import (
     PDFCraft,
     PDFOptions,
     SubmitKind,
-    TranslationStep,
     XMLTranslator,
 )
 from pdf_craft.extractor.chapter.chapter import BlockLayout, BlockMember, Chapter, HTMLTag, ParagraphLayout
@@ -258,10 +257,10 @@ def _run_pdf(
     if run.route in {"package-markdown", "markdown"}:
         markdown = output_path / "book.md"
         markdown_assets = Path("assets")
-        steps = _package_steps(run, run_path)
+        transformer = _package_translation(run, run_path)
         with report.stage("render"):
-            if steps:
-                package = _translate_package_steps(craft, package, run_path, steps)
+            if transformer is not None:
+                package = _translate_package(craft, package, run_path, transformer)
             craft.render_markdown(package, markdown, markdown_assets)
         with report.stage("check"):
             errors = check_package(package)
@@ -274,10 +273,10 @@ def _run_pdf(
         return status, errors, details
     if run.route in {"package-epub", "epub"}:
         epub = output_path / "book.epub"
-        steps = _package_steps(run, run_path)
+        transformer = _package_translation(run, run_path)
         with report.stage("render"):
-            if steps:
-                package = _translate_package_steps(craft, package, run_path, steps)
+            if transformer is not None:
+                package = _translate_package(craft, package, run_path, transformer)
             craft.render_epub(package, epub)
         with report.stage("check"):
             errors = check_package(package)
@@ -372,47 +371,36 @@ class _DeterministicChapterTransformer:
         return item
 
 
-def _package_steps(run: SmokeRun, run_path: Path):
+def _package_translation(run: SmokeRun, run_path: Path):
     translation_transformer = _xml_translation_transformer(run, run_path)
     if translation_transformer is not None:
         translation = run.translation or {}
         mode = SubmitKind[translation.get("submit", "REPLACE").upper()]
-        return (TranslationStep(ChapterPackageTransformer(translation_transformer), mode),)
+        return ChapterPackageTransformer(translation_transformer, mode=mode)
 
     translation = run.translation or {}
     marker = translation.get("package_marker")
     if not isinstance(marker, str):
-        return ()
+        return None
     mode = SubmitKind[translation.get("package_submit", "REPLACE").upper()]
-    return (TranslationStep(ChapterPackageTransformer(_DeterministicChapterTransformer(marker)), mode),)
+    return ChapterPackageTransformer(_DeterministicChapterTransformer(marker), mode=mode)
 
 
-def _translate_package_steps(
+def _translate_package(
     craft: PDFCraft,
     package,
     run_path: Path,
-    steps,
+    transformer,
 ):
-    """Run smoke package translations through the public facade method."""
-    current = package
-    for index, step in enumerate(steps):
-        if isinstance(step, TranslationStep):
-            transformer = step.transformer
-            mode = step.mode
-        else:
-            transformer = step
-            mode = getattr(step, "mode", SubmitKind.REPLACE)
-        if not isinstance(transformer, ChapterPackageTransformer):
-            raise TypeError("smoke package routes require a ChapterPackageTransformer")
-        if isinstance(step, TranslationStep) and mode == SubmitKind.REPLACE:
-            mode = transformer.mode
-        current = craft.translate_package(
-            current,
-            run_path / f"translated-{index}",
-            transformer.chapter_transformer,
-            submit=mode,
-        )
-    return current
+    """Run one smoke package translation through the public facade method."""
+    if not isinstance(transformer, ChapterPackageTransformer):
+        raise TypeError("smoke package routes require a ChapterPackageTransformer")
+    return craft.translate_package(
+        package,
+        run_path / "translated",
+        transformer.chapter_transformer,
+        submit=transformer.mode,
+    )
 
 
 def _xml_translation_transformer(run: SmokeRun, run_path: Path) -> ChapterXMLTransformer | None:

--- a/tests/test_craft.py
+++ b/tests/test_craft.py
@@ -4,7 +4,7 @@ from pathlib import Path
 from unittest.mock import Mock, patch
 from xml.etree.ElementTree import tostring
 
-from pdf_craft.craft import ExtractionOptions, PDFCraft, PDFOptions, TranslationStep
+from pdf_craft.craft import ExtractionOptions, PDFCraft, PDFOptions
 from pdf_craft.document import DocumentPackage
 from pdf_craft.extractor.chapter.chapter import BlockLayout, Chapter, ParagraphLayout, encode
 from pdf_craft.transformer import ChapterPackageTransformer, SubmitKind
@@ -127,48 +127,6 @@ class TestPDFCraft(unittest.TestCase):
             assert target.toc_path is not None
             self.assertIn('translated="yes"', target.toc_path.read_text())
 
-    def test_pdf_rejects_append_block_steps_before_transforming(self):
-        craft = PDFCraft.from_engine(_Engine())
-        step = TranslationStep(Mock(), SubmitKind.APPEND_BLOCK)
-        with self.assertRaisesRegex(ValueError, "APPEND_BLOCK"):
-            craft.translate_pdf(
-                "source.pdf", DocumentPackage(Path("chapters"), Path("assets")),
-                "out.pdf", lambda text: text, steps=[step]
-            )
-
-    def test_pdf_rejects_append_block_package_transformer(self):
-        craft = PDFCraft.from_engine(_Engine())
-        transformer = ChapterPackageTransformer(Mock(), mode=SubmitKind.APPEND_BLOCK)
-        with self.assertRaisesRegex(ValueError, "APPEND_BLOCK"):
-            craft.translate_pdf(
-                "source.pdf", DocumentPackage(Path("chapters"), Path("assets")),
-                "out.pdf", lambda text: text, steps=[transformer]
-            )
-
-    def test_pdf_rejects_append_block_custom_package_step(self):
-        class CustomPackageTransformer:
-            def transform(self, package: DocumentPackage, output_path: Path) -> DocumentPackage:
-                del output_path
-                return package
-
-        craft = PDFCraft.from_engine(_Engine())
-        with self.assertRaisesRegex(ValueError, "APPEND_BLOCK"):
-            craft.translate_pdf(
-                "source.pdf", DocumentPackage(Path("chapters"), Path("assets")),
-                "out.pdf", lambda text: text,
-                steps=[TranslationStep(CustomPackageTransformer(), SubmitKind.APPEND_BLOCK)],
-            )
-
-    def test_optional_chapter_transformer_is_not_treated_as_package_transformer(self):
-        class OptionalChapterTransformer:
-            def transform(self, chapter: Chapter, *, trace: bool = False) -> Chapter:
-                del trace
-                return chapter
-
-        step = TranslationStep(OptionalChapterTransformer())
-        transformer = getattr(PDFCraft, "_as_package_transformer")(step)
-        self.assertIsInstance(transformer, ChapterPackageTransformer)
-
     def test_epub_only_facade_needs_no_pdf_options(self):
         craft = PDFCraft()
         with patch("pdf_craft.craft.run_epub_translation") as translate:
@@ -201,13 +159,20 @@ class TestPDFCraft(unittest.TestCase):
                 PDFCraft().render_markdown(package, root / "book.md")
             render.assert_called_once()
 
-    def test_one_shot_workflow_uses_public_steps(self):
+    def test_one_shot_workflow_supports_one_translator(self):
         craft = PDFCraft.from_engine(_Engine())
+        translator = Mock()
         with patch.object(craft, "extract_pdf_with_metering", return_value=(object(), "metering")) as extract, \
+             patch.object(craft, "translate_package", return_value=object()) as translate, \
              patch.object(craft, "render_markdown") as render:
-            result = craft.convert_pdf_to_markdown("source.pdf", "book.md", package_path="package")
+            result = craft.convert_pdf_to_markdown(
+                "source.pdf", "book.md", package_path="package",
+                translator=translator, submit=SubmitKind.APPEND_TEXT,
+            )
         self.assertEqual(result, "metering")
         extract.assert_called_once()
+        translate.assert_called_once()
+        self.assertEqual(translate.call_args.kwargs["submit"], SubmitKind.APPEND_TEXT)
         render.assert_called_once()
 
     def test_one_shot_markdown_workflow_cleans_implicit_workspace(self):
@@ -258,17 +223,18 @@ class TestPDFCraft(unittest.TestCase):
         self.assertEqual(render.call_args.kwargs["book_meta"], "detected metadata")
         self.assertIs(render.call_args.kwargs["aborted"], stopped)
 
-    def test_epub_conversion_forwards_translation_events_to_steps(self):
+    def test_epub_conversion_forwards_translation_events_to_translator(self):
         craft = PDFCraft.from_engine(_Engine())
         callback = Mock()
+        translator = Mock()
         with patch.object(craft, "extract_pdf_with_metering", return_value=(object(), "metering")), \
-             patch.object(craft, "_apply_steps", return_value=object()) as apply_steps, \
+             patch.object(craft, "translate_package", return_value=object()) as translate, \
              patch.object(craft, "render_epub"):
             craft.convert_pdf_to_epub(
                 "source.pdf", "book.epub", package_path="package",
-                on_translation_event=callback,
+                translator=translator, on_translation_event=callback,
             )
-        self.assertIs(apply_steps.call_args.kwargs["on_translation_event"], callback)
+        self.assertIs(translate.call_args.kwargs["on_translation_event"], callback)
 
     def test_markdown_workflow_forwards_aborted_to_renderer_step(self):
         craft = PDFCraft.from_engine(_Engine())

--- a/tests/test_translation_events.py
+++ b/tests/test_translation_events.py
@@ -3,13 +3,38 @@ import unittest
 from pathlib import Path
 from xml.etree.ElementTree import tostring
 
-from pdf_craft import TranslationEventKind, TranslationItemKind
+from pdf_craft import ChapterPackageTransformer, TranslationEventKind, TranslationItemKind
 from pdf_craft.craft import PDFCraft
 from pdf_craft.document import DocumentPackage
 from pdf_craft.extractor.chapter.chapter import BlockLayout, Chapter, ParagraphLayout, encode
 
 
 class TestTranslationEvents(unittest.TestCase):
+    def test_direct_package_transform_does_not_claim_translation_events(self):
+        with tempfile.TemporaryDirectory() as directory:
+            root = Path(directory)
+            source = DocumentPackage.from_path(root / "source")
+            source.chapters_path.mkdir(parents=True)
+            source.assets_path.mkdir()
+            source.write_metadata(page_pixel_sizes={1: (10, 10)})
+            chapter = Chapter(None, -1, [ParagraphLayout(
+                "text", 0, [BlockLayout(1, 1, (1, 1, 5, 5), ["source"])]
+            )])
+            (source.chapters_path / "chapter_head.xml").write_text(
+                '<?xml version="1.0" encoding="UTF-8"?>\n'
+                + tostring(encode(chapter), encoding="unicode")
+            )
+
+            class Identity:
+                def transform(self, chapter):
+                    return chapter
+
+            events = []
+            ChapterPackageTransformer(Identity()).transform(
+                source, root / "target", on_translation_event=events.append
+            )
+            self.assertEqual(events, [])
+
     def test_package_translation_reports_format_neutral_chapter_events(self):
         with tempfile.TemporaryDirectory() as directory:
             root = Path(directory)


### PR DESCRIPTION
## Summary
- remove legacy on_progress and TranslationStep/steps APIs
- expose singular translator flow and unified translation events
- scope translation events to explicit translation operations and add regression coverage

## Verification
- poetry run pytest -q
- poetry run pyright pdf_craft tests
- poetry run pylint pdf_craft tests