### PR TITLE
docs: add conversion examples to readmes

### DIFF
--- a/README.md
+++ b/README.md
@@ -74,6 +74,8 @@ craft.convert_pdf_to_markdown(
 )
 ```
 
+![PDF to Markdown example](docs/images/pdf2md-en.png)
+
 The conversion uses a temporary working directory automatically and removes it
 when the conversion finishes or fails. Pass `package_path` only when you want to
 keep the intermediate work for debugging or reuse.
@@ -102,6 +104,8 @@ craft.convert_pdf_to_epub(
     book_meta=BookMeta(title="Book title", authors=["Author"]),
 )
 ```
+
+![PDF to EPUB example](docs/images/pdf2epub-en.png)
 
 If `book_meta` is omitted, pdf-craft tries to read the metadata from the source PDF.
 

--- a/README.md
+++ b/README.md
@@ -26,7 +26,7 @@ compute. Translation uses a separate text LLM.
 
 ## Online Version
 
-Want to try the workflow before installing anything? Open [Inkora - PDF Craft](https://inkora.oomol.com/pdf-craft/),
+Want to try the workflow before installing anything? Open [PDF Craft Online](https://inkora.oomol.com/pdf-craft/),
 the online version of the same core experience. Upload a PDF in your browser and see
 the main workflow in action.
 

--- a/README_zh-CN.md
+++ b/README_zh-CN.md
@@ -27,7 +27,7 @@ pdf-craft 围绕书籍和学术、技术文档的结构设计，支持识别正�
 
 ## 在线版本
 
-如果你希望在不进行本地安装的情况下体验 pdf-craft，可以试试 [Inkora - PDF Craft](https://inkora.oomol.com/pdf-craft/)，这是一个基于相同 PDF 转换流程构建的在线应用。你可以直接上传 PDF 文件，在浏览器中体验主要功能。
+如果你希望在不进行本地安装的情况下体验 pdf-craft，可以试试 [PDF Craft Online](https://inkora.oomol.com/pdf-craft/)，这是一个基于相同 PDF 转换流程构建的在线应用。你可以直接上传 PDF 文件，在浏览器中体验主要功能。
 
 [![PDF Craft 在线版本](docs/images/website-cn.png)](https://inkora.oomol.com/pdf-craft/)
 

--- a/README_zh-CN.md
+++ b/README_zh-CN.md
@@ -74,6 +74,8 @@ craft.convert_pdf_to_markdown(
 )
 ~~~
 
+![PDF 转 Markdown 示例](docs/images/pdf2md-cn.png)
+
 转换过程会自动使用系统临时目录，并在完成或发生异常后清理。如果需要保留中间结果以便
 调试或重复使用，可以显式传入 `package_path`。
 
@@ -106,6 +108,8 @@ craft.convert_pdf_to_epub(
     book_meta=BookMeta(title="书名", authors=["作者"]),
 )
 ~~~
+
+![PDF 转 EPUB 示例](docs/images/pdf2epub-cn.png)
 
 `book_meta` 用于填写 EPUB 的书名和作者信息；如果不提供，pdf-craft 会尝试读取 PDF
 自身的元数据。


### PR DESCRIPTION
## Summary
- add the PDF-to-Markdown screenshot to the Quick Start section in both READMEs
- add the PDF-to-EPUB screenshot beside the matching example in both READMEs
- use the repository-local language-specific images with descriptive alt text

## Verification
- `poetry run pytest -q` (308 passed)
- verified all four referenced image files exist
- `git diff --check`