### PR TITLE
将 DocumentPackage 升级为 PDFCraftExtraction（.pcex）

### DIFF
--- a/README.md
+++ b/README.md
@@ -76,9 +76,9 @@ craft.convert_pdf_to_markdown(
 
 ![PDF to Markdown example](docs/images/pdf2md-en.png)
 
-The conversion uses a temporary working directory automatically and removes it
-when the conversion finishes or fails. Pass `package_path` only when you want to
-keep the intermediate work for debugging or reuse.
+The conversion uses a temporary analysis workspace automatically and removes it
+when the conversion finishes or fails. Pass `analysing_path` to retain diagnostics,
+or `extraction_path="book.pcex"` to retain the portable intermediate extraction.
 
 For the complete PDF conversion workflow and customization options, see the
 [PDF Translation Guide](docs/en/PDF_TRANSLATION.md) and [API Reference](docs/en/API_REFERENCE.md).
@@ -107,7 +107,8 @@ craft.convert_pdf_to_epub(
 
 ![PDF to EPUB example](docs/images/pdf2epub-en.png)
 
-If `book_meta` is omitted, pdf-craft tries to read the metadata from the source PDF.
+If `book_meta` is omitted, pdf-craft uses metadata stored in the PDFCraftExtraction
+manifest when the PDF was extracted.
 
 ### PDF → translated Markdown or EPUB
 
@@ -142,8 +143,8 @@ craft = PDFCraft(pdf=PDFOptions(ocr=DeepSeekOCRVendorConfig(
 def translator(text: str) -> str:
     return text
 
-package = craft.extract_pdf("input.pdf", "work/cache")
-craft.translate_pdf("input.pdf", package, "translated.pdf", translator)
+extraction = craft.extract_pdf("input.pdf", "work/book.pcex")
+craft.translate_pdf("input.pdf", extraction, "translated.pdf", translator)
 ```
 
 ### EPUB → translated EPUB

--- a/README_zh-CN.md
+++ b/README_zh-CN.md
@@ -76,8 +76,9 @@ craft.convert_pdf_to_markdown(
 
 ![PDF 转 Markdown 示例](docs/images/pdf2md-cn.png)
 
-转换过程会自动使用系统临时目录，并在完成或发生异常后清理。如果需要保留中间结果以便
-调试或重复使用，可以显式传入 `package_path`。
+转换过程会自动使用系统临时分析目录，并在完成或发生异常后清理。需要保留诊断信息时可传入
+`analysing_path`；需要复用、上传或跨机器交换中间结果时可传入
+`extraction_path="book.pcex"`。
 
 完整的 PDF 转换说明和库定制选项，请参阅 [PDF 转换与翻译指南](docs/zh-CN/PDF_TRANSLATION.md)
 和 [API 参考](docs/zh-CN/API_REFERENCE.md)。
@@ -111,8 +112,8 @@ craft.convert_pdf_to_epub(
 
 ![PDF 转 EPUB 示例](docs/images/pdf2epub-cn.png)
 
-`book_meta` 用于填写 EPUB 的书名和作者信息；如果不提供，pdf-craft 会尝试读取 PDF
-自身的元数据。
+`book_meta` 用于填写 EPUB 的书名和作者信息；如果不提供，pdf-craft 会使用 PDF 提取时写入
+PDFCraftExtraction manifest 的元数据。
 
 ### 转换 PDF 时同时翻译
 
@@ -150,8 +151,8 @@ craft = PDFCraft(pdf=PDFOptions(ocr=DeepSeekOCRVendorConfig(
 def translator(text: str) -> str:
     return text  # 这里只是占位；实际应调用文本 LLM，将 text 翻译成中文
 
-package = craft.extract_pdf("input.pdf", "work/cache")
-craft.translate_pdf("input.pdf", package, "translated.pdf", translator)
+extraction = craft.extract_pdf("input.pdf", "work/book.pcex")
+craft.translate_pdf("input.pdf", extraction, "translated.pdf", translator)
 ~~~
 
 ### 翻译 EPUB

--- a/docs/en/API_REFERENCE.md
+++ b/docs/en/API_REFERENCE.md
@@ -18,25 +18,53 @@ craft = PDFCraft(pdf=PDFOptions(ocr=your_ocr_config))
 
 | Method | Signature and purpose |
 | --- | --- |
-| `extract_pdf` | `extract_pdf(source, package_path, options=None) -> DocumentPackage` extracts a PDF into a persistent package directory. `package_path` is required. |
-| `extract_pdf_with_metering` | `extract_pdf_with_metering(source, package_path, options=None) -> tuple[DocumentPackage, OCRTokensMetering]` is the same extraction with OCR token accounting. |
-| `render_markdown` | `render_markdown(package, output, assets_path=None, *, aborted=...)` writes Markdown and optional assets. |
-| `render_epub` | `render_epub(package, output, *, book_meta=None, lan="zh", table_render=..., latex_render=..., inline_latex=True, aborted=...)` writes an EPUB. |
-| `convert_pdf_to_markdown` | `convert_pdf_to_markdown(source, output, *, package_path=None, extraction=None, assets_path=None, translator=None, submit=SubmitKind.REPLACE, on_translation_event=None) -> OCRTokensMetering` is the one-shot PDF-to-Markdown workflow. |
-| `convert_pdf_to_epub` | `convert_pdf_to_epub(source, output, *, package_path=None, extraction=None, book_meta=None, lan="zh", table_render=..., latex_render=..., inline_latex=True, translator=None, submit=SubmitKind.REPLACE, on_translation_event=None) -> OCRTokensMetering` is the one-shot PDF-to-EPUB workflow. |
+| `extract_pdf` | `extract_pdf(source, extraction_path, options=None, *, analysing_path=None) -> PDFCraftExtraction` extracts a PDF into a persistent `.pcex` archive. |
+| `extract_pdf_with_metering` | `extract_pdf_with_metering(source, extraction_path, options=None, *, analysing_path=None) -> tuple[PDFCraftExtraction, OCRTokensMetering]` is the same extraction with OCR token accounting. |
+| `render_markdown` | `render_markdown(extraction, output, assets_path=None, *, aborted=...)` writes Markdown and optional assets from a `PDFCraftExtraction` or `.pcex` path. |
+| `render_epub` | `render_epub(extraction, output, *, book_meta=None, lan=None, table_render=..., latex_render=..., inline_latex=True, aborted=...)` writes an EPUB. Metadata and language default to the extraction manifest. |
+| `convert_pdf_to_markdown` | `convert_pdf_to_markdown(source, output, *, analysing_path=None, extraction_path=None, extraction=None, assets_path=None, translator=None, submit=SubmitKind.REPLACE, on_translation_event=None) -> OCRTokensMetering` is the one-shot PDF-to-Markdown workflow. |
+| `convert_pdf_to_epub` | `convert_pdf_to_epub(source, output, *, analysing_path=None, extraction_path=None, extraction=None, book_meta=None, lan=None, table_render=..., latex_render=..., inline_latex=True, translator=None, submit=SubmitKind.REPLACE, on_translation_event=None) -> OCRTokensMetering` is the one-shot PDF-to-EPUB workflow. |
 
-The two `convert_pdf_to_*` methods clean up their temporary package workspace when `package_path` is omitted. Give `package_path` when you need to retain the package. `render_epub` accepts `epub_generator.BookMeta`, `TableRender`, and `LaTeXRender` values for output customization.
+The two `convert_pdf_to_*` methods use a directory-backed extraction inside their analysis workspace, avoiding a ZIP round trip. Give `analysing_path` to retain diagnostics and `extraction_path` to additionally export a `.pcex`. `render_epub` accepts `epub_generator.BookMeta`, `TableRender`, and `LaTeXRender` values for output customization.
 
-### Package translation and PDF patching
+### Extraction translation and PDF patching
 
 | Method | Signature and purpose |
 | --- | --- |
-| `translate_package` | `translate_package(package, output_path, translator, *, submit=SubmitKind.REPLACE, on_translation_event=None) -> DocumentPackage` translates a package into a new package. `translator` is a chapter transformer. |
-| `translate_pdf` | `translate_pdf(source, package, output, transformer, *, on_translation_event=None)` translates then patches text onto the source PDF. `transformer` may be a chapter transformer or `Callable[[str], str]`. |
-| `patch_pdf_with_package` | `patch_pdf_with_package(source, package, output)` patches a source PDF from a `DocumentPackage` or package path without OCR or LLM calls. |
+| `translate_extraction` | `translate_extraction(extraction, output_path, translator, *, submit=SubmitKind.REPLACE, on_translation_event=None) -> PDFCraftExtraction` translates a `.pcex` into a new `.pcex`. |
+| `translate_pdf` | `translate_pdf(source, extraction, output, transformer, *, on_translation_event=None)` translates then patches text onto the source PDF. `transformer` may be a chapter transformer or `Callable[[str], str]`. |
+| `patch_pdf_with_extraction` | `patch_pdf_with_extraction(source, extraction, output)` patches a source PDF from a `PDFCraftExtraction` or `.pcex` path without OCR or LLM calls. |
 | `translate_epub` | `translate_epub(source, output, *, target_language, submit, **options)` translates an existing EPUB. See [EPUB translation](EPUB_TRANSLATION.md) for its options. |
 
-`translate_pdf` and `patch_pdf_with_package` require a package with page geometry that matches the source PDF. PDF patching rejects `SubmitKind.APPEND_BLOCK`.
+`translate_pdf` and `patch_pdf_with_extraction` require extraction page geometry that matches the source PDF. PDF patching rejects `SubmitKind.APPEND_BLOCK`.
+
+## `PDFCraftExtraction` and `.pcex`
+
+`PDFCraftExtraction` is pdf-craft's structured, source-mapped intermediate format.
+It is more direct than Markdown or EPUB and retains each recognized block's PDF page
+and pixel-space bounding box. Public persistence and exchange always use a `.pcex`
+file, which is a validated ZIP archive with this layout:
+
+```text
+manifest.json
+pages.xml
+chapters/chapter_head.xml
+chapters/chapter_*.xml
+assets/
+toc.xml        # optional
+cover.png      # optional
+```
+
+`manifest.json` contains the format version, producer, creation time, and document
+metadata. `pages.xml` defines the one-based OCR-pixel coordinate space, extraction
+DPI, and actual pixel width and height of every extracted page. Chapter XML retains
+page and bounding-box source mappings. Analysis caches such as OCR responses and
+plots are deliberately excluded.
+
+Loading validates the archive version, member paths, required files, XML roots,
+page references, bounding boxes, and referenced assets. Unsupported, malformed,
+corrupt, or path-unsafe archives are rejected. Back-end operations only consume the
+extraction; they do not fall back to an analysis/OCR directory.
 
 ## PDF configuration
 
@@ -62,7 +90,7 @@ The two `convert_pdf_to_*` methods clean up their temporary package workspace wh
 | `max_ocr_output_tokens` | `None` | Cumulative OCR output-token budget. |
 | `includes_cover` | `False` | Retain a recognized cover image. |
 | `includes_footnotes` | `False` | Request and retain footnotes. |
-| `generate_plot` | `False` | Generate plot-related package assets. |
+| `generate_plot` | `False` | Generate plot diagnostics in the analysis workspace (not in `.pcex`). |
 | `toc_assumed` | `False` | Treat the document as already having usable TOC information. |
 | `toc_llm` | `None` | LLM used when TOC analysis is needed. |
 | `ignore_pdf_errors` | `False` | `True` or a predicate that decides whether a PDF error may be skipped. |
@@ -98,8 +126,8 @@ The following classes are exposed for applications that need custom structured t
 | Type | Role |
 | --- | --- |
 | `ChapterXMLTransformer` | Adapts XML-oriented work to chapter transformation. |
-| `ChapterPackageTransformer` | Applies a chapter transformer across a package and writes a new package. |
-| `PackageTransformer` | Public protocol for `transform(package, output_path) -> DocumentPackage`. |
+| `ChapterExtractionTransformer` | Applies a chapter transformer across an extraction and writes a new `.pcex`. |
+| `ExtractionTransformer` | Public protocol for `transform(extraction, output_path) -> PDFCraftExtraction`. |
 | `XMLTranslator` | XML-aware translation engine for integrations that need direct structured translation. |
 | `FillFailedEvent` | Information passed to EPUB XML-repair failure callbacks. |
 
@@ -110,7 +138,7 @@ metadata, or chapter items. Character counts are source-text character counts an
 are not token counts or percentages. Item events include the current item's
 completed and total source characters, while scope events include the aggregate
 counts. The same event callback is available for
-EPUB translation, package translation, PDF translation, and PDF conversion.
+EPUB translation, extraction translation, PDF translation, and PDF conversion.
 
 ## `LLM`
 
@@ -155,11 +183,11 @@ pipeline = PDFTranslationPipeline(patcher=patcher)
 
 `PatchTextOptions` controls text fitting. `overflow="error"` (the default) stops if translated text cannot fit; `overflow="skip"` records skipped replacements in `PDFPatcher.skipped_replacements`. `PDFReplacement` and `PDFSkippedReplacement` describe individual patch outcomes.
 
-`PDFTranslationPipeline` can perform lower-level translation or patching when the application owns the complete layout and output lifecycle. Prefer `PDFCraft.translate_pdf()` and `PDFCraft.patch_pdf_with_package()` when their fixed layout policy is sufficient.
+`PDFTranslationPipeline` can perform lower-level translation or patching when the application owns the complete layout and output lifecycle. Prefer `PDFCraft.translate_pdf()` and `PDFCraft.patch_pdf_with_extraction()` when their fixed layout policy is sufficient.
 
 ## Other useful exports
 
-- `DocumentPackage` represents a validated extracted or transformed document package; use `DocumentPackage.from_path(path)` to open one saved on disk.
+- `PDFCraftExtraction` represents a validated extracted or transformed document. Use `PDFCraftExtraction.open("book.pcex")` to load the portable ZIP-based artifact. Ordinary directories are intentionally not public inputs.
 - `PDFExtractor`, `MarkdownRenderer`, and `EpubRenderer` are the component-level extraction and rendering APIs behind the façade.
 - `OCRTokensMetering` exposes `input_tokens` and `output_tokens`.
 - `OCREvent` and `OCREventKind` support per-page progress and diagnostics.

--- a/docs/en/PDF_TRANSLATION.md
+++ b/docs/en/PDF_TRANSLATION.md
@@ -8,10 +8,10 @@ This guide covers workflows that start with a PDF: converting it to Markdown or 
 | --- | --- | --- |
 | Convert a PDF once | `convert_pdf_to_markdown()` or `convert_pdf_to_epub()` | Markdown or EPUB |
 | Translate as the PDF is converted | Pass one `translator` to either conversion method | Translated Markdown or EPUB |
-| Keep, inspect, or reuse OCR output | `extract_pdf()`, then render or translate the returned package | A durable `DocumentPackage` directory |
-| Produce a translated PDF | `translate_pdf()` or `patch_pdf_with_package()` | A new PDF with translated text over the source pages |
+| Reuse or move an extraction | `extract_pdf()`, then render or translate it | A portable `.pcex` file |
+| Produce a translated PDF | `translate_pdf()` or `patch_pdf_with_extraction()` | A new PDF with translated text over the source pages |
 
-For a one-off conversion, use the two `convert_pdf_to_*` methods. They extract the PDF, optionally translate it once, and render the final file. Use the lower-level package APIs only when you need a persistent intermediate package or need to control each stage separately.
+For a one-off conversion, use the two `convert_pdf_to_*` methods. They extract the PDF, optionally translate it once, and render the final file. Use the extraction APIs when you need a persistent intermediate artifact or need to control each stage separately.
 
 All PDF extraction requires a configured `PDFCraft` instance. The OCR configuration is independent of the text LLM used for translation.
 
@@ -36,18 +36,24 @@ metering = craft.convert_pdf_to_markdown("book.pdf", "book.md")
 print(metering.input_tokens, metering.output_tokens)
 ```
 
-The return value records OCR input and output tokens for the run. By default, pdf-craft creates a temporary `DocumentPackage` workspace and removes it on success or failure. If you want to inspect OCR XML, reuse it for another output format, or retain it after an error, provide `package_path` yourself:
+The return value records OCR input and output tokens for the run. By default,
+pdf-craft creates a temporary analysis workspace and removes it on success or
+failure. Retain diagnostics with `analysing_path`; independently export the stable
+intermediate format with `extraction_path`:
 
 ```python
 craft.convert_pdf_to_markdown(
     "book.pdf",
     "book.md",
-    package_path="work/book-package",
+    analysing_path="work/analysis",
+    extraction_path="work/book.pcex",
     assets_path="output/assets",
 )
 ```
 
-`assets_path` controls where Markdown images and other extracted assets are written. A caller-supplied package directory is persistent and is the caller's responsibility to manage.
+`assets_path` controls where Markdown images and other extracted assets are written.
+A caller-supplied analysis directory and `.pcex` file are persistent and are the
+caller's responsibility to manage.
 
 ## Convert a PDF to EPUB
 
@@ -89,20 +95,20 @@ craft.convert_pdf_to_markdown(
 )
 ```
 
-Use `SubmitKind.REPLACE` for a target-language-only document. `APPEND_TEXT` appends translated text to the same text flow, while `APPEND_BLOCK` adds separate translated blocks, which is generally the clearer bilingual layout for Markdown and EPUB. The high-level conversion methods perform at most one translation; advanced applications that need additional package transformations should compose the lower-level package APIs explicitly.
+Use `SubmitKind.REPLACE` for a target-language-only document. `APPEND_TEXT` appends translated text to the same text flow, while `APPEND_BLOCK` adds separate translated blocks, which is generally the clearer bilingual layout for Markdown and EPUB. The high-level conversion methods perform at most one translation; advanced applications should compose the extraction APIs explicitly.
 
-## Work explicitly with a DocumentPackage
+## Work explicitly with a PDFCraftExtraction
 
-A `DocumentPackage` is pdf-craft's on-disk, render-ready representation of an extracted document: chapters, assets, OCR metadata, and page geometry live together in one directory. It is intended for durable intermediate results, not as a separate plugin protocol.
+A `PDFCraftExtraction` is pdf-craft's source-mapped intermediate document. It contains chapters, assets, page geometry, document metadata, and optional TOC and cover. On disk it is exchanged as a `.pcex` ZIP file, so it can be stored or moved to another machine without carrying the analysis/OCR cache.
 
-Use an explicit package when the same extraction must feed more than one output, or when translation is a distinct operation:
+Use an explicit `.pcex` when the same extraction must feed more than one output, or when translation is a distinct operation:
 
 ```python
-package = craft.extract_pdf("book.pdf", "work/book-package")
+extraction = craft.extract_pdf("book.pdf", "work/book.pcex")
 
-translated = craft.translate_package(
-    package,
-    "work/book-package-zh",
+translated = craft.translate_extraction(
+    extraction,
+    "work/book.zh.pcex",
     translator,
     submit=SubmitKind.REPLACE,
 )
@@ -110,18 +116,18 @@ craft.render_markdown(translated, "book.zh.md", assets_path="output/assets")
 craft.render_epub(translated, "book.zh.epub", lan="zh")
 ```
 
-`extract_pdf()` deliberately requires a package path: its result is meant to survive after the method returns. `translate_package()` creates a new package at `output_path`; it does not overwrite the source package.
+`extract_pdf()` deliberately requires a `.pcex` path: its result is meant to survive after the method returns. `translate_extraction()` creates a new archive at `output_path`; it does not overwrite the source extraction. Rendering, translation, and PDF patching accept either the returned object or a `.pcex` path, but not an ordinary directory.
 
 ## Translate and patch a PDF
 
 To create a translated PDF, first extract the source and then ask pdf-craft to translate and patch it:
 
 ```python
-package = craft.extract_pdf("book.pdf", "work/book-package")
+extraction = craft.extract_pdf("book.pdf", "work/book.pcex")
 
 craft.translate_pdf(
     "book.pdf",
-    package,
+    extraction,
     "book.zh.pdf",
     translator,
 )
@@ -133,15 +139,15 @@ The `transformer` may be a chapter transformer or a simple `Callable[[str], str]
 def translate_text(text: str) -> str:
     return call_your_llm(text)
 
-craft.translate_pdf("book.pdf", package, "book.zh.pdf", translate_text)
+craft.translate_pdf("book.pdf", extraction, "book.zh.pdf", translate_text)
 ```
 
-If translation happened elsewhere, call `patch_pdf_with_package()` instead. It runs neither OCR nor an LLM; it uses the translated package's page geometry to patch the source PDF.
+If translation happened elsewhere, call `patch_pdf_with_extraction()` instead. It runs neither OCR nor an LLM; it uses the translated extraction's page geometry to patch the source PDF.
 
 ```python
-craft.patch_pdf_with_package(
+craft.patch_pdf_with_extraction(
     "book.pdf",
-    "work/book-package-zh",
+    "work/book.zh.pcex",
     "book.zh.pdf",
 )
 ```
@@ -150,7 +156,7 @@ craft.patch_pdf_with_package(
 
 PDF patching is a page-overlay workflow, not a general-purpose PDF layout engine. Each source page is rendered as an image and translated text is placed over its OCR bounding boxes. The output therefore does not retain the source PDF's selectable vector text, links, annotations, or other page objects. It replaces text and subtitle layouts only; tables and images are not translated in place.
 
-The source PDF and package must match. The package needs page geometry for every chapter page and its page numbers must be valid for the source file. `APPEND_BLOCK` is rejected for PDF output because new block-level content cannot safely be added to a fixed page. Text that cannot fit its original bounding box fails before a partial output PDF is left behind.
+The source PDF and extraction must match. `pages.xml` must contain geometry for every chapter page and its page numbers must be valid for the source file. There is no fallback to OCR caches or re-rendering to recover missing geometry. `APPEND_BLOCK` is rejected for PDF output because new block-level content cannot safely be added to a fixed page. Text that cannot fit its original bounding box fails before a partial output PDF is left behind.
 
 For custom fonts, fit rules, alignment, padding, or overflow handling, use the lower-level public `PDFPatcher`, `PatchTextOptions`, and `PDFTranslationPipeline` APIs described in the [API reference](API_REFERENCE.md).
 

--- a/docs/en/TROUBLESHOOTING.md
+++ b/docs/en/TROUBLESHOOTING.md
@@ -12,7 +12,7 @@ When a real conversion fails, first identify the layer: PDF reading and renderin
 | Vendor OCR returns an error | Endpoint, model, credential, network access, quota, and rate limits. |
 | EPUB/PDF translation reports an LLM error | Text LLM URL, model, key, and token encoding. |
 | No output file appears | Parent-directory permissions and the earlier exception. |
-| PDF patching rejects a package | The original PDF, page geometry, and translated package must correspond. |
+| PDF patching rejects an extraction | The original PDF, `pages.xml`, and translated `.pcex` must correspond. |
 
 ## PDF and Poppler
 
@@ -83,13 +83,20 @@ For EPUB XML-repair problems, register `on_fill_failed` and pay particular atten
 
 When `LLM(cache_path=...)` is used, successful requests can be reused after an interruption. Use separate cache directories for unrelated books or jobs, particularly while they may be writing concurrently. A rerun still creates a new EPUB output; it does not resume by appending to an incomplete destination file.
 
-## Outputs, package paths, and PDF patching
+## Outputs, extraction paths, and PDF patching
 
-`convert_pdf_to_markdown()` and `convert_pdf_to_epub()` use a temporary package directory when `package_path` is omitted, and clean it up in both success and exception paths. Pass a writable package path if you need OCR artifacts for debugging or reuse; pdf-craft will not delete that caller-owned directory.
+`convert_pdf_to_markdown()` and `convert_pdf_to_epub()` use a temporary analysis
+directory by default and clean it up after success or failure. Pass `analysing_path`
+to retain diagnostics, or `extraction_path` to export a portable `.pcex`. Back-end
+operations accept `.pcex`, not an analysis or ordinary extraction directory.
 
 If an output is absent, make sure its parent directory exists and is writable, then work backward to the first OCR, translation, or renderer exception. A partially created output is not a successful conversion.
 
-PDF patching requires the original PDF plus a package extracted from that same document. The package must include the relevant page geometry, and translated text must fit the original OCR bounding boxes. Patch output is rendered from page images, so it does not preserve source vector text, annotations, or links. `APPEND_BLOCK` is unsupported for PDF patching because it cannot add free-flowing content to a fixed page.
+PDF patching requires the original PDF plus a `.pcex` extracted from that same
+document. `pages.xml` must include the relevant page geometry; missing data is not
+recovered from OCR caches or by re-rendering. Translated text must fit the original
+OCR bounding boxes. Patch output is rendered from page images, so it does not
+preserve source vector text, annotations, or links. `APPEND_BLOCK` is unsupported.
 
 ## What to include in a bug report
 
@@ -100,6 +107,6 @@ Provide enough context to reproduce the failure without exposing secrets:
 - for local OCR: GPU model and `torch.cuda.is_available()` result;
 - input page or chapter count, and the workflow stage that failed;
 - full exception type and message, redacted of credentials and private content;
-- relevant `package_path`, model-cache path, or LLM-cache path choices.
+- relevant `analysing_path`, `extraction_path`, model-cache path, or LLM-cache path choices.
 
 Do not attach API keys, complete private documents, model caches, or unredacted logs to a public issue.

--- a/docs/zh-CN/API_REFERENCE.md
+++ b/docs/zh-CN/API_REFERENCE.md
@@ -13,11 +13,11 @@ from pdf_craft import PDFCraft, PDFOptions
 翻译和 PDF 写回组合成一组方法。下面这些对象可直接从 `pdf_craft` 导入：
 
 - `PDFCraft`、`PDFOptions`、`ExtractionOptions`
-- `DocumentPackage`、`PDFExtractor`
+- `PDFCraftExtraction`、`PDFExtractor`
 - 六种 OCR 配置对象和 `OCRConfig`
 - `predownload_models`
 - `LLM`
-- `PackageTransformer`、`ChapterPackageTransformer`、`ChapterXMLTransformer`、
+- `ExtractionTransformer`、`ChapterExtractionTransformer`、`ChapterXMLTransformer`、
   `XMLTranslator`、`SubmitKind`
 - `BookMeta`、`TableRender`、`LaTeXRender`
 - `OCRTokensMetering`、`OCREvent`、`OCREventKind`、`TranslationEvent`、
@@ -39,7 +39,7 @@ from pdf_craft import PDFCraft, PDFOptions
 包含 `START`、`ITEM_START`、`ITEM_COMPLETE`、`PROGRESS` 和 `COMPLETE`；item 类型为
 TOC、metadata 或 chapter。字符统计是可翻译源文本的 Unicode 字符数，不是 token 数，
 也不是预先计算的百分比。chapter 可以来自 EPUB，也可以来自 PDF OCR 生成的
-`DocumentPackage`。
+`PDFCraftExtraction`。
 
 `ITEM_START`、`PROGRESS` 和 `ITEM_COMPLETE` 事件会提供当前 item 的已完成字符数和总字符数；
 范围事件会提供整个翻译范围的累计字符数。调用方可以据此自行计算 item 或整体百分比，库不
@@ -53,7 +53,7 @@ TOC、metadata 或 chapter。字符统计是可翻译源文本的 Unicode 字符
 craft = PDFCraft(pdf=PDFOptions(...))
 ```
 
-`PDFCraft()` 本身不会初始化 OCR。只做 EPUB → EPUB 翻译，或只渲染一个已经存在的 package
+`PDFCraft()` 本身不会初始化 OCR。只做 EPUB → EPUB 翻译，或只渲染已有 extraction
 时，可以不传 `PDFOptions`。凡是需要从 PDF 提取内容的操作，都必须提供 PDF 配置，或者使用
 已经准备好的测试 engine（后者是测试用途，不属于普通应用集成方式）。
 
@@ -129,37 +129,40 @@ LLM，不是 OCR 配置，也不是章节翻译器。
 
 ## PDF 工作流
 
-### 提取为 DocumentPackage
+### 提取为 PDFCraftExtraction
 
 ```python
-package = craft.extract_pdf(
+extraction = craft.extract_pdf(
     "input.pdf",
-    "work/package",
+    "work/book.pcex",
     ExtractionOptions(page_indexes={1, 2}),
 )
 ```
 
-`extract_pdf` 要求显式提供 `package_path`，因为返回的 `DocumentPackage` 需要在调用结束
-后继续有效。带计量版本返回二元组：
+`extract_pdf` 要求显式提供 `.pcex` 输出路径，因为返回的 `PDFCraftExtraction` 是可长期保存和
+跨机器交换的中间产物。普通目录不是公开输入。带计量版本返回二元组：
 
 ```python
-package, metering = craft.extract_pdf_with_metering(
-    "input.pdf", "work/package", ExtractionOptions()
+extraction, metering = craft.extract_pdf_with_metering(
+    "input.pdf", "work/book.pcex", ExtractionOptions()
 )
 print(metering.input_tokens, metering.output_tokens)
 ```
 
-`PDFExtractor` 是面向已有提取 backend 的低层包装器，构造时需要传入一个能够生成 package 的
+`PDFExtractor` 是面向已有提取 backend 的低层包装器，构造时需要传入提取 backend；
 backend。常规应用不应自行构造它，而应通过 `PDFCraft.extract_pdf*()` 获得已正确配置 OCR、PDF
 handler 和中断处理的提取流程。
 
 ### 直接转换为 Markdown 或 EPUB
 
-一键转换方法会在未提供 `package_path` 时创建系统临时目录，并在成功或异常后清理；需要
-调试、复用或保留中间结果时再显式传入路径：
+一键转换方法默认创建系统临时分析目录，并在成功或异常后清理。`analysing_path` 可保留 OCR、
+图表等诊断信息；`extraction_path` 可额外导出稳定的 `.pcex`。完整转换在内部直接使用
+`analysing_path/extraction/`，不会为衔接前后端执行无意义的压缩与解压：
 
 ```python
-craft.convert_pdf_to_markdown("input.pdf", "book.md")
+craft.convert_pdf_to_markdown(
+    "input.pdf", "book.md", extraction_path="work/book.pcex"
+)
 craft.convert_pdf_to_epub(
     "input.pdf", "book.epub",
     book_meta=BookMeta(title="Book title", authors=["Author"]),
@@ -171,21 +174,19 @@ craft.convert_pdf_to_epub(
 `inline_latex` 控制 EPUB 输出格式。
 两个方法都可以通过 `translator` 和 `on_translation_event` 在转换时完成一次翻译。
 
-### 从已有 package 渲染
+### 从已有 extraction 渲染
 
 ```python
-craft.render_markdown(package, "book.md", assets_path="book-assets")
+craft.render_markdown(extraction, "book.md", assets_path="book-assets")
 craft.render_epub(
-    package, "book.epub",
+    extraction, "book.epub",
     book_meta=BookMeta(title="Book title", authors=["Author"]),
 )
 ```
 
-渲染不会重新 OCR，也不会读取 PDF。Markdown 要求 package 通过
-`DocumentPackage.validate()`；EPUB 要求 `DocumentPackage.validate(require_toc=True)`，
-因此缺少 `toc.xml` 的 package 无法渲染为 EPUB。Markdown 可选复制图片资源；EPUB 读取
-章节、目录、封面和调用时提供的 `book_meta`。`document.json` 的页面几何元数据不参与 EPUB
-渲染，但 PDF 写回需要它。
+渲染不会重新 OCR，也不会读取 PDF。Markdown 要求 extraction 校验通过；EPUB 额外要求
+`toc.xml`。Markdown 可选复制图片资源；EPUB 从 `manifest.json` 读取默认元数据和语言，调用时
+显式提供的 `book_meta` / `lan` 优先。
 
 ### PDF 转换时翻译
 
@@ -215,54 +216,47 @@ def accepts_transformer(transformer: ChapterTransformer) -> None:
 ### 翻译并写回 PDF
 
 ```python
-package = craft.extract_pdf("input.pdf", "work/package")
+extraction = craft.extract_pdf("input.pdf", "work/book.pcex")
 craft.translate_pdf(
-    "input.pdf", package, "translated.pdf", translator,
+    "input.pdf", extraction, "translated.pdf", translator,
 )
 ```
 
-`translate_pdf` 会生成翻译后的临时 package，再调用 `patch_pdf_with_package`。写回只会
-替换 package 中记录了来源坐标的原始 PDF 文本，不是通用 PDF 排版器；输入 PDF 必须和 package
-来自同一份源文件，并且 package 要有页面几何元数据。PDF 写回不支持 `APPEND_BLOCK`；
+`translate_pdf` 会生成翻译后的临时 extraction，再执行 PDF 写回。写回只会替换 extraction
+中记录了来源坐标的原始 PDF 文本，不是通用 PDF 排版器；输入 PDF 必须来自同一源文件，并且
+`pages.xml` 要包含完整页面几何。PDF 写回不支持 `APPEND_BLOCK`；
 `APPEND_TEXT` 可以把双语内容放进原文本框，但更容易超过原有版面，通常优先选 `REPLACE`。
 
-如果已经有翻译后的 package，也可以单独写回：
+如果已经有翻译后的 `.pcex`，也可以单独写回：
 
 ```python
-craft.patch_pdf_with_package("input.pdf", translated_package, "translated.pdf")
+craft.patch_pdf_with_extraction("input.pdf", "work/translated.pcex", "translated.pdf")
 ```
 
-## DocumentPackage
+## PDFCraftExtraction 与 `.pcex`
 
-`DocumentPackage` 是渲染器和变换器之间的稳定中间对象。它通常从目录读取：
+`PDFCraftExtraction` 是带原始 PDF 页码和 bbox 映射的结构化中间对象。公开持久化和交换格式
+统一为 `.pcex`（ZIP），通过以下方式加载：
 
 ```python
-package = DocumentPackage.from_path("work/package")
-package.validate()
+extraction = PDFCraftExtraction.open("work/book.pcex")
+extraction.validate()
 ```
 
-公开字段包括：
+归档固定包含 `manifest.json`、`pages.xml`、`chapters/`、`assets/`，并可选包含 `toc.xml` 与
+`cover.png`。manifest 保存格式版本、producer、创建时间及书名、作者、出版社、语言等文档
+元数据；pages 保存 1-based 页码、OCR 像素坐标空间、实际 DPI 和各页像素宽高。OCR 响应、
+plot 和 done 标记属于 analysis 诊断信息，不进入 `.pcex`。
 
-- `chapters_path`：章节 XML 目录，必需。
-- `assets_path`：图片和其他资源目录，必需。
-- `toc_path`：可选目录文件。
-- `cover_path`：可选封面图片。
-- `metadata_path`：可选 `document.json`，包含 schema 和页面几何信息。
-
-`validate(require_toc=True)` 可以额外要求目录存在。`has_toc()`、`has_cover()` 和
-`page_pixel_sizes()` 可用于检查 package 能否用于相应输出。`page_pixel_sizes()` 返回
-以 1-based 页码为键的 OCR 画布尺寸；PDF 写回依赖这些元数据。
-
-`DocumentPackage` 是目录工件，不是独立的 PDF 或 EPUB 文件。使用 `extract_pdf` 生成的
-package 可以重复渲染、翻译或写回；使用一键 `convert_pdf_to_*` 时的隐式临时 package 会
-在方法返回后删除。
+加载时会检查版本、ZIP 路径安全、必需组件、XML、页面引用、bbox 和资源引用；非法、损坏或
+不支持版本的包会被拒绝。所有后端只读取 extraction 内字段，不会回退读取 analysis/OCR 缓存。
 
 ## 翻译与变换接口
 
 ### ChapterTransformer
 
 章节变换器实现一个 `transform(chapter) -> chapter` 方法。它可以修改章节文本、段落或布局，
-并被 `translate_package` 和 `translate_pdf` 使用。实现该低层协议时，需从
+并被 `translate_extraction` 和 `translate_pdf` 使用。实现该低层协议时，需从
 它的实际定义处导入 `Chapter`：
 
 ```python
@@ -280,23 +274,22 @@ transformer: ChapterTransformer = KeepChapterStructure()
 章节布局类型不是顶层 facade 的日常 API。自行编辑它们时必须保留原有页面来源信息，否则 PDF
 写回无法定位原文；纯文本翻译应优先使用下一节的 `XMLTranslator`，避免依赖章节内部结构。
 
-### PackageTransformer
+### ExtractionTransformer
 
-package 变换器实现：
+extraction 变换器实现：
 
 ```python
-def transform(package: DocumentPackage, output_path: Path) -> DocumentPackage:
+def transform(extraction: PDFCraftExtraction, output_path: Path) -> PDFCraftExtraction:
     ...
 ```
 
-它负责把一个完整 package 写入新的输出目录，并返回新的 `DocumentPackage`。适合需要同时
-修改章节、目录、资源或元数据的高级流程。
+它负责把一个完整 extraction 写入新的 `.pcex`，并返回新的 `PDFCraftExtraction`。
 
 ### 使用 XMLTranslator 翻译 PDF 章节
 
 `XMLTranslator` 是包顶层导出的结构化文本翻译器。它需要分别提供翻译文本和修复 XML
 结构的 LLM；同一个 `LLM` 可以同时承担两项工作。将它包装为 `ChapterXMLTransformer` 后，
-即可作为 `translator` 传给 PDF 转换或 package 翻译入口：
+即可作为 `translator` 传给 PDF 转换或 extraction 翻译入口：
 
 ```python
 from pdf_craft import (
@@ -334,12 +327,12 @@ craft.convert_pdf_to_markdown(
 `APPEND_TEXT` 或 `APPEND_BLOCK`；PDF 不支持 `APPEND_BLOCK`，而 `APPEND_TEXT` 虽可使用，
 但需要为双语文本的版面溢出承担处理成本，因此通常推荐 `REPLACE`。
 
-已有可复用 package 时，使用同一个 transformer 调用 `translate_package`，显式指定新的输出目录：
+已有可复用 extraction 时，调用 `translate_extraction` 并显式指定新的 `.pcex`：
 
 ```python
-translated_package = craft.translate_package(
-    package,
-    "work/translated-package",
+translated_extraction = craft.translate_extraction(
+    extraction,
+    "work/translated.pcex",
     ChapterXMLTransformer(xml_translator),
     submit=SubmitKind.REPLACE,
 )
@@ -383,20 +376,20 @@ translate_epub(
 
 ## 低层 PDF 写回 API
 
-通常应使用 `PDFCraft.patch_pdf_with_package()` 或 `PDFCraft.translate_pdf()`。顶层也公开了较低层的
+通常应使用 `PDFCraft.patch_pdf_with_extraction()` 或 `PDFCraft.translate_pdf()`。顶层也公开了较低层的
 写回组件，供已经能自行生成替换坐标与文字的集成方使用：
 
 - `PDFReplacement` 描述一段待替换文本：`page_index`、像素坐标 `bbox`、`text`、OCR 画布尺寸
   `page_pixel_size`，以及可选的 `dpi`、`reading_order`。
 - `PDFPatcher(options=PatchTextOptions(...), pdf_handler=...)` 通过 `.patch(source_path,
   target_path, replacements)` 写出 PDF。它接受任意通过字段校验的 `PDFReplacement`，不要求这些
-  替换项来自 `DocumentPackage` 或 OCR；`page_pixel_size` 仅用于把像素 `bbox` 换算为 PDF 坐标，
+  替换项来自 `PDFCraftExtraction` 或 OCR；`page_pixel_size` 仅用于把像素 `bbox` 换算为 PDF 坐标，
   patcher 不会验证它是否等于源页的实际渲染尺寸。调用方必须自行保证页码、坐标与尺寸对应源 PDF。
   `PatchTextOptions` 控制字体、字号、内边距、对齐和 `overflow` 策略；`overflow="error"`（默认）
   在文字无法放入原框时失败，`"skip"` 则把对应项记录在 `patcher.skipped_replacements` 中。
-- `PDFTranslationPipeline` 可将一个 `DocumentPackage` 与 `ChapterTransformer` 或
-  `Callable[[str], str]` 直接写回 PDF；其 `.patch()` 则把 package 已有的文字写回。这是
-  facade 的底层组成部分，普通应用无需直接构造。它只从 package 中带来源坐标的 `text` 和
+- `PDFTranslationPipeline` 可将一个 `PDFCraftExtraction` 与 `ChapterTransformer` 或
+  `Callable[[str], str]` 直接写回 PDF；其 `.patch()` 则把 extraction 已有的文字写回。这是
+  facade 的底层组成部分，普通应用无需直接构造。它只从 extraction 中带来源坐标的 `text` 和
   `sub_title` 布局收集替换项。
 
 它们都不会重排 PDF 页面；页码从 1 开始。
@@ -473,10 +466,10 @@ LLM(
 
 ## 组合建议
 
-- 一次性 PDF → Markdown/EPUB：使用 `PDFCraft(pdf=PDFOptions(...)).convert_pdf_to_*`，不传
-  `package_path` 即可自动管理临时目录。
-- 需要重复渲染、翻译或写回：先用 `extract_pdf` 保存 package，再调用 `render_*`、
-  `translate_package` 或 `patch_pdf_with_package`。
-- PDF → 翻译 PDF：使用同一源 PDF 生成 package，再调用 `translate_pdf`；不要把 EPUB 的
+- 一次性 PDF → Markdown/EPUB：使用 `PDFCraft(pdf=PDFOptions(...)).convert_pdf_to_*`，默认
+  自动管理临时 analysis；需要中间产物时传 `extraction_path`。
+- 需要重复渲染、翻译或写回：先用 `extract_pdf` 保存 `.pcex`，再调用 `render_*`、
+  `translate_extraction` 或 `patch_pdf_with_extraction`。
+- PDF → 翻译 PDF：使用同一源 PDF 生成 extraction，再调用 `translate_pdf`；不要把 EPUB 的
   `APPEND_BLOCK` 语义用于 PDF。
 - EPUB → EPUB：使用 `PDFCraft().translate_epub`，只配置文本 LLM，不需要 OCR。

--- a/docs/zh-CN/INSTALLATION.md
+++ b/docs/zh-CN/INSTALLATION.md
@@ -34,7 +34,7 @@ CUDA 环境安装匹配的 PyTorch。没有可用 CUDA 设备时，使用标准�
 - Poppler：PDF 页面渲染、OCR 提取以及公开的 PDF patch/translation 流程默认需要它，
   因为这些流程会渲染页面来生成或合成内容。
 - 只有纯粹使用 pypdf 读取并写回 PDF 的自定义流程才不需要 Poppler；这不是
-  `PDFCraft.patch_pdf_with_package` 和 `PDFCraft.translate_pdf` 的默认路径。
+  `PDFCraft.patch_pdf_with_extraction` 和 `PDFCraft.translate_pdf` 的默认路径。
 - vendor OCR：网络连接和有效的供应商配置；只要运行 OCR 提取，还需要 Poppler；本机不需要 CUDA。
 - local OCR：支持 CUDA 的 NVIDIA GPU、匹配的 PyTorch、模型缓存、足够的显存和 Poppler。
 

--- a/docs/zh-CN/OCR_BACKENDS.md
+++ b/docs/zh-CN/OCR_BACKENDS.md
@@ -118,7 +118,7 @@ craft = PDFCraft(pdf=PDFOptions(ocr=DeepSeekOCRLocalConfig(
     models_cache_path="models-cache",
 )))
 options = ExtractionOptions(ocr_size="base")
-craft.extract_pdf("input.pdf", "package", options)
+craft.extract_pdf("input.pdf", "book.pcex", options)
 ```
 
 ### 预下载模型

--- a/docs/zh-CN/PDF_TRANSLATION.md
+++ b/docs/zh-CN/PDF_TRANSLATION.md
@@ -64,14 +64,16 @@ metering = craft.convert_pdf_to_markdown("input.pdf", "output.md")
 print(metering.input_tokens, metering.output_tokens)
 ```
 
-`package_path` 默认为 `None`。省略它时，pdf-craft 使用操作系统临时目录，并在转换完成
-或发生异常后清理。需要保留中间结果进行调试或再次渲染时，传入一个可写目录：
+默认情况下，pdf-craft 使用操作系统临时 analysis 目录，并在转换完成或发生异常后清理。
+需要保留诊断信息时传入 `analysing_path`；需要复用或跨机器交换中间结果时传入
+`extraction_path` 导出 `.pcex`：
 
 ```python
 craft.convert_pdf_to_markdown(
     "input.pdf",
     "output.md",
-    package_path="work/pdf-package",
+    analysing_path="work/analysis",
+    extraction_path="work/book.pcex",
 )
 ```
 
@@ -105,8 +107,8 @@ craft.convert_pdf_to_markdown(
 文本 LLM 并返回修改后的章节。本文只说明 pdf-craft 如何接入变换器；LLM 客户端和具体
 提示词由你的应用负责准备。
 
-高层转换方法只执行一次翻译。需要额外 package 变换或更细粒度控制时，可以使用
-`extract_pdf()`、`translate_package()` 和 `render_*()` 自行组合。
+高层转换方法只执行一次翻译。需要分段或更细粒度控制时，可以使用
+`extract_pdf()`、`translate_extraction()` 和 `render_*()` 自行组合。
 
 ## PDF 转换为 EPUB
 
@@ -146,10 +148,10 @@ craft.convert_pdf_to_epub(
 PDF 中与章节来源匹配的文字区域：
 
 ```python
-package = craft.extract_pdf("input.pdf", "work/pdf-package")
+extraction = craft.extract_pdf("input.pdf", "work/book.pcex")
 craft.translate_pdf(
     "input.pdf",
-    package,
+    extraction,
     "translated.pdf",
     translator,
 )
@@ -162,7 +164,7 @@ PDF 写回使用章节中的页面来源和边界框信息，因此不需要重�
 def translator(text: str) -> str:
     return call_text_llm(text)
 
-craft.translate_pdf("input.pdf", package, "translated.pdf", translator)
+craft.translate_pdf("input.pdf", extraction, "translated.pdf", translator)
 ```
 
 PDF 输出不接受 `APPEND_BLOCK` 模式，因为 PDF pipeline 不能在原页面中安全追加新的块级内容。
@@ -182,29 +184,29 @@ PDF 输出不接受 `APPEND_BLOCK` 模式，因为 PDF pipeline 不能在原页�
 - 每段译文都必须在对应 OCR bbox 内排版。默认排版策略会在允许的字号范围内寻找可容纳的
   字号；最小字号仍无法容纳时抛出 `ValueError`。所有 bbox 会先完成预检，因此失败时不会
   留下部分输出文件。
-- `patch_pdf_with_package` 是写回已有 PDF 的操作，不是通用 PDF 排版器，不能只凭提取结果
+- `patch_pdf_with_extraction` 是写回已有 PDF 的操作，不是通用 PDF 排版器，不能只凭提取结果
   生成一个没有原始页面的全新 PDF。
 
-### `patch_pdf_with_package`
+### `patch_pdf_with_extraction`
 
 如果译文已经由其他流程生成，可以跳过 `translate_pdf`，直接把一个结果写回原始 PDF：
 
 ```python
-craft.patch_pdf_with_package(
+craft.patch_pdf_with_extraction(
     "input.pdf",
-    "work/translated-package",
+    "work/translated.pcex",
     "translated.pdf",
 )
 ```
 
-传入路径时，该目录必须符合 pdf-craft 的渲染结果契约；也可以直接传入
-`DocumentPackage` 对象。这个入口不会调用 OCR 或 LLM。PDF 写回使用 `pypdf` 和
+传入路径时必须是通过校验的 `.pcex`；也可以直接传入 `PDFCraftExtraction` 对象。普通目录
+不是公开输入。这个入口不会调用 OCR 或 LLM。PDF 写回使用 `pypdf` 和
 `reportlab`，它们是 pdf-craft 当前的直接运行时依赖；在依赖被移除或非标准安装的环境中，
 底层导入失败会抛出 `RuntimeError`。
 
 ### 调整写回排版
 
-`PDFCraft.translate_pdf` 与 `PDFCraft.patch_pdf_with_package` 为简化调用而设计，不提供字体、
+`PDFCraft.translate_pdf` 与 `PDFCraft.patch_pdf_with_extraction` 为简化调用而设计，不提供字体、
 字号、对齐、padding 或 overflow 策略参数。需要调整这些规则时，使用公开的低层
 `PDFPatcher` 与 `PatchTextOptions`，再交给 `PDFTranslationPipeline`：
 
@@ -223,7 +225,7 @@ patcher = PDFPatcher(options=PatchTextOptions(
     overflow="error",
 ))
 pipeline = PDFTranslationPipeline(patcher=patcher)
-pipeline.translate(Path("input.pdf"), Path("translated.pdf"), package, translator)
+pipeline.translate(Path("input.pdf"), Path("translated.pdf"), extraction, translator)
 ```
 
 `overflow="error"` 是默认策略，无法容纳的译文会失败；`overflow="skip"` 会跳过该 bbox，
@@ -240,7 +242,7 @@ pipeline.translate(Path("input.pdf"), Path("translated.pdf"), package, translato
 Poppler 位置，或让应用统一管理 PDF 文件访问时，才需要注入自定义 handler；通常无需自行实现它。
 
 在门面 API 中，将 handler 放进 `PDFOptions.pdf_handler`。它会用于 PDF 提取；在
-`translate_pdf` / `patch_pdf_with_package` 中也会传入 PDF 写回链路：
+`translate_pdf` / `patch_pdf_with_extraction` 中也会传入 PDF 写回链路：
 
 ```python
 from pdf_craft import DefaultPDFHandler, PDFCraft, PDFOptions
@@ -256,12 +258,11 @@ PDF 写回的低层入口还提供两个独立的注入点，签名和默认值�
 | 入口 | 参数 | 默认值 | 用途 |
 | --- | --- | --- | --- |
 | `PDFPatcher` | `pdf_handler`、`dpi` | `None`、`300` | 以 handler 将每个源页渲染为输出 PDF 的图像背景；没有任何替换项的页面使用其 `dpi`。 |
-| `PDFTranslationPipeline` | `pdf_handler`、`patcher`、`dpi` | `None`、`None`、`300` | 当结果目录缺少页面像素尺寸元数据时，用 handler 以该 `dpi` 渲染源页来解析尺寸；由它收集的替换项也携带该 `dpi`，供 patcher 渲染相应页面背景。 |
+| `PDFTranslationPipeline` | `pdf_handler`、`patcher`、`dpi` | `None`、`None`、`300` | 构造默认 patcher；替换项的坐标 DPI 始终来自 extraction 的 `pages.xml`，缺失时直接失败。 |
 
 `dpi` 越高，源页背景通常越清晰，但生成的 PDF 也会更大、写回更慢。若传入自定义
 `PDFPatcher`，应在它自身同时设置 `pdf_handler` 与 `dpi`；此时 pipeline 不会用自己的
-handler 或 dpi 重建该 patcher。保持二者使用同一 handler 和 dpi，能避免缺失页面尺寸元数据时
-的解析与最终背景渲染不一致：
+handler 或 dpi 重建该 patcher。保持二者使用同一 handler 和 dpi，可统一源页背景渲染策略：
 
 ```python
 from pdf_craft import DefaultPDFHandler, PDFPatcher, PDFTranslationPipeline
@@ -281,28 +282,28 @@ pipeline = PDFTranslationPipeline(pdf_handler=handler, patcher=patcher, dpi=200)
 
 ### `extract_pdf` 与 `extract_pdf_with_metering`
 
-这两个方法将 PDF 提取为 `DocumentPackage`。`package_path` 是必填项，因为返回对象仍然
-依赖该目录中的文件；与一次性转换不同，提取方法不会自动创建并清理临时目录。
+这两个方法将 PDF 提取为 `PDFCraftExtraction`。`.pcex` 输出路径是必填项；该文件可以直接
+存储、上传或交给另一台机器上的后端。普通目录不能作为后端公开输入。
 
 `extract_pdf_with_metering` 额外返回 `OCRTokensMetering`，用于读取本次 OCR 的输入和输出
 token 计量：
 
 ```python
-package, metering = craft.extract_pdf_with_metering(
+extraction, metering = craft.extract_pdf_with_metering(
     "input.pdf",
-    "work/pdf-package",
+    "work/book.pcex",
 )
 ```
 
 ### `render_markdown` 与 `render_epub`
 
-这两个方法只负责渲染已有 `DocumentPackage`，不会重新 OCR。它们适合在提取或变换完成后
+这两个方法只负责渲染已有 `PDFCraftExtraction`，不会重新 OCR。它们适合在提取或变换完成后
 重复生成不同输出格式。
 
-### `translate_package`
+### `translate_extraction`
 
-`translate_package` 将一个结果目录中的章节交给章节变换器，并生成另一个结果目录。它是
-库中唯一面向结果目录翻译的公开入口；任意变换链不属于公共 API。
+`translate_extraction` 将一个 `.pcex` 中的章节交给章节变换器，并生成另一个 `.pcex`。输出会
+保留 manifest、pages、TOC、封面和 assets；任意变换链不属于公共 API。
 
 ## `ExtractionOptions`
 
@@ -328,10 +329,11 @@ package, metering = craft.extract_pdf_with_metering(
 `False`，包括 `convert_pdf_to_epub`；若你的 PDF 确实包含需要按目录页处理的目录，应显式
 传入 `ExtractionOptions(toc_assumed=True)`。
 
-没有显式设置 `dpi` 时，提取时实际以 `300` DPI 渲染页面，且生成的 `document.json` 会记录
-`"dpi": 300`；`ExtractionOptions.dpi` 的 `None` 表示采用该默认值，不表示没有 DPI。提高
+没有显式设置 `dpi` 时，提取时实际以 `300` DPI 渲染页面，且生成的 `pages.xml` 会记录
+该值；`ExtractionOptions.dpi` 的 `None` 表示采用默认值，不表示没有 DPI。提高
 提取 DPI 可能改善小字或细节的 OCR 输入，但同时增加图像尺寸、处理时间和资源消耗。页面像素
-尺寸会随提取 DPI 写入 `document.json`，供后续 PDF 写回将 OCR bbox 对齐到源页。
+尺寸会随提取 DPI 写入 `pages.xml`，供后续 PDF 写回将 OCR bbox 对齐到源页。缺少几何时
+后端会直接拒绝，不会读取 OCR 缓存或重新渲染 PDF 来补齐。
 
 ## 计量、进度与中断
 

--- a/docs/zh-CN/TROUBLESHOOTING.md
+++ b/docs/zh-CN/TROUBLESHOOTING.md
@@ -24,7 +24,7 @@ OCR 请求成功并不代表翻译 LLM 已经配置正确。
 | vendor OCR 请求失败 | endpoint、模型名、API key、网络和供应商配额 |
 | EPUB/PDF 翻译时报 LLM 错误 | 文本 LLM 的 URL、模型、密钥和 token 编码 |
 | 输出文件没有生成 | 输出目录权限、输入文件类型和前一步是否已经失败 |
-| PDF 写回时报 package 或页面错误 | 原始 PDF 是否与提取结果匹配、页面几何信息是否存在 |
+| PDF 写回时报 extraction 或页面错误 | 原始 PDF 是否与 `.pcex` 匹配、`pages.xml` 是否完整 |
 
 ## PDF 和 Poppler 问题
 
@@ -114,7 +114,7 @@ preset：
   这个预算中扣除；`max_ocr_output_tokens` 则只累计限制输出 token。预算在进入下一页前耗尽
   时，提取会以 `TokenLimitError` 中断，而不是继续处理剩余页面。此时先记录异常和已发出的
   OCR 事件，再减少 `page_indexes` 或提高相应上限；提高上限也会增加供应商费用或本地显存压力。
-- `includes_cover=True` 才会把识别到的封面图写入 package；`includes_footnotes=True` 才会
+- `includes_cover=True` 才会把识别到的封面图写入 extraction；`includes_footnotes=True` 才会
   请求并保留脚注内容。遇到“正文有了但封面或脚注缺失”时，先检查这两个选项，而不是重复
   下载模型或更换 OCR backend。
 
@@ -124,7 +124,7 @@ preset：
 预期。需要用 LLM 分析目录时传入 `toc_llm`，并检查它的 endpoint、模型和凭据。目录分析失败
 时，先关闭 `toc_assumed` 或缩小 `page_indexes` 验证目录页，再处理 OCR 本身的问题。
 
-`generate_plot=True` 会额外生成图表相关资源并写入 package 的 `plots` 目录；输出体积突然
+`generate_plot=True` 会额外生成分析图并写入 analysis 的 `plots` 目录；这些诊断信息不进入 `.pcex`。输出体积突然
 变大或目录中出现额外资源时，这是预期行为。若磁盘空间不足，先关闭该选项。
 
 ### 用 OCR 事件定位具体页面
@@ -205,8 +205,9 @@ EPUB 翻译要求 LLM 返回完整、可解析的结构化结果。使用 `on_fi
 
 ## 输出文件和临时目录问题
 
-`convert_pdf_to_markdown` 与 `convert_pdf_to_epub` 未传入 `package_path` 时，会创建系统临时工作
-目录，并在成功或异常后清理。需要调试中间结果时，显式传入一个可写的 `package_path`；该目录
+`convert_pdf_to_markdown` 与 `convert_pdf_to_epub` 默认创建系统临时 analysis 目录，并在成功或
+异常后清理。需要调试时传入可写的 `analysing_path`；需要复用中间结果时传入 `.pcex`
+`extraction_path`。后端不接受普通目录；调用方提供的 analysis 和 `.pcex`
 由调用者负责管理，不会自动删除。
 
 如果最终输出没有生成，先确认输出路径的父目录存在且可写，并检查异常是否发生在 OCR、翻译或
@@ -236,6 +237,6 @@ PDF 翻译写回需要原始 PDF 和与它匹配的提取结果。写回阶段�
 - 是否使用 CUDA、`torch.cuda.is_available()` 的结果和 GPU 型号；
 - 输入 PDF/EPUB 的页数或章节数，以及失败发生在哪一步；
 - 完整异常类型和消息（删除 API key、token、文件内容等敏感信息）；
-- 是否使用显式 `package_path`、`models_cache_path` 或 LLM `cache_path`。
+- 是否使用显式 `analysing_path`、`extraction_path`、`models_cache_path` 或 LLM `cache_path`。
 
 不要把真实密钥、完整 PDF、模型缓存或生成日志直接提交到代码仓库。

--- a/pdf_craft/__init__.py
+++ b/pdf_craft/__init__.py
@@ -13,10 +13,10 @@ from .craft import ExtractionOptions, PDFCraft, PDFOptions
 from .pipeline.epub import translate_epub
 from .pipeline.pdf import PDFPatcher, PDFReplacement, PDFSkippedReplacement, PDFTranslationPipeline, PatchTextOptions
 from .transformer import (
-    ChapterPackageTransformer,
+    ChapterExtractionTransformer,
     ChapterXMLTransformer,
+    ExtractionTransformer,
     FillFailedEvent,
-    PackageTransformer,
     SubmitKind,
     XMLTranslator,
     TranslationEvent,
@@ -48,6 +48,6 @@ from .pdf import (
     PDFHandler,
     pdf_pages_count,
 )
-from .document import DocumentPackage, SourceLocation
+from .document import PDFCraftExtraction, SourceLocation
 from .extractor import PDFExtractor
 from .renderer import EpubRenderer, MarkdownRenderer

--- a/pdf_craft/craft.py
+++ b/pdf_craft/craft.py
@@ -1,5 +1,8 @@
 """Public facade that composes pdf-craft's independent components."""
 
+# Internal workspace methods are intentionally shared only inside pdf-craft.
+# pylint: disable=protected-access
+
 from collections.abc import Callable, Container
 from contextlib import contextmanager
 from dataclasses import dataclass
@@ -10,7 +13,7 @@ from typing import Iterator, Literal
 
 from epub_generator import BookMeta, LaTeXRender, TableRender
 
-from .document import DocumentPackage
+from .document import PDFCraftExtraction
 from .extractor.chapter.chapter import Chapter, ParagraphLayout
 from .extractor.chapter.reader import create_chapters_reader
 from .error import IgnoreOCRErrorsChecker, IgnorePDFErrorsChecker
@@ -23,7 +26,7 @@ from .pipeline.epub import translate_epub as run_epub_translation
 from .pipeline.pdf import PDFTranslationPipeline
 from .pipeline.pdf.pipeline import _to_patch_text
 from .renderer import EpubRenderer, MarkdownRenderer
-from .transformer import ChapterPackageTransformer, ChapterTransformer, SubmitKind, TranslationEvent
+from .transformer import ChapterExtractionTransformer, ChapterTransformer, SubmitKind, TranslationEvent
 
 
 @dataclass(frozen=True)
@@ -73,19 +76,24 @@ class PDFCraft:
         return cls(_engine=engine)
 
     def extract_pdf(
-        self, source: PathLike | str, package_path: PathLike | str,
+        self, source: PathLike | str, extraction_path: PathLike | str,
         options: ExtractionOptions | None = None,
-    ) -> DocumentPackage:
-        package, _ = self.extract_pdf_with_metering(source, package_path, options)
-        return package
+        *, analysing_path: PathLike | str | None = None,
+    ) -> PDFCraftExtraction:
+        extraction, _ = self.extract_pdf_with_metering(
+            source, extraction_path, options, analysing_path=analysing_path
+        )
+        return extraction
 
     def extract_pdf_with_metering(
-        self, source: PathLike | str, package_path: PathLike | str,
+        self, source: PathLike | str, extraction_path: PathLike | str,
         options: ExtractionOptions | None = None,
-    ) -> tuple[DocumentPackage, OCRTokensMetering]:
+        *, analysing_path: PathLike | str | None = None,
+    ) -> tuple[PDFCraftExtraction, OCRTokensMetering]:
         options = options or ExtractionOptions()
         return PDFExtractor(self._pdf_engine()).extract_with_metering(
-            Path(source), Path(package_path),
+            Path(source), Path(extraction_path),
+            analysing_path=Path(analysing_path) if analysing_path is not None else None,
             page_indexes=options.page_indexes,
             ocr_size=options.ocr_size, dpi=options.dpi,
             max_page_image_file_size=options.max_page_image_file_size,
@@ -101,69 +109,68 @@ class PDFCraft:
         )
 
     def render_markdown(
-        self, package: DocumentPackage, output: PathLike | str,
+        self, extraction: PDFCraftExtraction | PathLike | str, output: PathLike | str,
         assets_path: PathLike | str | None = None,
         *, aborted: AbortedCheck = lambda: False,
     ) -> None:
-        MarkdownRenderer().render(package, Path(output),
+        MarkdownRenderer().render(_ensure_extraction(extraction), Path(output),
                                   Path(assets_path) if assets_path is not None else None,
                                   aborted=aborted)
 
-    def translate_package(
-        self, package: DocumentPackage, output_path: PathLike | str,
+    def translate_extraction(
+        self, extraction: PDFCraftExtraction | PathLike | str, output_path: PathLike | str,
         translator: ChapterTransformer,
         *, submit: SubmitKind = SubmitKind.REPLACE,
         on_translation_event: Callable[[TranslationEvent], None] | None = None,
-    ) -> DocumentPackage:
-        """Translate one render-ready package into another package.
+    ) -> PDFCraftExtraction:
+        """Translate one PDFCraftExtraction into another ``.pcex`` artifact.
 
         The public operation is intentionally singular and translation-focused;
-        arbitrary package transformation chains remain an internal composition
-        detail used by the compatibility workflows.
+        arbitrary transformation chains remain an internal composition detail.
         """
-        package_transformer = ChapterPackageTransformer(translator, mode=submit)
-        return package_transformer.transform(
-            package, Path(output_path), on_translation_event=on_translation_event,
+        extraction_transformer = ChapterExtractionTransformer(translator, mode=submit)
+        return extraction_transformer.transform(
+            _ensure_extraction(extraction), Path(output_path), on_translation_event=on_translation_event,
             emit_translation_events=True,
         )
 
     def render_epub(
-        self, package: DocumentPackage, output: PathLike | str, *,
-        book_meta: BookMeta | None = None, lan: Literal["zh", "en"] = "zh",
+        self, extraction: PDFCraftExtraction | PathLike | str, output: PathLike | str, *,
+        book_meta: BookMeta | None = None, lan: Literal["zh", "en"] | None = None,
         table_render: TableRender = TableRender.HTML,
         latex_render: LaTeXRender = LaTeXRender.MATHML,
         inline_latex: bool = True,
         aborted: AbortedCheck = lambda: False,
     ) -> None:
-        EpubRenderer().render(package, Path(output), book_meta=book_meta, lan=lan,
+        EpubRenderer().render(_ensure_extraction(extraction), Path(output), book_meta=book_meta, lan=lan,
                               table_render=table_render, latex_render=latex_render,
                               inline_latex=inline_latex, aborted=aborted)
 
     def translate_pdf(
-        self, source: PathLike | str, package: DocumentPackage,
+        self, source: PathLike | str, extraction: PDFCraftExtraction | PathLike | str,
         output: PathLike | str, transformer: ChapterTransformer | Callable[[str], str],
         *, on_translation_event: Callable[[TranslationEvent], None] | None = None,
     ) -> None:
-        with TemporaryDirectory(prefix="pdf-craft-translated-package-") as directory:
+        with TemporaryDirectory(prefix="pdf-craft-translated-extraction-") as directory:
             translated = self._translate_for_pdf(
-                package, Path(directory), transformer,
+                _ensure_extraction(extraction), Path(directory), transformer,
                 on_translation_event=on_translation_event,
             )
-            self.patch_pdf_with_package(source, translated, output)
+            self.patch_pdf_with_extraction(source, translated, output)
 
-    def patch_pdf_with_package(
+    def patch_pdf_with_extraction(
         self,
         source: PathLike | str,
-        package: DocumentPackage | PathLike | str,
+        extraction: PDFCraftExtraction | PathLike | str,
         output: PathLike | str,
     ) -> None:
-        """Patch an existing PDF with text and geometry from a DocumentPackage."""
-        package = package if isinstance(package, DocumentPackage) else DocumentPackage.from_path(Path(package))
-        package.validate()
-        _validate_package_for_pdf(Path(source), package)
+        """Patch an existing PDF with text and geometry from a PDFCraftExtraction."""
+        extraction = _ensure_extraction(extraction)
+        extraction.validate()
+        _validate_extraction_for_pdf(Path(source), extraction)
         PDFTranslationPipeline(
             pdf_handler=self._pdf.pdf_handler if self._pdf else None
-        ).patch(Path(source), Path(output), package)
+        ).patch(Path(source), Path(output), extraction)
 
     def translate_epub(self, source: PathLike | str, output: PathLike | str, *,
                        target_language: str, submit: SubmitKind,
@@ -172,27 +179,37 @@ class PDFCraft:
 
     def convert_pdf_to_markdown(
         self, source: PathLike | str, output: PathLike | str, *,
-        package_path: PathLike | str | None = None, extraction: ExtractionOptions | None = None,
+        analysing_path: PathLike | str | None = None,
+        extraction_path: PathLike | str | None = None,
+        extraction: ExtractionOptions | None = None,
         assets_path: PathLike | str | None = None,
         translator: ChapterTransformer | None = None,
         submit: SubmitKind = SubmitKind.REPLACE,
         on_translation_event: Callable[[TranslationEvent], None] | None = None,
     ) -> OCRTokensMetering:
-        with _package_workspace(package_path) as workspace:
-            package, metering = self.extract_pdf_with_metering(source, workspace, extraction)
+        with _analysis_workspace(analysing_path) as workspace:
+            document, metering = self._extract_to_workspace(source, workspace, extraction)
+            if extraction_path is not None:
+                document.export(Path(extraction_path))
             if translator is not None:
-                package = self.translate_package(
-                    package, workspace / "translated", translator,
-                    submit=submit, on_translation_event=on_translation_event,
-                )
-            self.render_markdown(package, output, assets_path,
-                                 aborted=(extraction or ExtractionOptions()).aborted)
-            return metering
+                with TemporaryDirectory(prefix="pdf-craft-translated-extraction-") as directory:
+                    document = self._translate_to_workspace(
+                        document, Path(directory) / "extraction", translator,
+                        submit=submit, on_translation_event=on_translation_event,
+                    )
+                    self.render_markdown(document, output, assets_path,
+                                         aborted=(extraction or ExtractionOptions()).aborted)
+            else:
+                self.render_markdown(document, output, assets_path,
+                                     aborted=(extraction or ExtractionOptions()).aborted)
+        return metering
 
     def convert_pdf_to_epub(
         self, source: PathLike | str, output: PathLike | str, *,
-        package_path: PathLike | str | None = None, extraction: ExtractionOptions | None = None,
-        book_meta: BookMeta | None = None, lan: Literal["zh", "en"] = "zh",
+        analysing_path: PathLike | str | None = None,
+        extraction_path: PathLike | str | None = None,
+        extraction: ExtractionOptions | None = None,
+        book_meta: BookMeta | None = None, lan: Literal["zh", "en"] | None = None,
         table_render: TableRender = TableRender.HTML,
         latex_render: LaTeXRender = LaTeXRender.MATHML,
         inline_latex: bool = True,
@@ -201,35 +218,75 @@ class PDFCraft:
         on_translation_event: Callable[[TranslationEvent], None] | None = None,
     ) -> OCRTokensMetering:
         extraction = extraction or ExtractionOptions()
-        with _package_workspace(package_path) as workspace:
-            package, metering = self.extract_pdf_with_metering(source, workspace, extraction)
+        with _analysis_workspace(analysing_path) as workspace:
+            document, metering = self._extract_to_workspace(source, workspace, extraction)
+            if extraction_path is not None:
+                document.export(Path(extraction_path))
             if translator is not None:
-                package = self.translate_package(
-                    package, workspace / "translated", translator,
-                    submit=submit, on_translation_event=on_translation_event,
-                )
-            if book_meta is None:
-                book_meta = self._extract_book_meta(Path(source))
-            self.render_epub(package, output, book_meta=book_meta, lan=lan,
-                             table_render=table_render, latex_render=latex_render,
-                             inline_latex=inline_latex, aborted=extraction.aborted)
-            return metering
+                with TemporaryDirectory(prefix="pdf-craft-translated-extraction-") as directory:
+                    document = self._translate_to_workspace(
+                        document, Path(directory) / "extraction", translator,
+                        submit=submit, on_translation_event=on_translation_event,
+                    )
+                    self.render_epub(document, output, book_meta=book_meta, lan=lan,
+                                     table_render=table_render, latex_render=latex_render,
+                                     inline_latex=inline_latex, aborted=extraction.aborted)
+            else:
+                self.render_epub(document, output, book_meta=book_meta, lan=lan,
+                                 table_render=table_render, latex_render=latex_render,
+                                 inline_latex=inline_latex, aborted=extraction.aborted)
+        return metering
 
     def _translate_for_pdf(
         self,
-        package: DocumentPackage,
+        extraction: PDFCraftExtraction,
         output_root: Path,
         transformer: ChapterTransformer | Callable[[str], str],
         *, on_translation_event: Callable[[TranslationEvent], None] | None = None,
-    ) -> DocumentPackage:
-        current = package
+    ) -> PDFCraftExtraction:
         if callable(transformer):
             transformer = _TextChapterTransformer(transformer)
-        current = self.translate_package(
-            current, output_root / "translated", transformer,
+        return self._translate_to_workspace(
+            extraction, output_root / "translated", transformer,
             on_translation_event=on_translation_event,
         )
-        return current
+
+    def _translate_to_workspace(
+        self,
+        extraction: PDFCraftExtraction,
+        output_path: Path,
+        transformer: ChapterTransformer,
+        *,
+        submit: SubmitKind = SubmitKind.REPLACE,
+        on_translation_event: Callable[[TranslationEvent], None] | None = None,
+    ) -> PDFCraftExtraction:
+        return ChapterExtractionTransformer(transformer, mode=submit)._transform_to_workspace(
+            extraction, output_path, on_translation_event=on_translation_event,
+            emit_translation_events=True,
+        )
+
+    def _extract_to_workspace(
+        self,
+        source: PathLike | str,
+        analysing_path: Path,
+        options: ExtractionOptions | None,
+    ) -> tuple[PDFCraftExtraction, OCRTokensMetering]:
+        options = options or ExtractionOptions()
+        return PDFExtractor(self._pdf_engine())._extract_to_workspace(
+            Path(source), analysing_path,
+            page_indexes=options.page_indexes,
+            ocr_size=options.ocr_size, dpi=options.dpi,
+            max_page_image_file_size=options.max_page_image_file_size,
+            max_tokens=options.max_ocr_tokens,
+            max_output_tokens=options.max_ocr_output_tokens,
+            includes_cover=options.includes_cover,
+            includes_footnotes=options.includes_footnotes,
+            generate_plot=options.generate_plot,
+            toc_assumed=options.toc_assumed, toc_llm=options.toc_llm,
+            ignore_pdf_errors=options.ignore_pdf_errors,
+            ignore_ocr_errors=options.ignore_ocr_errors,
+            aborted=options.aborted, on_ocr_event=options.on_ocr_event,
+        )
 
     def _pdf_engine(self):
         if self._engine is not None:
@@ -239,27 +296,22 @@ class PDFCraft:
         # Import lazily so EPUB-only callers never import the historical adapter.
         from .transform import PDFExtractionEngine
         return PDFExtractionEngine(models_cache_path=self._pdf.models_cache_path,
-                         pdf_handler=self._pdf.pdf_handler,
-                         local_only=self._pdf.local_only, ocr=self._pdf.ocr)
-
-    def _extract_book_meta(self, source: Path) -> BookMeta | None:
-        engine = self._pdf_engine()
-        extract = getattr(engine, "_extract_book_meta", None)
-        return extract(source) if extract is not None else None
+                                   pdf_handler=self._pdf.pdf_handler,
+                                   local_only=self._pdf.local_only, ocr=self._pdf.ocr)
 
 
 @contextmanager
-def _package_workspace(package_path: PathLike | str | None) -> Iterator[Path]:
-    """Provide a persistent package path or a cleaned-up temporary workspace."""
-    if package_path is not None:
-        yield Path(package_path)
+def _analysis_workspace(analysing_path: PathLike | str | None) -> Iterator[Path]:
+    """Provide a persistent analysis path or a cleaned-up temporary workspace."""
+    if analysing_path is not None:
+        yield Path(analysing_path)
         return
-    with TemporaryDirectory(prefix="pdf-craft-package-") as directory:
+    with TemporaryDirectory(prefix="pdf-craft-analysis-") as directory:
         yield Path(directory)
 
 
 class _TextChapterTransformer:
-    """Adapt the legacy block-text callback to the package transformer shape."""
+    """Adapt the block-text callback to the extraction transformer shape."""
 
     def __init__(self, callback: Callable[[str], str]) -> None:
         self._callback = callback
@@ -276,32 +328,39 @@ class _TextChapterTransformer:
         return chapter
 
 
-def _validate_package_for_pdf(source: Path, package: DocumentPackage) -> None:
-    """Fail before patching when package geometry cannot match the PDF."""
+def _validate_extraction_for_pdf(source: Path, extraction: PDFCraftExtraction) -> None:
+    """Fail before patching when extraction geometry cannot match the PDF."""
     try:
         import pypdf
     except ImportError as error:
         raise RuntimeError("PDF patching requires the optional 'pypdf' dependency") from error
-    page_sizes = package.page_pixel_sizes()
+    page_sizes = extraction.page_pixel_sizes()
     if not page_sizes:
-        raise ValueError("DocumentPackage is missing page geometry metadata required for PDF patching")
+        raise ValueError("PDFCraftExtraction is missing page geometry required for PDF patching")
     page_count = len(pypdf.PdfReader(str(source)).pages)
-    chapter_pages = {
-        block.page_index
-        for chapter in create_chapters_reader(package.chapters_path)()
-        for layout in chapter.layouts
-        if isinstance(layout, ParagraphLayout)
-        for block in layout.blocks
-    }
+    with extraction._materialize() as paths:
+        chapter_pages = {
+            block.page_index
+            for chapter in create_chapters_reader(paths.chapters)()
+            for layout in chapter.layouts
+            if isinstance(layout, ParagraphLayout)
+            for block in layout.blocks
+        }
     invalid = sorted(page for page in set(page_sizes) | chapter_pages if page > page_count)
     if invalid:
         raise ValueError(
-            "DocumentPackage page geometry exceeds source PDF page count: "
+            "PDFCraftExtraction page geometry exceeds source PDF page count: "
             f"pages {invalid} of {page_count}"
         )
     missing = sorted(page for page in chapter_pages if page not in page_sizes)
     if missing:
         raise ValueError(
-            "DocumentPackage is missing page geometry for chapter pages: "
+            "PDFCraftExtraction is missing page geometry for chapter pages: "
             f"{missing}"
         )
+
+
+def _ensure_extraction(value: PDFCraftExtraction | PathLike | str) -> PDFCraftExtraction:
+    if isinstance(value, PDFCraftExtraction):
+        return value
+    return PDFCraftExtraction.open(Path(value))

--- a/pdf_craft/document/__init__.py
+++ b/pdf_craft/document/__init__.py
@@ -1,4 +1,4 @@
-from .package import DocumentPackage
+from .package import ExtractionPaths, PDFCraftExtraction, write_manifest, write_pages
 from .source import SourceLocation, source_location
 
-__all__ = ["DocumentPackage", "SourceLocation", "source_location"]
+__all__ = ["PDFCraftExtraction", "SourceLocation", "source_location"]

--- a/pdf_craft/document/package.py
+++ b/pdf_craft/document/package.py
@@ -231,6 +231,9 @@ def write_pages(root: Path, *, render_dpi: int, page_pixel_sizes: dict[int, tupl
 
 
 def _validate_workspace(paths: ExtractionPaths, *, require_toc: bool = False) -> None:
+    # Import lazily because the extractor package imports the public document API.
+    from ..extractor.chapter.chapter import decode as decode_chapter
+
     _read_manifest(paths.manifest)
     _, page_sizes = _read_pages(paths.pages)
     if not paths.chapters.is_dir():
@@ -252,6 +255,10 @@ def _validate_workspace(paths: ExtractionPaths, *, require_toc: bool = False) ->
             if not suffix.isdigit():
                 raise ValueError(f"invalid chapter filename: {path.name}")
         root = _require_xml_root(path, "chapter")
+        try:
+            decode_chapter(root)
+        except ValueError as error:
+            raise ValueError(f"invalid chapter schema in {path.name}: {error}") from error
         for element in root.iter():
             page_index = element.get("page_index")
             det = element.get("det")
@@ -266,8 +273,11 @@ def _validate_workspace(paths: ExtractionPaths, *, require_toc: bool = False) ->
             if det is not None:
                 _validate_bbox(det, page_sizes[index], path.name)
             asset_hash = element.get("hash") if element.tag == "asset" else None
-            if asset_hash is not None and not (paths.assets / f"{asset_hash}.png").is_file():
-                raise ValueError(f"{path.name} references missing asset: {asset_hash}.png")
+            if asset_hash is not None:
+                if not _is_asset_hash(asset_hash):
+                    raise ValueError(f"invalid asset hash in {path.name}: {asset_hash}")
+                if not (paths.assets / f"{asset_hash}.png").is_file():
+                    raise ValueError(f"{path.name} references missing asset: {asset_hash}.png")
 
 
 def _read_manifest(path: Path) -> dict[str, Any]:
@@ -295,7 +305,7 @@ def _read_manifest(path: Path) -> dict[str, Any]:
         except ValueError as error:
             raise ValueError("manifest.json created_at must be ISO 8601") from error
     document = payload.get("document")
-    if not isinstance(document, dict) or set(document) - _DOCUMENT_FIELDS:
+    if not isinstance(document, dict) or set(document) != _DOCUMENT_FIELDS:
         raise ValueError("manifest.json has invalid document metadata")
     for key in ("title", "description", "publisher", "isbn", "modified", "language"):
         value = document.get(key)
@@ -393,8 +403,7 @@ def _validate_workspace_members(paths: ExtractionPaths) -> None:
             path.is_file()
             and not path.is_symlink()
             and path.name.endswith(".png")
-            and len(path.name) == 68
-            and all(character in "0123456789abcdef" for character in path.name[:-4])
+            and _is_asset_hash(path.name[:-4])
         )
         if not valid:
             raise ValueError(f"invalid asset member: {path.name}")
@@ -472,8 +481,7 @@ def _validate_archive_member(info: ZipInfo) -> None:
         len(pure.parts) == 2
         and pure.parts[0] == "assets"
         and pure.parts[1].endswith(".png")
-        and len(pure.parts[1]) == 68
-        and all(character in "0123456789abcdef" for character in pure.parts[1][:-4])
+        and _is_asset_hash(pure.parts[1][:-4])
     )
     if not allowed:
         raise ValueError(f"unsupported PDFCraftExtraction member: {name}")
@@ -495,9 +503,11 @@ def _optional_string(value: object) -> str | None:
     return value if isinstance(value, str) else None
 
 
+def _is_asset_hash(value: str) -> bool:
+    return len(value) == 64 and all(character in "0123456789abcdef" for character in value)
+
+
 def _string_list(value: object) -> list[str]:
-    if value is None:
-        return []
     if not isinstance(value, list) or not all(isinstance(item, str) for item in value):
         raise ValueError("document contributor metadata must be arrays of strings")
     return list(value)

--- a/pdf_craft/document/package.py
+++ b/pdf_craft/document/package.py
@@ -1,92 +1,503 @@
+"""The public PDF Craft Extraction artifact and its internal workspace storage."""
+
+from collections.abc import Iterator
+from contextlib import contextmanager
 from dataclasses import dataclass
-from pathlib import Path
+from datetime import datetime, timezone
+from importlib.metadata import PackageNotFoundError, version
 import json
-from typing import Any
+from pathlib import Path, PurePosixPath
+from tempfile import NamedTemporaryFile, TemporaryDirectory
+from typing import Any, Protocol
+from xml.etree import ElementTree
+from zipfile import BadZipFile, ZIP_DEFLATED, ZipFile, ZipInfo
+
+from epub_generator import BookMeta
+
+from ..common import indent, save_xml
 
 
-@dataclass
-class DocumentPackage:
-    """Stable renderer input produced by an Extractor."""
+FORMAT_VERSION = 1
+EXTRACTION_SUFFIX = ".pcex"
+_MANIFEST_FIELDS = {"format_version", "producer", "created_at", "document"}
+_DOCUMENT_FIELDS = {
+    "title", "description", "publisher", "isbn", "authors", "editors",
+    "translators", "modified", "language",
+}
 
-    chapters_path: Path
-    assets_path: Path
-    toc_path: Path | None = None
-    cover_path: Path | None = None
-    metadata_path: Path | None = None
+
+@dataclass(frozen=True)
+class ExtractionPaths:
+    """Filesystem view used only while an extraction is materialized."""
+
+    root: Path
+    manifest: Path
+    pages: Path
+    chapters: Path
+    assets: Path
+    toc: Path
+    cover: Path
 
     @classmethod
-    def from_path(cls, path: Path) -> "DocumentPackage":
-        cover_path = path / "cover.png"
+    def at(cls, root: Path) -> "ExtractionPaths":
         return cls(
-            chapters_path=path / "chapters",
-            assets_path=path / "assets",
-            toc_path=path / "toc.xml",
-            cover_path=cover_path if cover_path.exists() else None,
-            metadata_path=path / "document.json",
+            root=root,
+            manifest=root / "manifest.json",
+            pages=root / "pages.xml",
+            chapters=root / "chapters",
+            assets=root / "assets",
+            toc=root / "toc.xml",
+            cover=root / "cover.png",
         )
 
-    def validate(self, require_toc: bool = False) -> "DocumentPackage":
-        if not self.chapters_path.is_dir():
-            raise ValueError(f"missing chapters directory: {self.chapters_path}")
-        if not self.assets_path.is_dir():
-            raise ValueError(f"missing assets directory: {self.assets_path}")
-        if require_toc and not self.has_toc():
-            raise ValueError("document package is missing toc.xml")
-        if self.metadata_path is not None and self.metadata_path.exists():
-            data = json.loads(self.metadata_path.read_text(encoding="utf-8"))
-            if data.get("schema") != 1:
-                raise ValueError("unsupported document package schema")
-            self._parse_page_pixel_sizes(data)
+
+class _Storage(Protocol):
+    @contextmanager
+    def materialize(self) -> Iterator[ExtractionPaths]: ...
+
+
+@dataclass(frozen=True)
+class _WorkspaceStorage:
+    root: Path
+
+    @contextmanager
+    def materialize(self) -> Iterator[ExtractionPaths]:
+        yield ExtractionPaths.at(self.root)
+
+
+class _ArchiveStorage:
+    """Validated archive snapshot materialized once for an extraction's lifetime."""
+
+    def __init__(self, path: Path, *, eager: bool = True) -> None:
+        self.path = path
+        self._temporary: TemporaryDirectory[str] | None = None
+        self._paths: ExtractionPaths | None = None
+        if eager:
+            self._ensure_materialized()
+
+    def _ensure_materialized(self) -> ExtractionPaths:
+        if self._paths is not None:
+            return self._paths
+        temporary = TemporaryDirectory(prefix="pdf-craft-extraction-")
+        paths = ExtractionPaths.at(Path(temporary.name))
+        try:
+            _extract_archive(self.path, paths.root)
+            _validate_workspace(paths)
+        except Exception:
+            temporary.cleanup()
+            raise
+        self._temporary = temporary
+        self._paths = paths
+        return paths
+
+    @contextmanager
+    def materialize(self) -> Iterator[ExtractionPaths]:
+        yield self._ensure_materialized()
+
+
+class PDFCraftExtraction:
+    """A structured PDF extraction backed by a workspace or ``.pcex`` archive.
+
+    Directory-backed instances are internal and keep one-shot conversion paths
+    fast. Public persistence and interchange use :meth:`open` and :meth:`export`.
+    """
+
+    def __init__(self, path: str | Path) -> None:
+        archive = Path(path)
+        _require_pcex_path(archive)
+        if not archive.is_file():
+            raise FileNotFoundError(f"PDFCraftExtraction does not exist: {archive}")
+        self._storage: _Storage = _ArchiveStorage(archive)
+
+    @classmethod
+    def open(cls, path: str | Path) -> "PDFCraftExtraction":
+        """Load and validate a public ``.pcex`` artifact."""
+        return cls(path)
+
+    @classmethod
+    def load(cls, path: str | Path) -> "PDFCraftExtraction":
+        """Alias for :meth:`open` for callers that prefer artifact terminology."""
+        return cls(path)
+
+    @classmethod
+    def _from_workspace(cls, root: Path) -> "PDFCraftExtraction":
+        """Create the internal directory-backed representation."""
+        extraction = cls.__new__(cls)
+        extraction._storage = _WorkspaceStorage(root)
+        return extraction
+
+    @classmethod
+    def _from_exported_archive(cls, path: Path) -> "PDFCraftExtraction":
+        """Create a lazy view of an archive just written by this process."""
+        extraction = cls.__new__(cls)
+        extraction._storage = _ArchiveStorage(path, eager=False)
+        return extraction
+
+    @contextmanager
+    def _materialize(self) -> Iterator[ExtractionPaths]:
+        with self._storage.materialize() as paths:
+            yield paths
+
+    def validate(self, *, require_toc: bool = False) -> "PDFCraftExtraction":
+        with self._materialize() as paths:
+            _validate_workspace(paths, require_toc=require_toc)
         return self
 
-    def write_metadata(self, *, dpi: int | None = None,
-                       page_pixel_sizes: dict[int, tuple[int, int]] | None = None) -> None:
-        path = self.metadata_path or self.chapters_path.parent / "document.json"
-        self.metadata_path = path
-        path.parent.mkdir(parents=True, exist_ok=True)
-        payload = {"schema": 1, "bbox_coordinate_space": "ocr_pixels",
-                   "page_index_base": 1, "dpi": dpi,
-                   "page_pixel_sizes": {str(k): list(v) for k, v in (page_pixel_sizes or {}).items()}}
-        path.write_text(json.dumps(payload, ensure_ascii=False, indent=2), encoding="utf-8")
+    def export(self, path: str | Path) -> "PDFCraftExtraction":
+        target = Path(path)
+        _require_pcex_path(target)
+        if target.exists():
+            raise FileExistsError(f"PDFCraftExtraction already exists: {target}")
+        target.parent.mkdir(parents=True, exist_ok=True)
+        with self._materialize() as paths:
+            _validate_workspace(paths)
+            _write_archive(paths, target)
+        return PDFCraftExtraction._from_exported_archive(target)
 
     def page_pixel_sizes(self) -> dict[int, tuple[int, int]]:
-        """Return OCR canvas sizes recorded by the Extractor, without OCR cache."""
-        if self.metadata_path is None or not self.metadata_path.exists():
-            return {}
-        payload = json.loads(self.metadata_path.read_text(encoding="utf-8"))
-        return self._parse_page_pixel_sizes(payload)
+        with self._materialize() as paths:
+            return _read_pages(paths.pages)[1]
 
-    @staticmethod
-    def _parse_page_pixel_sizes(payload: dict[str, Any]) -> dict[int, tuple[int, int]]:
-        raw_sizes = payload.get("page_pixel_sizes", {})
-        if not isinstance(raw_sizes, dict):
-            raise ValueError("page_pixel_sizes must be a mapping")
-        sizes: dict[int, tuple[int, int]] = {}
-        for raw_index, raw_size in raw_sizes.items():
+    def render_dpi(self) -> int:
+        with self._materialize() as paths:
+            return _read_pages(paths.pages)[0]
+
+    def book_meta(self) -> BookMeta | None:
+        document = self.document_metadata()
+        if not document:
+            return None
+        modified = document.get("modified")
+        parsed_modified = datetime.fromisoformat(modified) if isinstance(modified, str) else None
+        return BookMeta(
+            title=_optional_string(document.get("title")),
+            description=_optional_string(document.get("description")),
+            publisher=_optional_string(document.get("publisher")),
+            isbn=_optional_string(document.get("isbn")),
+            authors=_string_list(document.get("authors")),
+            editors=_string_list(document.get("editors")),
+            translators=_string_list(document.get("translators")),
+            modified=parsed_modified,
+        )
+
+    def language(self) -> str | None:
+        return _optional_string(self.document_metadata().get("language"))
+
+    def document_metadata(self) -> dict[str, Any]:
+        with self._materialize() as paths:
+            return dict(_read_manifest(paths.manifest)["document"])
+
+
+def write_manifest(
+    root: Path,
+    *,
+    book_meta: BookMeta | None,
+    language: str | None = None,
+) -> None:
+    """Write the format manifest at the extraction boundary."""
+    metadata = book_meta or BookMeta()
+    modified = metadata.modified.isoformat() if metadata.modified is not None else None
+    payload = {
+        "format_version": FORMAT_VERSION,
+        "producer": {"name": "pdf-craft", "version": _producer_version()},
+        "created_at": datetime.now(timezone.utc).isoformat(),
+        "document": {
+            "title": metadata.title,
+            "description": metadata.description,
+            "publisher": metadata.publisher,
+            "isbn": metadata.isbn,
+            "authors": list(metadata.authors),
+            "editors": list(metadata.editors),
+            "translators": list(metadata.translators),
+            "modified": modified,
+            "language": language,
+        },
+    }
+    path = ExtractionPaths.at(root).manifest
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(json.dumps(payload, ensure_ascii=False, indent=2), encoding="utf-8")
+
+
+def write_pages(root: Path, *, render_dpi: int, page_pixel_sizes: dict[int, tuple[int, int]]) -> None:
+    """Write page coordinate metadata consumed by all downstream PDF work."""
+    pages = ElementTree.Element(
+        "pages",
+        {"index_base": "1", "coordinate_space": "ocr_pixels", "render_dpi": str(render_dpi)},
+    )
+    for index, (width, height) in sorted(page_pixel_sizes.items()):
+        ElementTree.SubElement(
+            pages, "page", {"index": str(index), "width": str(width), "height": str(height)}
+        )
+    save_xml(indent(pages), ExtractionPaths.at(root).pages)
+
+
+def _validate_workspace(paths: ExtractionPaths, *, require_toc: bool = False) -> None:
+    _read_manifest(paths.manifest)
+    _, page_sizes = _read_pages(paths.pages)
+    if not paths.chapters.is_dir():
+        raise ValueError("PDFCraftExtraction is missing chapters directory")
+    if not paths.assets.is_dir():
+        raise ValueError("PDFCraftExtraction is missing assets directory")
+    if require_toc and not paths.toc.is_file():
+        raise ValueError("PDFCraftExtraction is missing toc.xml")
+    if paths.toc.exists():
+        _require_xml_root(paths.toc, "toc")
+    if paths.cover.exists() and not paths.cover.is_file():
+        raise ValueError("PDFCraftExtraction cover.png is not a file")
+    _validate_workspace_members(paths)
+
+    chapter_paths = list(paths.chapters.glob("chapter_*.xml"))
+    for path in chapter_paths:
+        if path.name != "chapter_head.xml":
+            suffix = path.stem.removeprefix("chapter_")
+            if not suffix.isdigit():
+                raise ValueError(f"invalid chapter filename: {path.name}")
+        root = _require_xml_root(path, "chapter")
+        for element in root.iter():
+            page_index = element.get("page_index")
+            det = element.get("det")
+            if page_index is None:
+                continue
             try:
-                page_index = int(raw_index)
-            except (TypeError, ValueError) as error:
-                raise ValueError("page_pixel_sizes keys must be page indexes") from error
-            if page_index < 1:
-                raise ValueError("page_pixel_sizes page indexes must be positive")
-            if (
-                not isinstance(raw_size, list | tuple)
-                or len(raw_size) != 2
-                or not all(
-                    isinstance(value, int)
-                    and not isinstance(value, bool)
-                    and value > 0
-                    for value in raw_size
-                )
-            ):
-                raise ValueError(
-                    "page_pixel_sizes values must be two positive numeric dimensions"
-                )
-            sizes[page_index] = (int(raw_size[0]), int(raw_size[1]))
-        return sizes
+                index = int(page_index)
+            except ValueError as error:
+                raise ValueError(f"invalid page_index in {path.name}: {page_index}") from error
+            if index not in page_sizes:
+                raise ValueError(f"{path.name} references page {index} missing from pages.xml")
+            if det is not None:
+                _validate_bbox(det, page_sizes[index], path.name)
+            asset_hash = element.get("hash") if element.tag == "asset" else None
+            if asset_hash is not None and not (paths.assets / f"{asset_hash}.png").is_file():
+                raise ValueError(f"{path.name} references missing asset: {asset_hash}.png")
 
-    def has_toc(self) -> bool:
-        return self.toc_path is not None and self.toc_path.exists()
 
-    def has_cover(self) -> bool:
-        return self.cover_path is not None and self.cover_path.exists()
+def _read_manifest(path: Path) -> dict[str, Any]:
+    if not path.is_file():
+        raise ValueError("PDFCraftExtraction is missing manifest.json")
+    try:
+        payload = json.loads(path.read_text(encoding="utf-8"))
+    except (OSError, UnicodeDecodeError, json.JSONDecodeError) as error:
+        raise ValueError("invalid PDFCraftExtraction manifest.json") from error
+    if not isinstance(payload, dict) or set(payload) - _MANIFEST_FIELDS:
+        raise ValueError("manifest.json contains unsupported fields")
+    if payload.get("format_version") != FORMAT_VERSION:
+        raise ValueError("unsupported PDFCraftExtraction format version")
+    producer = payload.get("producer")
+    if not isinstance(producer, dict) or set(producer) != {"name", "version"} or not all(
+        isinstance(producer.get(key), str) and producer[key] for key in ("name", "version")
+    ):
+        raise ValueError("manifest.json has an invalid producer")
+    created_at = payload.get("created_at")
+    if created_at is not None and not isinstance(created_at, str):
+        raise ValueError("manifest.json created_at must be a string")
+    if isinstance(created_at, str):
+        try:
+            datetime.fromisoformat(created_at)
+        except ValueError as error:
+            raise ValueError("manifest.json created_at must be ISO 8601") from error
+    document = payload.get("document")
+    if not isinstance(document, dict) or set(document) - _DOCUMENT_FIELDS:
+        raise ValueError("manifest.json has invalid document metadata")
+    for key in ("title", "description", "publisher", "isbn", "modified", "language"):
+        value = document.get(key)
+        if value is not None and not isinstance(value, str):
+            raise ValueError(f"manifest.json document.{key} must be a string or null")
+    for key in ("authors", "editors", "translators"):
+        _string_list(document.get(key))
+    if isinstance(document.get("modified"), str):
+        try:
+            datetime.fromisoformat(document["modified"])
+        except ValueError as error:
+            raise ValueError("manifest.json document.modified must be ISO 8601") from error
+    payload["document"] = document
+    return payload
+
+
+def _read_pages(path: Path) -> tuple[int, dict[int, tuple[int, int]]]:
+    root = _require_xml_root(path, "pages")
+    if set(root.attrib) != {"index_base", "coordinate_space", "render_dpi"}:
+        raise ValueError("pages.xml has unsupported root attributes")
+    if root.get("index_base") != "1" or root.get("coordinate_space") != "ocr_pixels":
+        raise ValueError("pages.xml uses an unsupported coordinate system")
+    try:
+        render_dpi = int(root.get("render_dpi", ""))
+    except ValueError as error:
+        raise ValueError("pages.xml render_dpi must be a positive integer") from error
+    if render_dpi <= 0:
+        raise ValueError("pages.xml render_dpi must be a positive integer")
+    sizes: dict[int, tuple[int, int]] = {}
+    for page in root:
+        if page.tag != "page":
+            raise ValueError(f"pages.xml contains unknown element: {page.tag}")
+        if set(page.attrib) != {"index", "width", "height"} or len(page):
+            raise ValueError("pages.xml has an invalid page element")
+        try:
+            index = int(page.get("index", ""))
+            width = int(page.get("width", ""))
+            height = int(page.get("height", ""))
+        except ValueError as error:
+            raise ValueError("pages.xml page values must be integers") from error
+        if index <= 0 or width <= 0 or height <= 0:
+            raise ValueError("pages.xml page values must be positive")
+        if index in sizes:
+            raise ValueError(f"pages.xml contains duplicate page {index}")
+        sizes[index] = (width, height)
+    return render_dpi, sizes
+
+
+def _require_xml_root(path: Path, expected: str) -> ElementTree.Element:
+    if not path.is_file():
+        raise ValueError(f"PDFCraftExtraction is missing {path.name}")
+    try:
+        root = ElementTree.parse(path).getroot()
+    except (OSError, ElementTree.ParseError) as error:
+        raise ValueError(f"invalid PDFCraftExtraction XML: {path.name}") from error
+    if root.tag != expected:
+        raise ValueError(f"expected <{expected}> in {path.name}, got <{root.tag}>")
+    return root
+
+
+def _validate_bbox(raw: str, size: tuple[int, int], chapter: str) -> None:
+    try:
+        values = tuple(int(value) for value in raw.split(","))
+    except (ValueError, TypeError) as error:
+        raise ValueError(f"invalid bbox in {chapter}: {raw}") from error
+    if len(values) != 4:
+        raise ValueError(f"invalid bbox in {chapter}: {raw}")
+    left, top, right, bottom = values
+    width, height = size
+    if left < 0 or top < 0 or right <= left or bottom <= top or right > width or bottom > height:
+        raise ValueError(f"bbox exceeds page geometry in {chapter}: {raw}")
+
+
+def _validate_workspace_members(paths: ExtractionPaths) -> None:
+    allowed_root = {
+        paths.manifest.name, paths.pages.name, paths.chapters.name, paths.assets.name,
+        paths.toc.name, paths.cover.name,
+    }
+    for path in paths.root.iterdir():
+        if path.name not in allowed_root or path.is_symlink():
+            raise ValueError(f"unsupported PDFCraftExtraction member: {path.name}")
+    for path in paths.chapters.iterdir():
+        valid = path.is_file() and not path.is_symlink() and (
+            path.name == "chapter_head.xml"
+            or (
+                path.name.startswith("chapter_")
+                and path.name.endswith(".xml")
+                and path.name[8:-4].isdigit()
+            )
+        )
+        if not valid:
+            raise ValueError(f"invalid chapter member: {path.name}")
+    for path in paths.assets.iterdir():
+        valid = (
+            path.is_file()
+            and not path.is_symlink()
+            and path.name.endswith(".png")
+            and len(path.name) == 68
+            and all(character in "0123456789abcdef" for character in path.name[:-4])
+        )
+        if not valid:
+            raise ValueError(f"invalid asset member: {path.name}")
+
+
+def _write_archive(paths: ExtractionPaths, target: Path) -> None:
+    members: list[tuple[Path, str]] = [
+        (paths.manifest, "manifest.json"),
+        (paths.pages, "pages.xml"),
+    ]
+    if paths.toc.is_file():
+        members.append((paths.toc, "toc.xml"))
+    if paths.cover.is_file():
+        members.append((paths.cover, "cover.png"))
+    members.extend((path, f"chapters/{path.name}") for path in sorted(paths.chapters.glob("*.xml")))
+    members.extend((path, f"assets/{path.name}") for path in sorted(paths.assets.glob("*.png")))
+
+    with NamedTemporaryFile(dir=target.parent, suffix=EXTRACTION_SUFFIX, delete=False) as temporary:
+        temporary_path = Path(temporary.name)
+    try:
+        with ZipFile(temporary_path, "w", compression=ZIP_DEFLATED) as archive:
+            archive.writestr("chapters/", b"")
+            archive.writestr("assets/", b"")
+            for source, member in members:
+                archive.write(source, member)
+        temporary_path.replace(target)
+    except Exception:
+        temporary_path.unlink(missing_ok=True)
+        raise
+
+
+def _extract_archive(archive_path: Path, target: Path) -> None:
+    try:
+        with ZipFile(archive_path) as archive:
+            infos = archive.infolist()
+            names = [info.filename for info in infos]
+            if len(names) != len(set(names)):
+                raise ValueError("PDFCraftExtraction contains duplicate ZIP members")
+            for info in infos:
+                _validate_archive_member(info)
+            broken = archive.testzip()
+            if broken is not None:
+                raise ValueError(f"PDFCraftExtraction contains a corrupt member: {broken}")
+            archive.extractall(target)
+    except (BadZipFile, RuntimeError) as error:
+        raise ValueError("invalid or corrupt PDFCraftExtraction archive") from error
+
+
+def _validate_archive_member(info: ZipInfo) -> None:
+    name = info.filename
+    pure = PurePosixPath(name)
+    normalized = pure.as_posix() + ("/" if info.is_dir() else "")
+    if (
+        pure.is_absolute()
+        or ".." in pure.parts
+        or "\\" in name
+        or name != normalized
+    ):
+        raise ValueError(f"unsafe PDFCraftExtraction member path: {name}")
+    if (info.external_attr >> 16) & 0o170000 == 0o120000:
+        raise ValueError(f"PDFCraftExtraction cannot contain symlinks: {name}")
+    allowed = name in {
+        "manifest.json", "pages.xml", "toc.xml", "cover.png", "chapters/", "assets/"
+    }
+    allowed = allowed or (
+        len(pure.parts) == 2
+        and pure.parts[0] == "chapters"
+        and (pure.parts[1] == "chapter_head.xml" or (
+            pure.parts[1].startswith("chapter_")
+            and pure.parts[1].endswith(".xml")
+            and pure.parts[1][8:-4].isdigit()
+        ))
+    )
+    allowed = allowed or (
+        len(pure.parts) == 2
+        and pure.parts[0] == "assets"
+        and pure.parts[1].endswith(".png")
+        and len(pure.parts[1]) == 68
+        and all(character in "0123456789abcdef" for character in pure.parts[1][:-4])
+    )
+    if not allowed:
+        raise ValueError(f"unsupported PDFCraftExtraction member: {name}")
+
+
+def _require_pcex_path(path: Path) -> None:
+    if path.suffix.lower() != EXTRACTION_SUFFIX:
+        raise ValueError(f"PDFCraftExtraction path must end with {EXTRACTION_SUFFIX}")
+
+
+def _producer_version() -> str:
+    try:
+        return version("pdf-craft")
+    except PackageNotFoundError:
+        return "unknown"
+
+
+def _optional_string(value: object) -> str | None:
+    return value if isinstance(value, str) else None
+
+
+def _string_list(value: object) -> list[str]:
+    if value is None:
+        return []
+    if not isinstance(value, list) or not all(isinstance(item, str) for item in value):
+        raise ValueError("document contributor metadata must be arrays of strings")
+    return list(value)

--- a/pdf_craft/document/package.py
+++ b/pdf_craft/document/package.py
@@ -233,6 +233,7 @@ def write_pages(root: Path, *, render_dpi: int, page_pixel_sizes: dict[int, tupl
 def _validate_workspace(paths: ExtractionPaths, *, require_toc: bool = False) -> None:
     # Import lazily because the extractor package imports the public document API.
     from ..extractor.chapter.chapter import decode as decode_chapter
+    from ..extractor.toc.types import decode as decode_toc
 
     _read_manifest(paths.manifest)
     _, page_sizes = _read_pages(paths.pages)
@@ -243,7 +244,11 @@ def _validate_workspace(paths: ExtractionPaths, *, require_toc: bool = False) ->
     if require_toc and not paths.toc.is_file():
         raise ValueError("PDFCraftExtraction is missing toc.xml")
     if paths.toc.exists():
-        _require_xml_root(paths.toc, "toc")
+        toc_root = _require_xml_root(paths.toc, "toc")
+        try:
+            decode_toc(toc_root)
+        except ValueError as error:
+            raise ValueError(f"invalid toc schema in {paths.toc.name}: {error}") from error
     if paths.cover.exists() and not paths.cover.is_file():
         raise ValueError("PDFCraftExtraction cover.png is not a file")
     _validate_workspace_members(paths)

--- a/pdf_craft/extractor/pdf/extractor.py
+++ b/pdf_craft/extractor/pdf/extractor.py
@@ -1,20 +1,57 @@
+# pylint: disable=protected-access
+
+from contextlib import contextmanager
 from pathlib import Path
-from typing import Any
-from ...document import DocumentPackage
+from tempfile import TemporaryDirectory
+from typing import Any, Iterator
+
+from ...document import PDFCraftExtraction
+from ...document.package import EXTRACTION_SUFFIX
+
 
 class PDFExtractor:
-    """Public PDF extraction boundary. Heavy OCR imports remain lazy."""
+    """PDF front end that emits a public ``.pcex`` extraction."""
+
     def __init__(self, transform: Any) -> None:
         self._transform = transform
 
-    def extract(self, pdf_path: Path, package_path: Path, **kwargs: Any) -> DocumentPackage:
-        package, _ = self.extract_with_metering(pdf_path, package_path, **kwargs)
-        return package
+    def extract(
+        self,
+        pdf_path: Path,
+        extraction_path: Path,
+        *,
+        analysing_path: Path | None = None,
+        **kwargs: Any,
+    ) -> PDFCraftExtraction:
+        extraction, _ = self.extract_with_metering(
+            pdf_path, extraction_path, analysing_path=analysing_path, **kwargs
+        )
+        return extraction
 
-    def extract_with_metering(self, pdf_path: Path, package_path: Path, **kwargs: Any):
-        package_path.mkdir(parents=True, exist_ok=True)
+    def extract_with_metering(
+        self,
+        pdf_path: Path,
+        extraction_path: Path,
+        *,
+        analysing_path: Path | None = None,
+        **kwargs: Any,
+    ):
+        if extraction_path.suffix.lower() != EXTRACTION_SUFFIX:
+            raise ValueError(f"PDFCraftExtraction path must end with {EXTRACTION_SUFFIX}")
+        if extraction_path.exists():
+            raise FileExistsError(f"PDFCraftExtraction already exists: {extraction_path}")
+        with _analysis_workspace(analysing_path) as workspace:
+            extraction, metering = self._extract_to_workspace(pdf_path, workspace, **kwargs)
+            exported = extraction.export(extraction_path)
+        return exported, metering
+
+    def _extract_to_workspace(
+        self, pdf_path: Path, analysing_path: Path, **kwargs: Any
+    ):
+        """Internal fast path used by complete conversions without ZIP churn."""
+        analysing_path.mkdir(parents=True, exist_ok=True)
         defaults = {
-            "analysing_path": package_path,
+            "analysing_path": analysing_path,
             "ocr_size": "gundam", "dpi": None,
             "max_page_image_file_size": None, "includes_cover": False,
             "includes_footnotes": False, "ignore_pdf_errors": False,
@@ -25,12 +62,17 @@ class PDFExtractor:
             "page_indexes": None,
         }
         defaults.update(kwargs)
-        defaults["analysing_path"] = package_path
-        _, _, _, _, metering = self._transform.extract_package(pdf_path=pdf_path,
-            **defaults)
-        # A DocumentPackage always owns an assets directory, even when the
-        # selected pages contain no extracted images.
-        (package_path / "assets").mkdir(exist_ok=True)
-        package = DocumentPackage.from_path(package_path)
-        package.validate()
-        return package, metering
+        defaults["analysing_path"] = analysing_path
+        _, _, _, _, metering = self._transform.extract_package(pdf_path=pdf_path, **defaults)
+        extraction = PDFCraftExtraction._from_workspace(analysing_path / "extraction")
+        extraction.validate()
+        return extraction, metering
+
+
+@contextmanager
+def _analysis_workspace(path: Path | None) -> Iterator[Path]:
+    if path is not None:
+        yield path
+        return
+    with TemporaryDirectory(prefix="pdf-craft-analysis-") as directory:
+        yield Path(directory)

--- a/pdf_craft/pipeline/pdf/pipeline.py
+++ b/pdf_craft/pipeline/pdf/pipeline.py
@@ -1,3 +1,5 @@
+# pylint: disable=protected-access
+
 from collections.abc import Callable
 from pathlib import Path
 from typing import cast
@@ -7,7 +9,7 @@ from pdf_craft.extractor.chapter.chapter import InlineExpression, Reference
 from pdf_craft.extractor.chapter.reader import create_chapters_reader
 from pdf_craft.markdown.paragraph import HTMLTag
 from pdf_craft.expression import to_markdown_string
-from pdf_craft.document import DocumentPackage
+from pdf_craft.document import PDFCraftExtraction
 from pdf_craft.transformer.events import TranslationEvent, TranslationEventKind, TranslationItemKind
 from pdf_craft.transformer.chapter_xml import ChapterXMLTransformer
 from pdf_craft.transformer.xml_translator.segment import search_text_segments
@@ -17,28 +19,26 @@ from pdf_craft.transformer import ChapterTransformer
 
 
 class PDFTranslationPipeline:
-    """Apply a replace-only text transformer to an extracted PDF package."""
+    """Apply a replace-only text transformer to a PDFCraftExtraction."""
 
     def __init__(self, pdf_handler: PDFHandler | None = None, patcher: PDFPatcher | None = None, dpi: int = 300) -> None:
-        self.pdf_handler = pdf_handler
-        self.patcher = patcher or PDFPatcher(pdf_handler=pdf_handler)
-        self.dpi = dpi
+        self.patcher = patcher or PDFPatcher(pdf_handler=pdf_handler, dpi=dpi)
 
     def translate(
         self,
         pdf_path: Path,
         target_path: Path,
-        package: DocumentPackage | Path,
+        extraction: PDFCraftExtraction | Path,
         transformer: Callable[[str], str] | ChapterTransformer,
         on_translation_event: Callable[[TranslationEvent], None] | None = None,
     ) -> None:
-        package = package if isinstance(package, DocumentPackage) else DocumentPackage.from_path(package)
-        package.validate()
-        document = self.pdf_handler.open(pdf_path) if self.pdf_handler else None
+        extraction = _ensure_extraction(extraction)
+        extraction.validate()
         replacements: list[PDFReplacement] = []
-        try:
-            pages = package.page_pixel_sizes()
-            reader = create_chapters_reader(package.chapters_path)
+        pages = extraction.page_pixel_sizes()
+        render_dpi = extraction.render_dpi()
+        with extraction._materialize() as paths:
+            reader = create_chapters_reader(paths.chapters)
             chapters = list(reader())
             chapter_tasks = []
             for chapter in chapters:
@@ -80,7 +80,9 @@ class PDFTranslationPipeline:
                 else:
                     transformed = transformer.transform(chapter) if structured else chapter
                 callback = transformer if callable(transformer) else (lambda text: text)
-                self._collect_chapter(transformed, callback, document, pages, replacements, structured)
+                self._collect_chapter(
+                    transformed, callback, pages, replacements, render_dpi, structured
+                )
                 completed_characters += character_count
                 if on_translation_event is not None and not is_xml_transformer:
                     on_translation_event(TranslationEvent(
@@ -101,9 +103,6 @@ class PDFTranslationPipeline:
                         completed_characters=completed_characters,
                         total_characters=total_characters,
                     ))
-        finally:
-            if document:
-                document.close()
         self.patcher.patch(pdf_path, target_path, replacements)
         if on_translation_event is not None:
             on_translation_event(TranslationEvent(
@@ -116,31 +115,31 @@ class PDFTranslationPipeline:
         self,
         pdf_path: Path,
         target_path: Path,
-        package: DocumentPackage | Path,
+        extraction: PDFCraftExtraction | Path,
     ) -> None:
-        """Write the text already present in ``package`` back to ``pdf_path``.
+        """Write text already present in ``extraction`` back to ``pdf_path``.
 
-        This is deliberately separate from :meth:`translate`: the package is
+        This is deliberately separate from :meth:`translate`: the extraction is
         already the source of the replacement text, so no OCR or LLM
         transformer is involved.
         """
-        package = package if isinstance(package, DocumentPackage) else DocumentPackage.from_path(package)
-        package.validate()
-        document = self.pdf_handler.open(pdf_path) if self.pdf_handler else None
+        extraction = _ensure_extraction(extraction)
+        extraction.validate()
         replacements: list[PDFReplacement] = []
-        try:
-            pages = package.page_pixel_sizes()
-            reader = create_chapters_reader(package.chapters_path)
+        pages = extraction.page_pixel_sizes()
+        render_dpi = extraction.render_dpi()
+        with extraction._materialize() as paths:
+            reader = create_chapters_reader(paths.chapters)
             for chapter in reader():
                 self._collect_chapter(
-                    chapter, lambda text: text, document, pages, replacements, structured=True,
+                    chapter, lambda text: text, pages, replacements, render_dpi, structured=True,
                 )
-        finally:
-            if document:
-                document.close()
         self.patcher.patch(pdf_path, target_path, replacements)
 
-    def _collect_chapter(self, chapter: Chapter, transformer, document, pages, replacements, structured: bool = False) -> None:
+    def _collect_chapter(
+        self, chapter: Chapter, transformer, pages, replacements,
+        render_dpi: int, structured: bool = False,
+    ) -> None:
         for layout in chapter.layouts:
             if not isinstance(layout, ParagraphLayout) or layout.ref not in {"text", "sub_title"}:
                 continue
@@ -152,12 +151,11 @@ class PDFTranslationPipeline:
                 if not translated or (translated == source and not structured):
                     continue
                 if block.page_index not in pages:
-                    if document is None:
-                        raise ValueError("PDF handler is required to resolve page dimensions")
-                    image = document.render_page(block.page_index, self.dpi)
-                    pages[block.page_index] = image.size
+                    raise ValueError(
+                        f"PDFCraftExtraction pages.xml is missing page {block.page_index}"
+                    )
                 replacements.append(PDFReplacement(
-                    block.page_index, block.det, translated, pages[block.page_index], self.dpi,
+                    block.page_index, block.det, translated, pages[block.page_index], render_dpi,
                     reading_order=block.order,
                 ))
 
@@ -181,3 +179,9 @@ def _to_patch_text(items) -> str:
         else:
             raise TypeError(f"unsupported chapter content for PDF patching: {type(item).__name__}")
     return "".join(parts)
+
+
+def _ensure_extraction(value: PDFCraftExtraction | Path) -> PDFCraftExtraction:
+    if isinstance(value, PDFCraftExtraction):
+        return value
+    return PDFCraftExtraction.open(value)

--- a/pdf_craft/renderer/epub/renderer.py
+++ b/pdf_craft/renderer/epub/renderer.py
@@ -1,18 +1,26 @@
+# pylint: disable=protected-access
+
 from pathlib import Path
-from typing import Literal
-from ...document import DocumentPackage
+from typing import Literal, cast
+from ...document import PDFCraftExtraction
 from .render import render_epub_file
-from epub_generator import LaTeXRender, TableRender
+from epub_generator import BookMeta, LaTeXRender, TableRender
 
 class EpubRenderer:
-    """Render a stable DocumentPackage to EPUB."""
-    def render(self, package: DocumentPackage, output_path: Path, *, book_meta=None,
-               lan: Literal["zh", "en"] = "zh", table_render=TableRender.HTML,
+    """Render a PDFCraftExtraction to EPUB."""
+    def render(self, extraction: PDFCraftExtraction, output_path: Path, *,
+               book_meta: BookMeta | None = None,
+               lan: Literal["zh", "en"] | None = None, table_render=TableRender.HTML,
                latex_render=LaTeXRender.MATHML, inline_latex: bool = True,
                aborted=lambda: False) -> None:
-        package.validate(require_toc=True)
-        if lan not in {"zh", "en"}:
-            raise ValueError(f"unsupported EPUB language: {lan}")
-        render_epub_file(package.chapters_path, package.toc_path, package.assets_path,
-                         output_path, package.cover_path, book_meta, lan, table_render,
-                         latex_render, inline_latex, aborted)
+        extraction.validate(require_toc=True)
+        language = lan or extraction.language() or "zh"
+        book_meta = book_meta or extraction.book_meta()
+        if language not in {"zh", "en"}:
+            raise ValueError(f"unsupported EPUB language: {language}")
+        language = cast(Literal["zh", "en"], language)
+        with extraction._materialize() as paths:
+            render_epub_file(paths.chapters, paths.toc, paths.assets,
+                             output_path, paths.cover if paths.cover.exists() else None,
+                             book_meta, language, table_render,
+                             latex_render, inline_latex, aborted)

--- a/pdf_craft/renderer/markdown/renderer.py
+++ b/pdf_craft/renderer/markdown/renderer.py
@@ -1,13 +1,16 @@
+# pylint: disable=protected-access
+
 from pathlib import Path
-from ...document import DocumentPackage
+from ...document import PDFCraftExtraction
 from ...markdown.render import render_markdown_file
 
 class MarkdownRenderer:
-    """Render a stable DocumentPackage to Markdown."""
-    def render(self, package: DocumentPackage, output_path: Path,
+    """Render a PDFCraftExtraction to Markdown."""
+    def render(self, extraction: PDFCraftExtraction, output_path: Path,
                assets_path: Path | None = None, cover_path: Path | None = None,
                aborted=lambda: False) -> None:
-        package.validate()
-        render_markdown_file(package.chapters_path, package.assets_path, output_path,
-                             assets_path or Path("assets"),
-                             cover_path or package.cover_path, aborted)
+        extraction.validate()
+        with extraction._materialize() as paths:
+            render_markdown_file(paths.chapters, paths.assets, output_path,
+                                 assets_path or Path("assets"),
+                                 cover_path or (paths.cover if paths.cover.exists() else None), aborted)

--- a/pdf_craft/transform.py
+++ b/pdf_craft/transform.py
@@ -1,3 +1,5 @@
+# pylint: disable=protected-access
+
 from collections.abc import Callable, Container
 from os import PathLike
 from pathlib import Path
@@ -15,7 +17,7 @@ from .ocr_config import OCRConfig, ensure_ocr_config
 from .pdf import DeepSeekOCRSize, OCR, OCREvent, OCREventKind, PDFHandler
 from .extractor.chapter import generate_chapter_files
 from .extractor.toc import analyse_toc
-from .document import DocumentPackage
+from .document import ExtractionPaths, PDFCraftExtraction, write_manifest, write_pages
 
 
 class PDFExtractionEngine:
@@ -63,18 +65,18 @@ class PDFExtractionEngine:
         on_ocr_event: Callable[[OCREvent], None],
         page_indexes: Container[int] | None = None,
     ):
-        assets_path = analysing_path / "assets"
+        extraction_path = analysing_path / "extraction"
+        extraction_paths = ExtractionPaths.at(extraction_path)
+        assets_path = extraction_paths.assets
         pages_path = analysing_path / "ocr"
-        chapters_path = analysing_path / "chapters"
-        toc_path = analysing_path / "toc.xml"
+        chapters_path = extraction_paths.chapters
+        toc_path = extraction_paths.toc
 
-        cover_path: Path | None = analysing_path / "cover.png" if includes_cover else None
+        cover_path: Path | None = extraction_paths.cover if includes_cover else None
         plot_path: Path | None = analysing_path / "plots" if generate_plot else None
         metering = OCRTokensMetering(input_tokens=0, output_tokens=0)
         usable_pages = 0
         failed_page_indexes: list[int] = []
-        existing_page_pixel_sizes = DocumentPackage.from_path(analysing_path).page_pixel_sizes()
-
         for event in self._ocr.recognize(
             pdf_path=pdf_path,
             asset_path=assets_path,
@@ -113,11 +115,15 @@ class PDFExtractionEngine:
         if cover_path and not cover_path.exists():
             cover_path = None
 
-        page_pixel_sizes = existing_page_pixel_sizes | self._ocr.last_page_pixel_sizes
-        DocumentPackage(chapters_path, assets_path, toc_path, cover_path).write_metadata(
-            dpi=dpi if dpi is not None else 300,
-            page_pixel_sizes=page_pixel_sizes,
+        assets_path.mkdir(parents=True, exist_ok=True)
+        render_dpi = dpi if dpi is not None else 300
+        write_pages(
+            extraction_path,
+            render_dpi=render_dpi,
+            page_pixel_sizes=self._ocr.last_page_pixel_sizes,
         )
+        write_manifest(extraction_path, book_meta=self._extract_book_meta(pdf_path))
+        PDFCraftExtraction._from_workspace(extraction_path).validate()
         return assets_path, chapters_path, toc_path, cover_path, metering
 
     def _extract_book_meta(self, pdf_path: Path):

--- a/pdf_craft/transformer/__init__.py
+++ b/pdf_craft/transformer/__init__.py
@@ -1,7 +1,7 @@
 from .xml_translator.xml_translator import FillFailedEvent, SubmitKind, TranslationTask, XMLTranslator
 from .protocol import ChapterTransformer
 from .chapter_xml import ChapterXMLTransformer
-from .package import ChapterPackageTransformer, PackageTransformer
+from .package import ChapterExtractionTransformer, ExtractionTransformer
 from .events import TranslationEvent, TranslationEventKind, TranslationItemKind
 
-__all__ = ["ChapterTransformer", "ChapterXMLTransformer", "ChapterPackageTransformer", "PackageTransformer", "FillFailedEvent", "SubmitKind", "TranslationTask", "XMLTranslator", "TranslationEvent", "TranslationEventKind", "TranslationItemKind"]
+__all__ = ["ChapterTransformer", "ChapterXMLTransformer", "ChapterExtractionTransformer", "ExtractionTransformer", "FillFailedEvent", "SubmitKind", "TranslationTask", "XMLTranslator", "TranslationEvent", "TranslationEventKind", "TranslationItemKind"]

--- a/pdf_craft/transformer/package.py
+++ b/pdf_craft/transformer/package.py
@@ -1,13 +1,18 @@
-"""Transformers operating on render-ready document packages."""
+"""Transformers operating on render-ready PDFCraftExtraction objects."""
+
+# Internal workspace methods keep one-shot conversions directory-backed.
+# pylint: disable=protected-access
 
 from collections.abc import Callable
 from pathlib import Path
 from shutil import copy2, copytree
+from tempfile import TemporaryDirectory
 from typing import Protocol, cast
 from xml.etree.ElementTree import Element
 
 from pdf_craft.common.xml import read_xml, save_xml
-from pdf_craft.document import DocumentPackage
+from pdf_craft.document import PDFCraftExtraction
+from pdf_craft.document.package import EXTRACTION_SUFFIX
 from pdf_craft.extractor.chapter.chapter import decode, encode
 from pdf_craft.transformer.protocol import ChapterTransformer
 from pdf_craft.transformer.events import TranslationEvent, TranslationEventKind, TranslationItemKind
@@ -16,14 +21,16 @@ from pdf_craft.transformer.chapter_xml import ChapterXMLTransformer
 from pdf_craft.transformer.xml_translator.xml_translator import SubmitKind
 
 
-class PackageTransformer(Protocol):
-    """A format-neutral transformation from one package to another."""
+class ExtractionTransformer(Protocol):
+    """A format-neutral transformation from one extraction to another."""
 
-    def transform(self, package: DocumentPackage, output_path: Path) -> DocumentPackage: ...
+    def transform(
+        self, extraction: PDFCraftExtraction, output_path: Path
+    ) -> PDFCraftExtraction: ...
 
 
-class ChapterPackageTransformer:
-    """Copy a package and transform its chapter XML files independently."""
+class ChapterExtractionTransformer:
+    """Copy an extraction and transform its chapter XML files independently."""
 
     def __init__(
         self,
@@ -40,21 +47,41 @@ class ChapterPackageTransformer:
 
     def transform(
         self,
-        package: DocumentPackage,
+        extraction: PDFCraftExtraction,
         output_path: Path,
         *,
         on_translation_event: Callable[[TranslationEvent], None] | None = None,
         emit_translation_events: bool = False,
-    ) -> DocumentPackage:
-        package.validate()
+    ) -> PDFCraftExtraction:
+        if output_path.suffix.lower() != EXTRACTION_SUFFIX:
+            raise ValueError(f"PDFCraftExtraction path must end with {EXTRACTION_SUFFIX}")
+        with TemporaryDirectory(prefix="pdf-craft-transformed-extraction-") as directory:
+            transformed = self._transform_to_workspace(
+                extraction,
+                Path(directory) / "extraction",
+                on_translation_event=on_translation_event,
+                emit_translation_events=emit_translation_events,
+            )
+            return transformed.export(output_path)
+
+    def _transform_to_workspace(
+        self,
+        extraction: PDFCraftExtraction,
+        output_path: Path,
+        *,
+        on_translation_event: Callable[[TranslationEvent], None] | None = None,
+        emit_translation_events: bool = False,
+    ) -> PDFCraftExtraction:
+        extraction.validate()
         if output_path.exists():
-            raise FileExistsError(f"output package already exists: {output_path}")
+            raise FileExistsError(f"output extraction workspace already exists: {output_path}")
         output_path.mkdir(parents=True)
-        copytree(package.chapters_path, output_path / "chapters")
-        copytree(package.assets_path, output_path / "assets")
-        for source in (package.toc_path, package.cover_path, package.metadata_path):
-            if source is not None and source.exists():
-                copy2(source, output_path / source.name)
+        with extraction._materialize() as paths:
+            copytree(paths.chapters, output_path / "chapters")
+            copytree(paths.assets, output_path / "assets")
+            for source in (paths.manifest, paths.pages, paths.toc, paths.cover):
+                if source.exists():
+                    copy2(source, output_path / source.name)
 
         chapter_paths = sorted((output_path / "chapters").glob("chapter*.xml"))
         chapter_tasks = []
@@ -121,12 +148,13 @@ class ChapterPackageTransformer:
                     total_characters=total_characters,
                 ))
 
-        if self.toc_transformer is not None and package.toc_path is not None and package.toc_path.exists():
-            save_xml(self.toc_transformer(read_xml(output_path / package.toc_path.name)), output_path / package.toc_path.name)
+        toc_path = output_path / "toc.xml"
+        if self.toc_transformer is not None and toc_path.exists():
+            save_xml(self.toc_transformer(read_xml(toc_path)), toc_path)
         if emit_translation_events and on_translation_event is not None:
             on_translation_event(TranslationEvent(
                 kind=TranslationEventKind.COMPLETE,
                 completed_characters=completed_characters,
                 total_characters=total_characters,
             ))
-        return DocumentPackage.from_path(output_path).validate()
+        return PDFCraftExtraction._from_workspace(output_path).validate()

--- a/pdf_craft_tool/README.md
+++ b/pdf_craft_tool/README.md
@@ -42,30 +42,30 @@ run 的 `backend` 字段中选择。local backend 使用自己的模型缓存、
 序号命名，例如 `citation-convert-20260822-001/`；同一次调用绝不会覆盖已有目录。
 `package render` 和 `epub translate` 也使用此规则。通过 `--work-dir` 指定位置时，
 目录不存在则创建，已存在则复用。PDF 命令会在工作目录内记录来源 PDF 和 OCR
-设置，防止不同输入或不同 OCR backend 错误复用已有 OCR 缓存。工作目录保存中间
-`package/`、翻译缓存和日志，方便人工检查、恢复或后续单独渲染。
+设置，防止不同输入或不同 OCR backend 错误复用已有 OCR 缓存。工作目录保存
+`analysis/`、`book.pcex`、翻译缓存和日志，方便人工检查、恢复或后续单独渲染。
 
 所有 `--pages` 参数使用从 1 开始的 PDF 页码，例如 `--pages 1,2,3`。
 
-## PDF 与 Package
+## PDF 与 PDFCraftExtraction
 
 ```shell
-# PDF -> 可复用 DocumentPackage
+# PDF -> 可复用 .pcex
 poetry run python -m pdf_craft_tool pdf extract tests/assets/pdf/citation.pdf \
   --ocr-mode deepseek-ocr-vendor --pages 1 --work-dir pdf-craft-output/citation-extract
 
-# DocumentPackage -> 翻译后的 DocumentPackage
+# .pcex -> 翻译后的 .pcex
 poetry run python -m pdf_craft_tool package translate \
-  pdf-craft-output/citation-extract/package zh \
-  --output-package pdf-craft-output/citation-zh-package
+  pdf-craft-output/citation-extract/book.pcex zh \
+  --output-package pdf-craft-output/citation-zh.pcex
 
-# Package -> Markdown 或 EPUB；此命令不需要 OCR 配置
-poetry run python -m pdf_craft_tool package render pdf-craft-output/citation-extract/package \
+# .pcex -> Markdown 或 EPUB；此命令不需要 OCR 配置
+poetry run python -m pdf_craft_tool package render pdf-craft-output/citation-extract/book.pcex \
   --format markdown --work-dir pdf-craft-output/citation-render
 
-# 原始 PDF + translated DocumentPackage -> patched PDF；此命令不需要 OCR/LLM
+# 原始 PDF + translated .pcex -> patched PDF；此命令不需要 OCR/LLM
 poetry run python -m pdf_craft_tool package patch-pdf \
-  tests/assets/pdf/citation.pdf pdf-craft-output/citation-zh-package \
+  tests/assets/pdf/citation.pdf pdf-craft-output/citation-zh.pcex \
   --output pdf-craft-output/citation-zh.pdf
 
 # PDF -> Markdown 或 EPUB
@@ -84,8 +84,8 @@ PDF 提取参数可在以上三个 PDF 命令中组合使用：
 `--ocr-mode` 覆盖 `.env` 内的 `PDF_CRAFT_OCR_MODE`；不传时使用 `.env` 的默认值。
 它只决定本次运行使用哪个已配置 backend，不会改写 `.env`。
 
-`package translate` 只读取已有 DocumentPackage，不会重新运行 OCR；
-`package patch-pdf` 只把已有 package 的文字按页面几何信息写回指定原始 PDF，
+`package translate` 只读取已有 `.pcex`，不会重新运行 OCR；
+`package patch-pdf` 只把已有 extraction 的文字按页面几何信息写回指定原始 PDF，
 不会调用 OCR 或 LLM。
 
 ## 翻译
@@ -124,7 +124,7 @@ poetry run python -m pdf_craft_tool smoke assets
 `smoke run` 将一条参数化通路写入 Git 忽略的 `pdf-craft-output/smoke/` 下独立目录。
 目录同样以来源、route、日期和当日序号命名。通过 `--output-root DIR` 可替换这个根目录。
 目录包含
-`manifest.json`、`checks.json`、`logs/`、提取的 `package/` 和渲染产物；凭据会
+`manifest.json`、`checks.json`、`logs/`、提取的 `book.pcex`、`analysis/` 和渲染产物；凭据会
 从报告和 traceback 中脱敏。
 
 smoke 命令的进程退出码与报告状态一致：`passed` 和 `planned` 返回 0，`failed`

--- a/pdf_craft_tool/cli.py
+++ b/pdf_craft_tool/cli.py
@@ -8,11 +8,11 @@ from typing import Any, cast
 
 from pdf_craft import (
     ChapterXMLTransformer,
-    DocumentPackage,
     ExtractionOptions,
     OCRMode,
     OCRTokensMetering,
     PDFCraft,
+    PDFCraftExtraction,
     PDFOptions,
     SubmitKind,
     XMLTranslator,
@@ -34,7 +34,8 @@ from .smoke.assets import discover_assets
 @dataclass(frozen=True)
 class _ExtractionResult:
     craft: PDFCraft
-    package: DocumentPackage
+    extraction: PDFCraftExtraction
+    path: Path
     metering: OCRTokensMetering
 
 
@@ -54,7 +55,7 @@ def _parser() -> argparse.ArgumentParser:
 
     pdf = commands.add_parser("pdf", help="extract, convert, or translate a PDF")
     pdf_commands = pdf.add_subparsers(dest="pdf_command", required=True)
-    extract = pdf_commands.add_parser("extract", help="PDF -> DocumentPackage")
+    extract = pdf_commands.add_parser("extract", help="PDF -> PDFCraftExtraction (.pcex)")
     _add_pdf_source(extract)
     _add_extraction_options(extract)
     extract.set_defaults(handler=_extract_pdf)
@@ -75,10 +76,10 @@ def _parser() -> argparse.ArgumentParser:
     _add_extraction_options(translate)
     translate.set_defaults(handler=_translate_pdf)
 
-    package = commands.add_parser("package", help="operate on an existing DocumentPackage")
+    package = commands.add_parser("package", help="operate on a PDFCraftExtraction (.pcex)")
     package_commands = package.add_subparsers(dest="package_command", required=True)
     package_translate = package_commands.add_parser(
-        "translate", help="translate an existing DocumentPackage"
+        "translate", help="translate an existing PDFCraftExtraction"
     )
     package_translate.add_argument("package", type=Path)
     package_translate.add_argument("target_language")
@@ -88,7 +89,7 @@ def _parser() -> argparse.ArgumentParser:
     package_translate.set_defaults(handler=_translate_package)
 
     package_patch = package_commands.add_parser(
-        "patch-pdf", help="patch an original PDF with an existing DocumentPackage"
+        "patch-pdf", help="patch an original PDF with a PDFCraftExtraction"
     )
     package_patch.add_argument("source", type=Path)
     package_patch.add_argument("package", type=Path)
@@ -96,7 +97,7 @@ def _parser() -> argparse.ArgumentParser:
     _add_work_dir(package_patch, "isolated run directory")
     package_patch.set_defaults(handler=_patch_package_pdf)
 
-    render = package_commands.add_parser("render", help="DocumentPackage -> Markdown or EPUB")
+    render = package_commands.add_parser("render", help="PDFCraftExtraction -> Markdown or EPUB")
     render.add_argument("package", type=Path)
     render.add_argument("--format", choices=("markdown", "epub"), required=True)
     render.add_argument("--output", type=Path, help="rendered file; defaults inside --work-dir")
@@ -206,18 +207,18 @@ def _add_smoke_options(parser: argparse.ArgumentParser) -> None:
 
 def _extract_pdf(args: argparse.Namespace) -> None:
     work_dir = _work_dir(args.source, args.work_dir, "extract")
-    result = _extract(args, work_dir / "package")
-    print(f"Package: {result.package.chapters_path.parent}")
+    result = _extract(args, work_dir / "book.pcex")
+    print(f"Extraction: {result.path}")
     _print_metering(result.metering)
 
 
 def _convert_pdf(args: argparse.Namespace) -> None:
     work_dir = _work_dir(args.source, args.work_dir, "convert")
-    result = _extract(args, work_dir / "package")
+    result = _extract(args, work_dir / "book.pcex")
     output = args.output or work_dir / ("book.md" if args.format == "markdown" else "book.epub")
     output.parent.mkdir(parents=True, exist_ok=True)
-    _render(result.craft, result.package, args.format, output)
-    print(f"Package: {result.package.chapters_path.parent}")
+    _render(result.craft, result.extraction, args.format, output)
+    print(f"Extraction: {result.path}")
     print(f"Output: {output}")
     _print_metering(result.metering)
 
@@ -226,21 +227,21 @@ def _translate_pdf(args: argparse.Namespace) -> None:
     if args.format == "pdf" and args.submit != "replace":
         raise SystemExit("PDF output supports only --submit replace")
     work_dir = _work_dir(args.source, args.work_dir, "translate")
-    result = _extract(args, work_dir / "package")
+    result = _extract(args, work_dir / "book.pcex")
     transformer = _xml_transformer(args, work_dir)
     if args.format == "pdf":
         output = args.output or work_dir / f"{args.source.stem}-{args.target_language}.pdf"
         output.parent.mkdir(parents=True, exist_ok=True)
-        result.craft.translate_pdf(args.source, result.package, output, transformer)
+        result.craft.translate_pdf(args.source, result.extraction, output, transformer)
     else:
         mode = SubmitKind[args.submit.replace("-", "_").upper()]
-        translated = result.craft.translate_package(
-            result.package, work_dir / "translated", transformer, submit=mode,
+        translated = result.craft.translate_extraction(
+            result.extraction, work_dir / "translated.pcex", transformer, submit=mode,
         )
         output = args.output or work_dir / ("book.md" if args.format == "markdown" else "book.epub")
         output.parent.mkdir(parents=True, exist_ok=True)
         _render(result.craft, translated, args.format, output)
-    print(f"Package: {result.package.chapters_path.parent}")
+    print(f"Extraction: {result.path}")
     print(f"Output: {output}")
     _print_metering(result.metering)
 
@@ -248,31 +249,31 @@ def _translate_pdf(args: argparse.Namespace) -> None:
 def _translate_package(args: argparse.Namespace) -> None:
     load_project_env(_project_root())
     work_dir = _work_dir(args.package, args.work_dir, "package-translate")
-    package = DocumentPackage.from_path(args.package).validate()
-    output_package = args.output_package or work_dir / "translated-package"
+    extraction = PDFCraftExtraction.open(args.package)
+    output_package = args.output_package or work_dir / "translated.pcex"
     transformer = _xml_transformer(args, work_dir)
     mode = SubmitKind[args.submit.replace("-", "_").upper()]
-    translated = PDFCraft().translate_package(
-        package, output_package, transformer, submit=mode,
+    PDFCraft().translate_extraction(
+        extraction, output_package, transformer, submit=mode,
     )
-    print(f"Package: {translated.chapters_path.parent}")
+    print(f"Extraction: {output_package}")
 
 
 def _patch_package_pdf(args: argparse.Namespace) -> None:
     work_dir = _work_dir(args.source, args.work_dir, "package-patch")
-    package = DocumentPackage.from_path(args.package).validate()
+    extraction = PDFCraftExtraction.open(args.package)
     output = args.output or work_dir / f"{args.source.stem}-patched.pdf"
     output.parent.mkdir(parents=True, exist_ok=True)
-    PDFCraft().patch_pdf_with_package(args.source, package, output)
+    PDFCraft().patch_pdf_with_extraction(args.source, extraction, output)
     print(f"Output: {output}")
 
 
 def _render_package(args: argparse.Namespace) -> None:
     work_dir = _work_dir(args.package, args.work_dir, "render")
-    package = DocumentPackage.from_path(args.package).validate()
+    extraction = PDFCraftExtraction.open(args.package)
     output = args.output or work_dir / ("book.md" if args.format == "markdown" else "book.epub")
     output.parent.mkdir(parents=True, exist_ok=True)
-    _render(PDFCraft(), package, args.format, output)
+    _render(PDFCraft(), extraction, args.format, output)
     print(f"Output: {output}")
 
 
@@ -424,26 +425,27 @@ def _resolve_translation_profiles(translation: dict[str, Any] | None, output_roo
     return resolved
 
 
-def _extract(args: argparse.Namespace, package_path: Path) -> _ExtractionResult:
+def _extract(args: argparse.Namespace, extraction_path: Path) -> _ExtractionResult:
     load_project_env(_project_root())
     ocr_mode = cast(OCRMode | None, args.ocr_mode) or ocr_mode_from_env()
     ocr_size = _resolve_ocr_size(args.ocr_size, ocr_mode, args.default_ocr_size)
     _validate_ocr_size(ocr_mode, ocr_size)
-    _record_pdf_cache_owner(package_path.parent, args, ocr_mode, ocr_size)
+    _record_pdf_cache_owner(extraction_path.parent, args, ocr_mode, ocr_size)
     craft = PDFCraft(pdf=PDFOptions(ocr=create_ocr_config_from_env(ocr_mode)))
-    package, metering = craft.extract_pdf_with_metering(
-        args.source, package_path, ExtractionOptions(
+    extraction, metering = craft.extract_pdf_with_metering(
+        args.source, extraction_path, ExtractionOptions(
             page_indexes=_page_indexes(args.pages), ocr_size=cast(Any, ocr_size), dpi=args.dpi,
             max_page_image_file_size=args.max_page_image_file_size,
             max_ocr_tokens=args.max_ocr_tokens, max_ocr_output_tokens=args.max_ocr_output_tokens,
             includes_cover=args.cover, includes_footnotes=args.footnotes,
             generate_plot=args.plot, toc_assumed=args.toc_assumed,
-            toc_llm=(create_llm_from_env(args.toc_llm, cache_path=package_path.parent / "toc-cache",
-                log_dir_path=package_path.parent / "toc-logs") if args.toc_llm else None),
+            toc_llm=(create_llm_from_env(args.toc_llm, cache_path=extraction_path.parent / "toc-cache",
+                log_dir_path=extraction_path.parent / "toc-logs") if args.toc_llm else None),
             on_ocr_event=_print_ocr_event,
-        )
+        ),
+        analysing_path=extraction_path.parent / "analysis",
     )
-    return _ExtractionResult(craft, package, metering)
+    return _ExtractionResult(craft, extraction, extraction_path, metering)
 
 
 def _xml_transformer(args: argparse.Namespace, work_dir: Path) -> ChapterXMLTransformer:
@@ -460,11 +462,12 @@ def _xml_transformer(args: argparse.Namespace, work_dir: Path) -> ChapterXMLTran
     return ChapterXMLTransformer(cast(Any, translator))
 
 
-def _render(craft: PDFCraft, package: DocumentPackage, format_name: str, output: Path) -> None:
+def _render(craft: PDFCraft, extraction: PDFCraftExtraction,
+            format_name: str, output: Path) -> None:
     if format_name == "markdown":
-        craft.render_markdown(package, output, Path("assets"))
+        craft.render_markdown(extraction, output, Path("assets"))
     else:
-        craft.render_epub(package, output)
+        craft.render_epub(extraction, output)
 
 
 def _work_dir(source: Path, requested: Path | None, operation: str) -> Path:
@@ -513,7 +516,7 @@ def _record_pdf_cache_owner(
                 f"settings ({', '.join(mismatched)}): {work_dir}"
             )
         return
-    if (work_dir / "package" / "ocr").exists():
+    if (work_dir / "analysis" / "ocr").exists():
         raise SystemExit(
             "Work directory contains legacy OCR cache without ownership metadata; "
             f"use a fresh directory or remove the stale cache: {work_dir}"

--- a/pdf_craft_tool/smoke/checks.py
+++ b/pdf_craft_tool/smoke/checks.py
@@ -1,4 +1,5 @@
-import json
+# pylint: disable=protected-access
+
 import re
 import zipfile
 from posixpath import normpath
@@ -8,50 +9,45 @@ from urllib.parse import urlparse
 
 import pypdf
 
-from pdf_craft.document import DocumentPackage
+from pdf_craft.document import PDFCraftExtraction
 from pdf_craft.extractor.chapter.chapter import ParagraphLayout
 from pdf_craft.extractor.chapter.reader import create_chapters_reader
 
 
-def check_package(package: DocumentPackage, require_geometry: bool = False) -> list[str]:
-    package.validate()
+def check_package(extraction: PDFCraftExtraction, require_geometry: bool = False) -> list[str]:
+    extraction.validate()
     errors: list[str] = []
-    chapters = sorted(package.chapters_path.glob("chapter*.xml"))
-    if not chapters:
-        errors.append("DocumentPackage contains no chapter XML")
-    for chapter in chapters:
-        try:
-            ElementTree.parse(chapter)
-        except ElementTree.ParseError as error:
-            errors.append(f"invalid chapter XML {chapter.name}: {error}")
-    if package.has_toc():
-        try:
-            ElementTree.parse(package.toc_path)  # type: ignore[arg-type]
-        except ElementTree.ParseError as error:
-            errors.append(f"invalid toc.xml: {error}")
-    if require_geometry and not package.page_pixel_sizes():
-        errors.append("DocumentPackage lacks required page geometry metadata")
+    with extraction._materialize() as paths:
+        chapters = sorted(paths.chapters.glob("chapter*.xml"))
+        if not chapters:
+            errors.append("PDFCraftExtraction contains no chapter XML")
+        for chapter in chapters:
+            try:
+                ElementTree.parse(chapter)
+            except ElementTree.ParseError as error:
+                errors.append(f"invalid chapter XML {chapter.name}: {error}")
+        if paths.toc.is_file():
+            try:
+                ElementTree.parse(paths.toc)
+            except ElementTree.ParseError as error:
+                errors.append(f"invalid toc.xml: {error}")
+    if require_geometry and not extraction.page_pixel_sizes():
+        errors.append("PDFCraftExtraction lacks required page geometry metadata")
     return errors
 
 
-def check_pdf_patch_geometry(package: DocumentPackage) -> list[str]:
-    """Require package-owned geometry for every block a PDF patch may replace.
-
-    The PDF pipeline can otherwise re-render a source page when geometry is
-    absent. Smoke runs must reject that fallback so their package contract is
-    explicit and reproducible.
-    """
-    if package.metadata_path is None or not package.metadata_path.exists():
-        return ["PDF patch requires DocumentPackage document.json geometry metadata"]
+def check_pdf_patch_geometry(extraction: PDFCraftExtraction) -> list[str]:
+    """Require extraction-owned geometry for every block a PDF patch may replace."""
     try:
-        page_sizes = package.page_pixel_sizes()
-    except (OSError, ValueError, json.JSONDecodeError) as error:
-        return [f"PDF patch has invalid DocumentPackage geometry metadata: {error}"]
+        page_sizes = extraction.page_pixel_sizes()
+    except (OSError, ValueError) as error:
+        return [f"PDF patch has invalid PDFCraftExtraction geometry metadata: {error}"]
     needed_pages: set[int] = set()
-    for chapter in create_chapters_reader(package.chapters_path)():
-        for layout in chapter.layouts:
-            if isinstance(layout, ParagraphLayout) and layout.ref in {"text", "sub_title"}:
-                needed_pages.update(block.page_index for block in layout.blocks if block.content)
+    with extraction._materialize() as paths:
+        for chapter in create_chapters_reader(paths.chapters)():
+            for layout in chapter.layouts:
+                if isinstance(layout, ParagraphLayout) and layout.ref in {"text", "sub_title"}:
+                    needed_pages.update(block.page_index for block in layout.blocks if block.content)
     missing = sorted(needed_pages - set(page_sizes))
     if missing:
         return [f"PDF patch geometry missing for replacement pages: {missing}"]

--- a/pdf_craft_tool/smoke/runner.py
+++ b/pdf_craft_tool/smoke/runner.py
@@ -12,7 +12,7 @@ from time import perf_counter
 from typing import Any, Literal, cast
 
 from pdf_craft import (
-    ChapterPackageTransformer,
+    ChapterExtractionTransformer,
     ChapterXMLTransformer,
     ExtractionOptions,
     LLM,
@@ -181,7 +181,7 @@ def _execute(run: SmokeRun, asset: SmokeAsset, run_path: Path,
     if asset.format == "epub":
         output = run_path / "output" / "book.epub"
         report.skipped("configure", "EPUB routes do not require OCR configuration")
-        report.skipped("extract", "EPUB routes do not extract a DocumentPackage")
+        report.skipped("extract", "EPUB routes do not extract a PDFCraftExtraction")
         if run.route == "epub-check":
             with report.stage("render"):
                 shutil.copy2(asset.path, output)
@@ -221,14 +221,14 @@ def _run_pdf(
     run: SmokeRun, asset: SmokeAsset, run_path: Path, ocr: OCRConfig,
     report: _ExecutionReport | None = None,
 ) -> tuple[str, list[str], dict[str, Any]]:
-    package_path = run_path / "package"
+    extraction_path = run_path / "book.pcex"
     output_path = run_path / "output"
     craft = PDFCraft(pdf=PDFOptions(ocr=ocr))
     try:
         report = report or _ExecutionReport()
         with report.stage("extract"):
             package, metering = craft.extract_pdf_with_metering(
-                asset.path, package_path, ExtractionOptions(
+                asset.path, extraction_path, ExtractionOptions(
                     page_indexes=run.page_indexes, ocr_size=cast(Any, run.ocr_size), dpi=run.dpi,
                     max_page_image_file_size=run.max_page_image_file_size,
                     max_ocr_tokens=run.max_ocr_tokens,
@@ -237,15 +237,16 @@ def _run_pdf(
                     includes_footnotes=run.includes_footnotes,
                 generate_plot=run.generate_plot, toc_assumed=run.toc_assumed,
                 on_ocr_event=report.on_ocr_event,
-                )
+                ),
+                analysing_path=run_path / "analysis",
             )
     except Exception as error:
         unavailable = _unavailable_ocr_reason(error)
         if unavailable is not None:
-            return "skipped", [unavailable], {"package": str(package_path)}
+            return "skipped", [unavailable], {"package": str(extraction_path)}
         raise
     details = {
-        "package": str(package_path),
+        "package": str(extraction_path),
         "metering": {"input_tokens": metering.input_tokens, "output_tokens": metering.output_tokens},
     }
     if run.route == "package":
@@ -376,14 +377,14 @@ def _package_translation(run: SmokeRun, run_path: Path):
     if translation_transformer is not None:
         translation = run.translation or {}
         mode = SubmitKind[translation.get("submit", "REPLACE").upper()]
-        return ChapterPackageTransformer(translation_transformer, mode=mode)
+        return ChapterExtractionTransformer(translation_transformer, mode=mode)
 
     translation = run.translation or {}
     marker = translation.get("package_marker")
     if not isinstance(marker, str):
         return None
     mode = SubmitKind[translation.get("package_submit", "REPLACE").upper()]
-    return ChapterPackageTransformer(_DeterministicChapterTransformer(marker), mode=mode)
+    return ChapterExtractionTransformer(_DeterministicChapterTransformer(marker), mode=mode)
 
 
 def _translate_package(
@@ -393,11 +394,11 @@ def _translate_package(
     transformer,
 ):
     """Run one smoke package translation through the public facade method."""
-    if not isinstance(transformer, ChapterPackageTransformer):
-        raise TypeError("smoke package routes require a ChapterPackageTransformer")
-    return craft.translate_package(
+    if not isinstance(transformer, ChapterExtractionTransformer):
+        raise TypeError("smoke extraction routes require a ChapterExtractionTransformer")
+    return craft.translate_extraction(
         package,
-        run_path / "translated",
+        run_path / "translated.pcex",
         transformer.chapter_transformer,
         submit=transformer.mode,
     )

--- a/references/architecture.md
+++ b/references/architecture.md
@@ -8,22 +8,27 @@
 
 `pdf_craft` 的主要业务模块围绕可组合的文档处理阶段组织：
 
-- `extractor/`：PDF 页面、OCR、目录和章节分析的适配入口；产出 Document Package。
-- `document/`：渲染就绪工件的路径契约和来源位置（页码、bbox、阅读顺序）。
-- `renderer/`：Document Package 到 Markdown 或 EPUB 的格式渲染入口。
+- `extractor/`：PDF 页面、OCR、目录和章节分析的适配入口；产出 PDFCraftExtraction。
+- `document/`：PDFCraftExtraction 的 workspace/`.pcex` 存储、校验和来源位置契约。
+- `renderer/`：PDFCraftExtraction 到 Markdown 或 EPUB 的格式渲染入口。
 - `transformer/`：格式无关的 XML 内容变换，包括 LLM 翻译、结构填充和校验。
 - `pipeline/`：格式专属编排。EPUB Pipeline 将 EPUB XHTML/目录/元数据交给 Transformer；PDF Pipeline 以 replace-only 方式将 Chapter 来源区域写回 PDF。
 
-提取后的渲染工件为 `chapters/`、`assets/`、`toc.xml` 和可选 `cover.png`。`ocr/`、`plots/` 与 `done` 仅是可丢弃的分析缓存。
+公开中间格式为 `PDFCraftExtraction`，持久化与交换载体必须是 `.pcex` ZIP。其内容为
+`manifest.json`、`pages.xml`、`chapters/`、`assets/`，以及可选 `toc.xml`、`cover.png`。
+目录-backed 形态只供一键转换在 `analysing_path/extraction/` 内部衔接前后端；普通目录不是
+公开输入。`ocr/`、`plots/`、`done` 和其他 analysis 文件仅是可丢弃的诊断/恢复缓存。
 
-`pdf_craft/__init__.py` 是公共导入面。`pdf_craft/functions.py` 提供便利函数，负责创建 `Transform` 并转发到实例方法。`pdf_craft/transform.py` 是完整 Markdown 和 EPUB 转换的编排边界。
+`pdf_craft/__init__.py` 是公共导入面。`PDFCraft` 是门面；`pdf_craft/transform.py` 是 PDF 前端
+提取 engine。Markdown、EPUB、翻译和 PDF 写回后端只能读取 PDFCraftExtraction，不得读取
+analysis/OCR 缓存。
 
 除非任务明确要求破坏性 API 变更，否则把以下名称和默认值视为公共 API：
 
-- `transform_markdown`
-- `transform_epub`
+- `PDFCraft`、`PDFOptions`、`ExtractionOptions`、`PDFCraftExtraction`
+- `PDFExtractor`、`MarkdownRenderer`、`EpubRenderer`
+- `ExtractionTransformer`、`ChapterExtractionTransformer`、`ChapterXMLTransformer`
 - `predownload_models`
-- `Transform`
 - `LLM`
 - `DeepSeekOCRLocalConfig`、`DeepSeekOCR2LocalConfig`、`UnlimitedOCRLocalConfig`
 - `DeepSeekOCRVendorConfig`、`DeepSeekOCR2VendorConfig`、`UnlimitedOCRVendorConfig`

--- a/references/conversion-pipeline.md
+++ b/references/conversion-pipeline.md
@@ -6,30 +6,39 @@
 
 ## 组合流程
 
-Extractor 生成 Document Package 后，Renderer 可直接生成 Markdown 或 EPUB。可选 Transformer 可以在渲染前修改结构化文本；`pipeline/epub` 也可把既有 EPUB 的 XHTML、目录和元数据交给同一个 XML Transformer。PDF Translation Pipeline 只支持替换已记录来源 bbox 内的文本，不支持 append 语义。
+Extractor 生成 PDFCraftExtraction 后，Renderer 可直接生成 Markdown 或 EPUB。可选 Transformer
+可以在渲染前修改结构化文本；`pipeline/epub` 也可把既有 EPUB 的 XHTML、目录和元数据交给
+同一个 XML Transformer。PDF Translation Pipeline 只处理已记录来源 bbox 内的文本。
 
-`Transform.transform_markdown()` 和 `Transform.transform_epub()` 都会先调用 `_extract_from_pdf()`，再渲染目标输出。提取流程是：
+`PDFCraft.convert_pdf_to_markdown()` 和 `PDFCraft.convert_pdf_to_epub()` 会先提取到内部 workspace，
+再渲染目标输出。提取流程是：
 
 1. 通过 `PDFHandler` 渲染 PDF 页面。
 2. 通过 `OCR.recognize()` 识别页面布局。
-3. 在 `analysing_path` 下写入 OCR 页 XML 和资源文件。
+3. 在 `analysing_path/ocr/` 写入 OCR 页 XML 和恢复缓存，在
+   `analysing_path/extraction/assets/` 写入资源。
 4. 分析 TOC 数据。
-5. 生成章节 XML。
-6. 根据章节 XML 渲染 Markdown 或 EPUB。
+5. 在 `analysing_path/extraction/` 生成章节、TOC、页面几何和 manifest。
+6. 仅从该 extraction 渲染 Markdown 或 EPUB。
 
 当未传入 `analysing_path` 时，`EnsureFolder` 会创建临时目录。当传入该路径时，它会成为可持久复用的缓存和调试输出目录。
 
 ## 中间产物契约
 
-转换流水线期望 `analysing_path` 下存在或生成这些路径：
+analysis 与稳定 extraction 明确分离：
 
-- `assets/`：按内容 hash 存放裁剪出的图片、公式和表格。
 - `ocr/page_*.xml`：OCR 页数据。
 - `ocr/done`：表示所有选中页面已完成识别的标记。
-- `toc.xml`：TOC 分析结果。
-- `chapters/chapter_*.xml`：生成的章节记录。
-- `cover.png`：可选的首页封面。
 - `plots/`：启用 plot 生成时的可选可视化调试输出。
+- `extraction/manifest.json`：格式版本、producer、创建时间和文档元数据。
+- `extraction/pages.xml`：1-based OCR 像素坐标空间、实际渲染 DPI 和逐页像素宽高。
+- `extraction/assets/`：按内容 hash 存放裁剪出的图片、公式和表格。
+- `extraction/chapters/chapter_*.xml`：生成的章节记录及原 PDF page/bbox 映射。
+- `extraction/toc.xml`、`extraction/cover.png`：可选目录和封面。
+
+公共分段流程把 `extraction/` 打包为 `.pcex`；恢复后端只接受 `.pcex` 或已加载的
+`PDFCraftExtraction`。一键转换直接使用 workspace，只有显式 `extraction_path` 时才额外导出
+`.pcex`，避免压缩往返。翻译后的 `.pcex` 必须保留 manifest、pages、TOC、封面和资源。
 
 修改 XML schema、文件命名或跳过语义会影响多个模块，应视为跨流水线变更，并配套有针对性的测试。
 

--- a/tests/extraction_helpers.py
+++ b/tests/extraction_helpers.py
@@ -1,0 +1,33 @@
+"""Small valid PDFCraftExtraction fixtures used by boundary tests."""
+
+# pylint: disable=protected-access
+
+from pathlib import Path
+
+from epub_generator import BookMeta
+
+from pdf_craft.document import PDFCraftExtraction
+from pdf_craft.document.package import write_manifest, write_pages
+
+
+def make_extraction(
+    root: Path,
+    *,
+    page_pixel_sizes: dict[int, tuple[int, int]] | None = None,
+    render_dpi: int = 300,
+    with_toc: bool = False,
+    book_meta: BookMeta | None = None,
+    language: str | None = None,
+) -> PDFCraftExtraction:
+    """Create a directory-backed fixture through the private workspace path."""
+    (root / "chapters").mkdir(parents=True)
+    (root / "assets").mkdir()
+    if with_toc:
+        (root / "toc.xml").write_text("<toc/>", encoding="utf-8")
+    write_pages(
+        root,
+        render_dpi=render_dpi,
+        page_pixel_sizes=page_pixel_sizes or {1: (100, 100)},
+    )
+    write_manifest(root, book_meta=book_meta, language=language)
+    return PDFCraftExtraction._from_workspace(root)

--- a/tests/extraction_helpers.py
+++ b/tests/extraction_helpers.py
@@ -6,8 +6,10 @@ from pathlib import Path
 
 from epub_generator import BookMeta
 
+from pdf_craft.common import save_xml
 from pdf_craft.document import PDFCraftExtraction
 from pdf_craft.document.package import write_manifest, write_pages
+from pdf_craft.extractor.toc.types import TocInfo, encode as encode_toc
 
 
 def make_extraction(
@@ -23,7 +25,7 @@ def make_extraction(
     (root / "chapters").mkdir(parents=True)
     (root / "assets").mkdir()
     if with_toc:
-        (root / "toc.xml").write_text("<toc/>", encoding="utf-8")
+        save_xml(encode_toc(TocInfo(content=[], page_indexes=[])), root / "toc.xml")
     write_pages(
         root,
         render_dpi=render_dpi,

--- a/tests/test_composable_boundaries.py
+++ b/tests/test_composable_boundaries.py
@@ -1,3 +1,5 @@
+# pylint: disable=protected-access
+
 import tempfile
 import unittest
 from pathlib import Path
@@ -6,13 +8,12 @@ from typing import cast
 from xml.etree.ElementTree import tostring
 from PIL import Image
 
-from pdf_craft.document import DocumentPackage
 from pdf_craft.error import NoUsableOCRPagesError, OCRError
 from pdf_craft.extractor import PDFExtractor
 from pdf_craft.pipeline.pdf.pipeline import PDFTranslationPipeline
 from pdf_craft.pipeline.pdf import PDFPatcher
 from pdf_craft.transformer import (
-    ChapterPackageTransformer, ChapterXMLTransformer,
+    ChapterExtractionTransformer, ChapterXMLTransformer,
     TranslationEvent, TranslationEventKind,
 )
 from pdf_craft.renderer import EpubRenderer, MarkdownRenderer
@@ -23,25 +24,21 @@ from pdf_craft.pdf.ocr import OCR, OCREvent, OCREventKind
 from pdf_craft.pdf.handler import PDFHandler
 from pdf_craft.pdf.types import Page
 from pdf_craft.transform import PDFExtractionEngine
+from tests.extraction_helpers import make_extraction
 
 
 class _FakeTransform:
     def extract_package(self, *, analysing_path, **_kwargs):
-        (analysing_path / "chapters").mkdir(parents=True)
-        (analysing_path / "assets").mkdir()
-        (analysing_path / "toc.xml").write_text("<toc/>")
-        DocumentPackage.from_path(analysing_path).write_metadata(
-            dpi=300, page_pixel_sizes={1: (100, 100)}
+        make_extraction(
+            analysing_path / "extraction", page_pixel_sizes={1: (100, 100)},
+            with_toc=True,
         )
         return None, None, None, None, "metering"
 
 
 class _NoAssetTransform:
     def extract_package(self, *, analysing_path, **_kwargs):
-        (analysing_path / "chapters").mkdir(parents=True)
-        DocumentPackage.from_path(analysing_path).write_metadata(
-            dpi=300, page_pixel_sizes={1: (100, 100)}
-        )
+        make_extraction(analysing_path / "extraction", page_pixel_sizes={1: (100, 100)})
         return None, None, None, None, "metering"
 
 
@@ -143,68 +140,66 @@ class TestComposableBoundaries(unittest.TestCase):
             self.assertEqual(raised.exception.failed_page_indexes, (1, 2))
             analyse_toc.assert_not_called()
 
-    def test_package_translation_skips_empty_chapters(self):
+    def test_extraction_translation_skips_empty_chapters(self):
         with tempfile.TemporaryDirectory() as directory:
             root = Path(directory)
-            source = DocumentPackage.from_path(root / "source")
-            source.chapters_path.mkdir(parents=True)
-            source.assets_path.mkdir()
-            source.write_metadata(page_pixel_sizes={1: (100, 100)})
+            source_root = root / "source"
+            source = make_extraction(source_root, page_pixel_sizes={1: (100, 100)})
             empty = Chapter(None, 0, [])
             text = Chapter(None, 0, [ParagraphLayout(
                 "text", 0, [BlockLayout(1, 1, (1, 1, 50, 50), ["text"])]
             )])
-            (source.chapters_path / "chapter_1.xml").write_text(
+            (source_root / "chapters/chapter_1.xml").write_text(
                 '<?xml version="1.0" encoding="UTF-8"?>\n'
                 + tostring(encode(empty), encoding="unicode")
             )
-            (source.chapters_path / "chapter_2.xml").write_text(
+            (source_root / "chapters/chapter_2.xml").write_text(
                 '<?xml version="1.0" encoding="UTF-8"?>\n'
                 + tostring(encode(text), encoding="unicode")
             )
 
             translator = _DeterministicXMLTranslator()
-            target = ChapterPackageTransformer(
+            target = ChapterExtractionTransformer(
                 ChapterXMLTransformer(translator)
-            ).transform(source, root / "target")
+            ).transform(source, root / "target.pcex")
 
             self.assertEqual(translator.calls, 1)
-            self.assertEqual(
-                (target.chapters_path / "chapter_1.xml").read_text(),
-                (source.chapters_path / "chapter_1.xml").read_text(),
-            )
-            self.assertIn("T:text", (target.chapters_path / "chapter_2.xml").read_text())
+            with target._materialize() as paths:
+                self.assertEqual(
+                    (paths.chapters / "chapter_1.xml").read_text(),
+                    (source_root / "chapters/chapter_1.xml").read_text(),
+                )
+                self.assertIn("T:text", (paths.chapters / "chapter_2.xml").read_text())
 
     def test_extractor_creates_empty_assets_directory_for_asset_free_pages(self):
         with tempfile.TemporaryDirectory() as directory:
             root = Path(directory)
-            package, _ = PDFExtractor(_NoAssetTransform()).extract_with_metering(
-                root / "input.pdf", root / "package"
+            extraction, _ = PDFExtractor(_NoAssetTransform()).extract_with_metering(
+                root / "input.pdf", root / "book.pcex"
             )
-            self.assertTrue(package.assets_path.is_dir())
+            with extraction._materialize() as paths:
+                self.assertTrue(paths.assets.is_dir())
 
-    def test_extractor_produces_package_consumed_by_renderers_without_ocr_cache(self):
+    def test_extractor_produces_extraction_consumed_without_analysis_cache(self):
         with tempfile.TemporaryDirectory() as directory:
             root = Path(directory)
-            package, metering = PDFExtractor(_FakeTransform()).extract_with_metering(root / "input.pdf", root / "package")
+            extraction, metering = PDFExtractor(_FakeTransform()).extract_with_metering(
+                root / "input.pdf", root / "book.pcex", analysing_path=root / "analysis"
+            )
             self.assertEqual(metering, "metering")
-            self.assertFalse((root / "package" / "ocr").exists())
-            self.assertIsNone(package.cover_path)
-            self.assertEqual(package.page_pixel_sizes(), {1: (100, 100)})
+            self.assertFalse((root / "analysis" / "extraction" / "ocr").exists())
+            self.assertEqual(extraction.page_pixel_sizes(), {1: (100, 100)})
             with patch("pdf_craft.renderer.markdown.renderer.render_markdown_file") as markdown:
-                MarkdownRenderer().render(package, root / "book.md")
-            self.assertEqual(markdown.call_args.args[0], package.chapters_path)
+                MarkdownRenderer().render(extraction, root / "book.md")
+            self.assertEqual(markdown.call_args.args[0].name, "chapters")
             with patch("pdf_craft.renderer.epub.renderer.render_epub_file") as epub:
-                EpubRenderer().render(package, root / "book.epub")
-            self.assertEqual(epub.call_args.args[0], package.chapters_path)
+                EpubRenderer().render(extraction, root / "book.epub")
+            self.assertEqual(epub.call_args.args[0].name, "chapters")
 
     def test_pdf_pipeline_preserves_structured_content_and_uses_package_metadata(self):
         with tempfile.TemporaryDirectory() as directory:
             root = Path(directory)
-            package = DocumentPackage.from_path(root)
-            package.chapters_path.mkdir(parents=True)
-            package.assets_path.mkdir()
-            package.write_metadata(dpi=300, page_pixel_sizes={1: (100, 100)})
+            extraction = make_extraction(root, page_pixel_sizes={1: (100, 100)})
             reference = Reference(1, 2, "[1]", [])
             chapter = Chapter(None, -1, [
                 ParagraphLayout("text", 0, [BlockLayout(
@@ -215,7 +210,7 @@ class TestComposableBoundaries(unittest.TestCase):
             patcher = _CapturePatcher()
             with patch("pdf_craft.pipeline.pdf.pipeline.create_chapters_reader", return_value=lambda: iter([chapter])):
                 PDFTranslationPipeline(patcher=cast(PDFPatcher, patcher)).translate(
-                    root / "input.pdf", root / "out.pdf", package,
+                    root / "input.pdf", root / "out.pdf", extraction,
                     ChapterXMLTransformer(_DeterministicXMLTranslator())
                 )
             self.assertEqual(len(patcher.replacements), 2)
@@ -228,10 +223,7 @@ class TestComposableBoundaries(unittest.TestCase):
     def test_pdf_pipeline_forwards_translation_events_to_structured_transformer(self):
         with tempfile.TemporaryDirectory() as directory:
             root = Path(directory)
-            package = DocumentPackage.from_path(root)
-            package.chapters_path.mkdir(parents=True)
-            package.assets_path.mkdir()
-            package.write_metadata(page_pixel_sizes={1: (100, 100)})
+            extraction = make_extraction(root, page_pixel_sizes={1: (100, 100)})
             chapter = Chapter(None, -1, [ParagraphLayout(
                 "text", 0, [BlockLayout(1, 1, (1, 1, 50, 50), ["text"])]
             )])
@@ -252,7 +244,7 @@ class TestComposableBoundaries(unittest.TestCase):
             callback = observed.append
             with patch("pdf_craft.pipeline.pdf.pipeline.create_chapters_reader", return_value=lambda: iter([chapter])):
                 PDFTranslationPipeline(patcher=cast(PDFPatcher, _CapturePatcher())).translate(
-                    root / "input.pdf", root / "out.pdf", package,
+                    root / "input.pdf", root / "out.pdf", extraction,
                     ChapterXMLTransformer(EventTranslator()),
                     on_translation_event=callback,
                 )
@@ -264,23 +256,38 @@ class TestComposableBoundaries(unittest.TestCase):
                 [event.kind for event in observed],
             )
 
-    def test_metadata_path_is_retained_for_direct_package(self):
+    def test_pdf_pipeline_never_recovers_missing_geometry_from_source_pdf(self):
         with tempfile.TemporaryDirectory() as directory:
             root = Path(directory)
-            package = DocumentPackage(root / "chapters", root / "assets")
-            package.write_metadata(dpi=300, page_pixel_sizes={1: (30, 30)})
-            self.assertEqual(package.page_pixel_sizes(), {1: (30, 30)})
+            extraction = make_extraction(root, page_pixel_sizes={1: (100, 100)})
+            chapter = Chapter(None, -1, [ParagraphLayout(
+                "text", 0, [BlockLayout(2, 1, (1, 1, 50, 50), ["text"])]
+            )])
+            handler = _FakeHandler()
+            patcher = _CapturePatcher()
+            with patch(
+                "pdf_craft.pipeline.pdf.pipeline.create_chapters_reader",
+                return_value=lambda: iter([chapter]),
+            ), self.assertRaisesRegex(ValueError, "pages.xml is missing page 2"):
+                PDFTranslationPipeline(
+                    pdf_handler=cast(PDFHandler, handler),
+                    patcher=cast(PDFPatcher, patcher),
+                ).patch(root / "input.pdf", root / "out.pdf", extraction)
+            self.assertEqual(handler.document.render_count, 0)
+            self.assertEqual(patcher.replacements, [])
+
+    def test_pages_xml_is_used_for_direct_workspace_extraction(self):
+        with tempfile.TemporaryDirectory() as directory:
+            root = Path(directory)
+            extraction = make_extraction(root, page_pixel_sizes={1: (30, 30)})
+            self.assertEqual(extraction.page_pixel_sizes(), {1: (30, 30)})
 
     def test_epub_renderer_rejects_unsupported_language(self):
         with tempfile.TemporaryDirectory() as directory:
             root = Path(directory)
-            package = DocumentPackage.from_path(root)
-            package.chapters_path.mkdir()
-            package.assets_path.mkdir()
-            assert package.toc_path is not None
-            package.toc_path.write_text("<toc/>")
+            extraction = make_extraction(root, with_toc=True)
             with self.assertRaises(ValueError):
-                EpubRenderer().render(package, root / "book.epub", lan="fr")  # type: ignore[arg-type]
+                EpubRenderer().render(extraction, root / "book.epub", lan="fr")  # type: ignore[arg-type]
 
     def test_ocr_geometry_cache_survives_interrupted_resume_without_rerendering(self):
         with tempfile.TemporaryDirectory() as directory:
@@ -327,19 +334,22 @@ class TestComposableBoundaries(unittest.TestCase):
             self.assertFalse((root / "ocr" / "page_1.failed").exists())
             self.assertTrue((root / "ocr" / "done").exists())
 
-    def test_package_rejects_malformed_page_geometry(self):
+    def test_extraction_rejects_malformed_page_geometry(self):
         with tempfile.TemporaryDirectory() as directory:
             root = Path(directory)
-            package = DocumentPackage.from_path(root)
-            package.chapters_path.mkdir()
-            package.assets_path.mkdir()
-            assert package.metadata_path is not None
-            package.metadata_path.write_text('{"schema": 1, "page_pixel_sizes": {"1": [1]}}')
-            with self.assertRaisesRegex(ValueError, "page_pixel_sizes"):
-                package.validate()
-            package.metadata_path.write_text('{"schema": 1, "page_pixel_sizes": {"1": [1.5, 2]}}')
-            with self.assertRaisesRegex(ValueError, "page_pixel_sizes"):
-                package.validate()
+            extraction = make_extraction(root)
+            (root / "pages.xml").write_text(
+                '<pages index_base="1" coordinate_space="ocr_pixels" render_dpi="300">'
+                '<page index="1" width="1" /></pages>'
+            )
+            with self.assertRaisesRegex(ValueError, "pages.xml"):
+                extraction.validate()
+            (root / "pages.xml").write_text(
+                '<pages index_base="1" coordinate_space="ocr_pixels" render_dpi="300">'
+                '<page index="1" width="1.5" height="2" /></pages>'
+            )
+            with self.assertRaisesRegex(ValueError, "pages.xml"):
+                extraction.validate()
 
     def test_ocr_rejects_malformed_geometry_cache(self):
         with tempfile.TemporaryDirectory() as directory:

--- a/tests/test_craft.py
+++ b/tests/test_craft.py
@@ -1,249 +1,241 @@
+# pylint: disable=protected-access
+
 import tempfile
 import unittest
 from pathlib import Path
 from unittest.mock import Mock, patch
-from xml.etree.ElementTree import tostring
+
+from epub_generator import BookMeta
 
 from pdf_craft.craft import ExtractionOptions, PDFCraft, PDFOptions
-from pdf_craft.document import DocumentPackage
+from pdf_craft.document import PDFCraftExtraction
+from pdf_craft.extractor import PDFExtractor
 from pdf_craft.extractor.chapter.chapter import BlockLayout, Chapter, ParagraphLayout, encode
-from pdf_craft.transformer import ChapterPackageTransformer, SubmitKind
+from pdf_craft.common import save_xml
+from pdf_craft.transformer import ChapterExtractionTransformer, SubmitKind
+from tests.extraction_helpers import make_extraction
 
 
 class _Engine:
     def __init__(self):
         self.kwargs = None
-        self.metadata_source = None
+        self.analysing_path = None
 
     def extract_package(self, *, analysing_path, **kwargs):
         self.kwargs = kwargs
-        (analysing_path / "chapters").mkdir(parents=True)
-        (analysing_path / "assets").mkdir()
-        (analysing_path / "toc.xml").write_text("<toc/>")
-        DocumentPackage.from_path(analysing_path).write_metadata(page_pixel_sizes={1: (10, 10)})
+        self.analysing_path = analysing_path
+        make_extraction(
+            analysing_path / "extraction",
+            page_pixel_sizes={1: (10, 10)},
+            with_toc=True,
+            book_meta=BookMeta(title="Detected title"),
+            language="en",
+        )
         return None, None, None, None, "metering"
 
-    def _extract_book_meta(self, source):
-        self.metadata_source = source
-        return "detected metadata"
+
+def _source_extraction(root: Path, *, with_toc: bool = False) -> PDFCraftExtraction:
+    extraction = make_extraction(
+        root, page_pixel_sizes={1: (10, 10)}, with_toc=with_toc
+    )
+    chapter = Chapter(
+        None,
+        -1,
+        [ParagraphLayout("text", 0, [BlockLayout(1, 1, (1, 1, 5, 5), ["original"])])],
+    )
+    save_xml(encode(chapter), root / "chapters" / "chapter_1.xml")
+    return extraction.validate()
+
+
+class _Upper:
+    def transform(self, chapter: Chapter) -> Chapter:
+        layout = chapter.layouts[0]
+        assert isinstance(layout, ParagraphLayout)
+        layout.blocks[0].content = ["translated"]
+        return chapter
+
+
+class _Identity:
+    def transform(self, chapter: Chapter) -> Chapter:
+        return chapter
 
 
 class TestPDFCraft(unittest.TestCase):
-    def test_translate_package_is_the_public_package_translation_entry(self):
+    def test_translate_extraction_is_the_public_translation_entry(self):
         with tempfile.TemporaryDirectory() as directory:
             root = Path(directory)
-            source = DocumentPackage.from_path(root / "source")
-            source.chapters_path.mkdir(parents=True)
-            source.assets_path.mkdir()
-            source.write_metadata(page_pixel_sizes={1: (10, 10)})
-            chapter = Chapter(
-                None, -1, [ParagraphLayout(
-                    "text", 0, [BlockLayout(1, 1, (1, 1, 5, 5), ["original"])]
-                )]
-            )
-            (source.chapters_path / "chapter_1.xml").write_text(
-                '<?xml version="1.0" encoding="UTF-8"?>\n'
-                + tostring(encode(chapter), encoding="unicode")
-            )
+            source = _source_extraction(root / "source")
+            target_path = root / "target.pcex"
 
-            class Upper:
-                def transform(self, chapter: Chapter) -> Chapter:
-                    layout = chapter.layouts[0]
-                    assert isinstance(layout, ParagraphLayout)
-                    layout.blocks[0].content = ["translated"]
-                    return chapter
+            target = PDFCraft().translate_extraction(source, target_path, _Upper())
 
-            target = PDFCraft().translate_package(source, root / "target", Upper())
+            self.assertTrue(target_path.is_file())
             self.assertEqual(target.page_pixel_sizes(), {1: (10, 10)})
-            self.assertIn("translated", (target.chapters_path / "chapter_1.xml").read_text())
-            self.assertFalse(hasattr(PDFCraft, "transform_package"))
+            with target._materialize() as paths:
+                self.assertIn("translated", (paths.chapters / "chapter_1.xml").read_text())
+            self.assertFalse(hasattr(PDFCraft, "translate_package"))
 
-    def test_patch_pdf_with_package_delegates_to_pdf_patch_pipeline(self):
+    def test_patch_pdf_with_extraction_delegates_to_pdf_patch_pipeline(self):
         with tempfile.TemporaryDirectory() as directory:
-            root = Path(directory)
-            package = DocumentPackage.from_path(root / "package")
-            package.chapters_path.mkdir(parents=True)
-            package.assets_path.mkdir()
-            with patch("pdf_craft.craft._validate_package_for_pdf") as validate, \
+            extraction = _source_extraction(Path(directory) / "source")
+            with patch("pdf_craft.craft._validate_extraction_for_pdf") as validate, \
                     patch("pdf_craft.craft.PDFTranslationPipeline.patch") as patch_pdf:
-                PDFCraft().patch_pdf_with_package("source.pdf", package, "target.pdf")
+                PDFCraft().patch_pdf_with_extraction("source.pdf", extraction, "target.pdf")
             validate.assert_called_once()
             patch_pdf.assert_called_once()
 
-    def test_package_step_creates_independent_package(self):
+    def test_extraction_transform_creates_independent_archive(self):
         with tempfile.TemporaryDirectory() as directory:
             root = Path(directory)
-            source = DocumentPackage.from_path(root / "source")
-            source.chapters_path.mkdir(parents=True)
-            source.assets_path.mkdir()
-            assert source.toc_path is not None
-            source.toc_path.write_text("<toc page_indexes=\"1\" />")
-            source.write_metadata(page_pixel_sizes={1: (10, 10)})
-            chapter = Chapter(
-                None, -1, [ParagraphLayout(
-                    "text", 0, [BlockLayout(1, 1, (1, 1, 5, 5), ["original"])]
-                )]
-            )
-            (source.chapters_path / "chapter_1.xml").write_text(
-                '<?xml version="1.0" encoding="UTF-8"?>\n'
-                + tostring(encode(chapter), encoding="unicode")
+            source = _source_extraction(root / "source", with_toc=True)
+            target = ChapterExtractionTransformer(_Upper()).transform(
+                source, root / "target.pcex"
             )
 
-            class Upper:
-                def transform(self, chapter: Chapter) -> Chapter:
-                    layout = chapter.layouts[0]
-                    assert isinstance(layout, ParagraphLayout)
-                    layout.blocks[0].content = ["translated"]
-                    return chapter
+            with source._materialize() as paths:
+                self.assertIn("original", (paths.chapters / "chapter_1.xml").read_text())
+            with target._materialize() as paths:
+                self.assertIn("translated", (paths.chapters / "chapter_1.xml").read_text())
+                self.assertTrue(paths.toc.is_file())
 
-            target = ChapterPackageTransformer(Upper()).transform(source, root / "target")
-            self.assertEqual(target.page_pixel_sizes(), {1: (10, 10)})
-            self.assertIn("original", (source.chapters_path / "chapter_1.xml").read_text())
-            self.assertIn("translated", (target.chapters_path / "chapter_1.xml").read_text())
-            assert target.toc_path is not None
-            self.assertEqual(source.toc_path.read_text(), target.toc_path.read_text())
-
-    def test_package_toc_transform_is_explicit(self):
+    def test_extraction_toc_transform_is_explicit(self):
         with tempfile.TemporaryDirectory() as directory:
             root = Path(directory)
-            source = DocumentPackage.from_path(root / "source")
-            source.chapters_path.mkdir(parents=True)
-            source.assets_path.mkdir()
-            assert source.toc_path is not None
-            source.toc_path.write_text('<toc page_indexes="1"><item /></toc>')
-            source.write_metadata(page_pixel_sizes={1: (10, 10)})
-
-            class Identity:
-                def transform(self, chapter: Chapter) -> Chapter:
-                    return chapter
+            source = _source_extraction(root / "source", with_toc=True)
 
             def translate_toc(element):
                 element.set("translated", "yes")
                 return element
 
-            target = ChapterPackageTransformer(
-                Identity(), toc_transformer=translate_toc
-            ).transform(source, root / "target")
-            assert target.toc_path is not None
-            self.assertIn('translated="yes"', target.toc_path.read_text())
+            target = ChapterExtractionTransformer(
+                _Identity(), toc_transformer=translate_toc
+            ).transform(source, root / "target.pcex")
+            with target._materialize() as paths:
+                self.assertIn('translated="yes"', paths.toc.read_text(encoding="utf-8"))
 
     def test_epub_only_facade_needs_no_pdf_options(self):
         craft = PDFCraft()
         with patch("pdf_craft.craft.run_epub_translation") as translate:
-            craft.translate_epub("source.epub", "target.epub", target_language="zh", submit=SubmitKind.REPLACE)
+            craft.translate_epub(
+                "source.epub", "target.epub", target_language="zh",
+                submit=SubmitKind.REPLACE,
+            )
         translate.assert_called_once()
 
     def test_pdf_extraction_requires_options_only_when_used(self):
         with self.assertRaisesRegex(ValueError, "PDFOptions"):
-            PDFCraft().extract_pdf("source.pdf", "package")
+            PDFCraft().extract_pdf("source.pdf", "book.pcex")
 
     def test_extraction_options_reach_extractor_engine(self):
         with tempfile.TemporaryDirectory() as directory:
+            root = Path(directory)
             engine = _Engine()
-            package, metering = PDFCraft.from_engine(engine).extract_pdf_with_metering(
-                "source.pdf", Path(directory), ExtractionOptions(page_indexes=(2, 4), max_ocr_tokens=12)
+            extraction, metering = PDFCraft.from_engine(engine).extract_pdf_with_metering(
+                "source.pdf",
+                root / "book.pcex",
+                ExtractionOptions(page_indexes=(2, 4), max_ocr_tokens=12),
+                analysing_path=root / "analysis",
             )
             self.assertEqual(metering, "metering")
             assert engine.kwargs is not None
             self.assertEqual(engine.kwargs["page_indexes"], (2, 4))
             self.assertEqual(engine.kwargs["max_tokens"], 12)
-            self.assertTrue(package.has_toc())
+            extraction.validate(require_toc=True)
+            self.assertTrue((root / "analysis" / "extraction").is_dir())
 
-    def test_rendering_package_does_not_construct_pdf_engine(self):
+    def test_public_extraction_requires_pcex_output(self):
+        with tempfile.TemporaryDirectory() as directory:
+            engine = _Engine()
+            with self.assertRaisesRegex(ValueError, "\\.pcex"):
+                PDFCraft.from_engine(engine).extract_pdf(
+                    "source.pdf", Path(directory) / "book"
+                )
+            self.assertIsNone(engine.kwargs)
+        self.assertFalse(hasattr(PDFExtractor, "extract_to_workspace"))
+        self.assertFalse(hasattr(ChapterExtractionTransformer, "transform_to_workspace"))
+
+    def test_rendering_extraction_does_not_construct_pdf_engine(self):
         with tempfile.TemporaryDirectory() as directory:
             root = Path(directory)
-            package = DocumentPackage.from_path(root)
-            package.chapters_path.mkdir()
-            package.assets_path.mkdir()
+            extraction = _source_extraction(root / "source")
             with patch("pdf_craft.craft.MarkdownRenderer.render") as render:
-                PDFCraft().render_markdown(package, root / "book.md")
+                PDFCraft().render_markdown(extraction, root / "book.md")
             render.assert_called_once()
 
-    def test_one_shot_workflow_supports_one_translator(self):
-        craft = PDFCraft.from_engine(_Engine())
-        translator = Mock()
-        with patch.object(craft, "extract_pdf_with_metering", return_value=(object(), "metering")) as extract, \
-             patch.object(craft, "translate_package", return_value=object()) as translate, \
-             patch.object(craft, "render_markdown") as render:
-            result = craft.convert_pdf_to_markdown(
-                "source.pdf", "book.md", package_path="package",
-                translator=translator, submit=SubmitKind.APPEND_TEXT,
-            )
-        self.assertEqual(result, "metering")
-        extract.assert_called_once()
-        translate.assert_called_once()
-        self.assertEqual(translate.call_args.kwargs["submit"], SubmitKind.APPEND_TEXT)
-        render.assert_called_once()
+    def test_one_shot_workflow_uses_workspace_without_zip_churn(self):
+        with tempfile.TemporaryDirectory() as directory:
+            root = Path(directory)
+            craft = PDFCraft.from_engine(_Engine())
+            with patch.object(PDFCraftExtraction, "export") as export, \
+                    patch.object(craft, "render_markdown") as render:
+                result = craft.convert_pdf_to_markdown(
+                    "source.pdf", root / "book.md", analysing_path=root / "analysis"
+                )
+            self.assertEqual(result, "metering")
+            export.assert_not_called()
+            rendered_extraction = render.call_args.args[0]
+            with rendered_extraction._materialize() as paths:
+                self.assertEqual(paths.root, root / "analysis" / "extraction")
 
-    def test_one_shot_markdown_workflow_cleans_implicit_workspace(self):
-        craft = PDFCraft.from_engine(_Engine())
-        workspaces = []
+    def test_one_shot_workflow_can_also_export_extraction(self):
+        with tempfile.TemporaryDirectory() as directory:
+            root = Path(directory)
+            craft = PDFCraft.from_engine(_Engine())
+            with patch.object(craft, "render_markdown"), \
+                    patch("pdf_craft.document.package._extract_archive") as unpack:
+                craft.convert_pdf_to_markdown(
+                    "source.pdf",
+                    root / "book.md",
+                    analysing_path=root / "analysis",
+                    extraction_path=root / "book.pcex",
+                )
+            self.assertTrue((root / "book.pcex").is_file())
+            unpack.assert_not_called()
 
-        def extract(*args):
-            workspaces.append(Path(args[1]))
-            self.assertTrue(workspaces[-1].is_dir())
-            return object(), "metering"
-
-        with patch.object(craft, "extract_pdf_with_metering", side_effect=extract), \
-             patch.object(craft, "render_markdown"):
-            result = craft.convert_pdf_to_markdown("source.pdf", "book.md")
-
-        self.assertEqual(result, "metering")
-        self.assertEqual(len(workspaces), 1)
-        self.assertFalse(workspaces[0].exists())
-
-    def test_one_shot_epub_workflow_cleans_implicit_workspace_on_error(self):
-        craft = PDFCraft.from_engine(_Engine())
-        workspaces = []
-
-        def extract(*args):
-            workspaces.append(Path(args[1]))
-            return object(), "metering"
-
-        with patch.object(craft, "extract_pdf_with_metering", side_effect=extract), \
-             patch.object(craft, "render_epub", side_effect=RuntimeError("render failed")), \
-             self.assertRaisesRegex(RuntimeError, "render failed"):
-            craft.convert_pdf_to_epub("source.pdf", "book.epub")
-
-        self.assertEqual(len(workspaces), 1)
-        self.assertFalse(workspaces[0].exists())
-
-    def test_epub_workflow_detects_metadata_and_forwards_aborted(self):
+    def test_one_shot_markdown_cleans_implicit_analysis_workspace(self):
         engine = _Engine()
         craft = PDFCraft.from_engine(engine)
-        stopped = lambda: False
-        with patch.object(craft, "extract_pdf_with_metering", return_value=(object(), "metering")), \
-             patch.object(craft, "render_epub") as render:
-            result = craft.convert_pdf_to_epub(
-                "source.pdf", "book.epub", package_path="package",
-                extraction=ExtractionOptions(aborted=stopped),
-            )
+        with patch.object(craft, "render_markdown"):
+            result = craft.convert_pdf_to_markdown("source.pdf", "book.md")
         self.assertEqual(result, "metering")
-        self.assertEqual(engine.metadata_source, Path("source.pdf"))
-        self.assertEqual(render.call_args.kwargs["book_meta"], "detected metadata")
-        self.assertIs(render.call_args.kwargs["aborted"], stopped)
+        assert engine.analysing_path is not None
+        self.assertFalse(engine.analysing_path.exists())
 
-    def test_epub_conversion_forwards_translation_events_to_translator(self):
+    def test_epub_uses_manifest_metadata_without_rereading_source_pdf(self):
+        craft = PDFCraft.from_engine(_Engine())
+        observed = {}
+
+        def inspect_manifest(extraction, _output, **kwargs):
+            observed["title"] = extraction.book_meta().title
+            observed["language"] = extraction.language()
+            observed["book_meta"] = kwargs["book_meta"]
+            observed["lan"] = kwargs["lan"]
+
+        with patch.object(craft, "render_epub", side_effect=inspect_manifest):
+            craft.convert_pdf_to_epub("source.pdf", "book.epub")
+        self.assertEqual(observed["title"], "Detected title")
+        self.assertEqual(observed["language"], "en")
+        self.assertIsNone(observed["book_meta"])
+        self.assertIsNone(observed["lan"])
+
+    def test_epub_conversion_forwards_translation_events(self):
         craft = PDFCraft.from_engine(_Engine())
         callback = Mock()
         translator = Mock()
-        with patch.object(craft, "extract_pdf_with_metering", return_value=(object(), "metering")), \
-             patch.object(craft, "translate_package", return_value=object()) as translate, \
-             patch.object(craft, "render_epub"):
+        with patch.object(craft, "_translate_to_workspace", return_value=Mock()) as translate, \
+                patch.object(craft, "render_epub"):
             craft.convert_pdf_to_epub(
-                "source.pdf", "book.epub", package_path="package",
-                translator=translator, on_translation_event=callback,
+                "source.pdf", "book.epub", translator=translator,
+                on_translation_event=callback,
             )
         self.assertIs(translate.call_args.kwargs["on_translation_event"], callback)
 
-    def test_markdown_workflow_forwards_aborted_to_renderer_step(self):
+    def test_markdown_workflow_forwards_aborted_to_renderer(self):
         craft = PDFCraft.from_engine(_Engine())
         stopped = lambda: False
-        with patch.object(craft, "extract_pdf_with_metering", return_value=(object(), "metering")), \
-             patch.object(craft, "render_markdown") as render:
+        with patch.object(craft, "render_markdown") as render:
             craft.convert_pdf_to_markdown(
-                "source.pdf", "book.md", package_path="package",
-                extraction=ExtractionOptions(aborted=stopped),
+                "source.pdf", "book.md", extraction=ExtractionOptions(aborted=stopped)
             )
         self.assertIs(render.call_args.kwargs["aborted"], stopped)
 

--- a/tests/test_pdf_craft_extraction.py
+++ b/tests/test_pdf_craft_extraction.py
@@ -22,6 +22,17 @@ class _Identity:
         return chapter
 
 
+def _replace_archive_members(
+    source_path: Path,
+    target_path: Path,
+    replacements: dict[str, bytes],
+) -> None:
+    with ZipFile(source_path) as source, ZipFile(target_path, "w") as target:
+        for info in source.infolist():
+            content = replacements.get(info.filename, source.read(info.filename))
+            target.writestr(info, content)
+
+
 class TestPDFCraftExtraction(unittest.TestCase):
     def test_archive_remains_usable_after_analysis_workspace_is_gone(self):
         with tempfile.TemporaryDirectory() as directory:
@@ -131,6 +142,93 @@ class TestPDFCraftExtraction(unittest.TestCase):
                     target.writestr(info, content)
             with self.assertRaisesRegex(ValueError, "format version"):
                 PDFCraftExtraction.open(unsupported)
+
+    def test_invalid_manifest_json_and_incomplete_document_are_rejected(self):
+        with tempfile.TemporaryDirectory() as directory:
+            root = Path(directory)
+            extraction = make_extraction(root / "workspace")
+            valid = root / "valid.pcex"
+            extraction.export(valid)
+
+            invalid_json = root / "invalid-json.pcex"
+            _replace_archive_members(
+                valid,
+                invalid_json,
+                {"manifest.json": b"{"},
+            )
+            with self.assertRaisesRegex(ValueError, "invalid PDFCraftExtraction manifest.json"):
+                PDFCraftExtraction.open(invalid_json)
+
+            incomplete = root / "incomplete-document.pcex"
+            with ZipFile(valid) as archive:
+                manifest = json.loads(archive.read("manifest.json"))
+            manifest["document"] = {}
+            _replace_archive_members(
+                valid,
+                incomplete,
+                {"manifest.json": json.dumps(manifest).encode()},
+            )
+            with self.assertRaisesRegex(ValueError, "invalid document metadata"):
+                PDFCraftExtraction.open(incomplete)
+
+    def test_invalid_chapter_xml_and_schema_are_rejected_when_opened(self):
+        with tempfile.TemporaryDirectory() as directory:
+            root = Path(directory)
+            workspace = root / "workspace"
+            extraction = make_extraction(workspace)
+            save_xml(encode(Chapter(None, -1, [])), workspace / "chapters/chapter_head.xml")
+            valid = root / "valid.pcex"
+            extraction.export(valid)
+
+            cases = {
+                "malformed": (b"<chapter>", "invalid PDFCraftExtraction XML"),
+                "missing-body": (b"<chapter/>", "invalid chapter schema"),
+            }
+            for name, (chapter_xml, error_pattern) in cases.items():
+                with self.subTest(name=name):
+                    invalid = root / f"{name}.pcex"
+                    _replace_archive_members(
+                        valid,
+                        invalid,
+                        {"chapters/chapter_head.xml": chapter_xml},
+                    )
+                    with self.assertRaisesRegex(ValueError, error_pattern):
+                        PDFCraftExtraction.open(invalid)
+
+    def test_invalid_toc_xml_is_rejected_when_opened(self):
+        with tempfile.TemporaryDirectory() as directory:
+            root = Path(directory)
+            extraction = make_extraction(root / "workspace", with_toc=True)
+            valid = root / "valid.pcex"
+            extraction.export(valid)
+            invalid = root / "invalid-toc.pcex"
+            _replace_archive_members(valid, invalid, {"toc.xml": b"<toc>"})
+
+            with self.assertRaisesRegex(ValueError, "invalid PDFCraftExtraction XML: toc.xml"):
+                PDFCraftExtraction.open(invalid)
+
+    def test_noncanonical_asset_hash_cannot_escape_assets_directory(self):
+        with tempfile.TemporaryDirectory() as directory:
+            root = Path(directory)
+            workspace = root / "workspace"
+            extraction = make_extraction(workspace)
+            save_xml(encode(Chapter(None, -1, [])), workspace / "chapters/chapter_head.xml")
+            (workspace / "cover.png").write_bytes(b"cover")
+            valid = root / "valid.pcex"
+            extraction.export(valid)
+            invalid = root / "invalid-hash.pcex"
+            chapter_xml = (
+                b'<chapter><body><asset ref="image" page_index="1" det="0,0,1,1" '
+                b'hash="../cover"/></body></chapter>'
+            )
+            _replace_archive_members(
+                valid,
+                invalid,
+                {"chapters/chapter_head.xml": chapter_xml},
+            )
+
+            with self.assertRaisesRegex(ValueError, "invalid asset hash"):
+                PDFCraftExtraction.open(invalid)
 
     def test_translation_preserves_manifest_pages_toc_cover_and_assets(self):
         with tempfile.TemporaryDirectory() as directory:

--- a/tests/test_pdf_craft_extraction.py
+++ b/tests/test_pdf_craft_extraction.py
@@ -195,17 +195,22 @@ class TestPDFCraftExtraction(unittest.TestCase):
                     with self.assertRaisesRegex(ValueError, error_pattern):
                         PDFCraftExtraction.open(invalid)
 
-    def test_invalid_toc_xml_is_rejected_when_opened(self):
+    def test_invalid_toc_xml_and_schema_are_rejected_when_opened(self):
         with tempfile.TemporaryDirectory() as directory:
             root = Path(directory)
             extraction = make_extraction(root / "workspace", with_toc=True)
             valid = root / "valid.pcex"
             extraction.export(valid)
-            invalid = root / "invalid-toc.pcex"
-            _replace_archive_members(valid, invalid, {"toc.xml": b"<toc>"})
-
-            with self.assertRaisesRegex(ValueError, "invalid PDFCraftExtraction XML: toc.xml"):
-                PDFCraftExtraction.open(invalid)
+            cases = {
+                "malformed": (b"<toc>", "invalid PDFCraftExtraction XML: toc.xml"),
+                "missing-page-indexes": (b"<toc/>", "invalid toc schema"),
+            }
+            for name, (toc_xml, error_pattern) in cases.items():
+                with self.subTest(name=name):
+                    invalid = root / f"invalid-toc-{name}.pcex"
+                    _replace_archive_members(valid, invalid, {"toc.xml": toc_xml})
+                    with self.assertRaisesRegex(ValueError, error_pattern):
+                        PDFCraftExtraction.open(invalid)
 
     def test_noncanonical_asset_hash_cannot_escape_assets_directory(self):
         with tempfile.TemporaryDirectory() as directory:

--- a/tests/test_pdf_craft_extraction.py
+++ b/tests/test_pdf_craft_extraction.py
@@ -1,0 +1,160 @@
+# pylint: disable=protected-access
+
+import json
+import tempfile
+import unittest
+from datetime import datetime, timezone
+from pathlib import Path
+from zipfile import ZipFile
+
+from epub_generator import BookMeta
+
+from pdf_craft.craft import PDFCraft
+from pdf_craft.document import PDFCraftExtraction
+from pdf_craft.extractor.chapter.chapter import Chapter
+from pdf_craft.common import save_xml
+from pdf_craft.extractor.chapter.chapter import encode
+from tests.extraction_helpers import make_extraction
+
+
+class _Identity:
+    def transform(self, chapter: Chapter) -> Chapter:
+        return chapter
+
+
+class TestPDFCraftExtraction(unittest.TestCase):
+    def test_archive_remains_usable_after_analysis_workspace_is_gone(self):
+        with tempfile.TemporaryDirectory() as directory:
+            root = Path(directory)
+            archive_path = root / "book.pcex"
+            with tempfile.TemporaryDirectory() as analysis_directory:
+                extraction_root = Path(analysis_directory) / "extraction"
+                extraction = make_extraction(extraction_root)
+                save_xml(
+                    encode(Chapter(None, -1, [])),
+                    extraction_root / "chapters/chapter_head.xml",
+                )
+                extraction.export(archive_path)
+
+            opened = PDFCraftExtraction.open(archive_path)
+            opened.validate()
+            self.assertEqual(opened.page_pixel_sizes(), {1: (100, 100)})
+
+    def test_archive_round_trip_has_only_standard_members(self):
+        with tempfile.TemporaryDirectory() as directory:
+            root = Path(directory)
+            modified = datetime(2025, 1, 2, tzinfo=timezone.utc)
+            extraction = make_extraction(
+                root / "workspace",
+                page_pixel_sizes={1: (1200, 1800), 2: (900, 1400)},
+                render_dpi=240,
+                with_toc=True,
+                book_meta=BookMeta(
+                    title="A book", authors=["Author"], translators=["Translator"],
+                    modified=modified,
+                ),
+                language="en",
+            )
+            save_xml(encode(Chapter(None, -1, [])), root / "workspace/chapters/chapter_head.xml")
+            (root / "workspace/cover.png").write_bytes(b"cover")
+            asset_name = "a" * 64 + ".png"
+            (root / "workspace/assets" / asset_name).write_bytes(b"asset")
+            archive_path = root / "book.pcex"
+
+            opened = extraction.export(archive_path)
+
+            self.assertEqual(opened.page_pixel_sizes(), {1: (1200, 1800), 2: (900, 1400)})
+            self.assertEqual(PDFCraftExtraction.load(archive_path).render_dpi(), 240)
+            self.assertEqual(opened.render_dpi(), 240)
+            self.assertEqual(opened.language(), "en")
+            metadata = opened.book_meta()
+            assert metadata is not None
+            self.assertEqual(metadata.title, "A book")
+            self.assertEqual(metadata.authors, ["Author"])
+            self.assertEqual(metadata.modified, modified)
+            with ZipFile(archive_path) as archive:
+                self.assertEqual(
+                    set(archive.namelist()),
+                    {
+                        "manifest.json", "pages.xml", "toc.xml", "cover.png",
+                        "chapters/", "chapters/chapter_head.xml",
+                        "assets/", f"assets/{asset_name}",
+                    },
+                )
+
+    def test_folder_and_non_pcex_paths_are_not_public_inputs(self):
+        with tempfile.TemporaryDirectory() as directory:
+            root = Path(directory)
+            make_extraction(root / "workspace")
+            with self.assertRaisesRegex(ValueError, "\\.pcex"):
+                PDFCraftExtraction.open(root / "workspace")
+            (root / "book.zip").write_bytes(b"not a zip")
+            with self.assertRaisesRegex(ValueError, "\\.pcex"):
+                PDFCraftExtraction.open(root / "book.zip")
+
+    def test_corrupt_and_unsafe_archives_are_rejected(self):
+        with tempfile.TemporaryDirectory() as directory:
+            root = Path(directory)
+            corrupt = root / "corrupt.pcex"
+            corrupt.write_bytes(b"not a zip")
+            with self.assertRaisesRegex(ValueError, "invalid or corrupt"):
+                PDFCraftExtraction.open(corrupt)
+
+            unsafe = root / "unsafe.pcex"
+            with ZipFile(unsafe, "w") as archive:
+                archive.writestr("../manifest.json", "{}")
+            with self.assertRaisesRegex(ValueError, "unsafe"):
+                PDFCraftExtraction.open(unsafe)
+
+    def test_missing_component_and_unsupported_version_are_rejected(self):
+        with tempfile.TemporaryDirectory() as directory:
+            root = Path(directory)
+            extraction = make_extraction(root / "workspace")
+            extraction.export(root / "valid.pcex")
+
+            missing = root / "missing.pcex"
+            with ZipFile(root / "valid.pcex") as source, ZipFile(missing, "w") as target:
+                for info in source.infolist():
+                    if info.filename != "pages.xml":
+                        target.writestr(info, source.read(info.filename))
+            with self.assertRaisesRegex(ValueError, "pages.xml"):
+                PDFCraftExtraction.open(missing)
+
+            unsupported = root / "unsupported.pcex"
+            with ZipFile(root / "valid.pcex") as source, ZipFile(unsupported, "w") as target:
+                for info in source.infolist():
+                    content = source.read(info.filename)
+                    if info.filename == "manifest.json":
+                        payload = json.loads(content)
+                        payload["format_version"] = 999
+                        content = json.dumps(payload).encode()
+                    target.writestr(info, content)
+            with self.assertRaisesRegex(ValueError, "format version"):
+                PDFCraftExtraction.open(unsupported)
+
+    def test_translation_preserves_manifest_pages_toc_cover_and_assets(self):
+        with tempfile.TemporaryDirectory() as directory:
+            root = Path(directory)
+            source_workspace = root / "source"
+            source = make_extraction(
+                source_workspace,
+                page_pixel_sizes={1: (20, 30)},
+                with_toc=True,
+                book_meta=BookMeta(title="Metadata"),
+                language="zh",
+            )
+            save_xml(encode(Chapter(None, -1, [])), source_workspace / "chapters/chapter_head.xml")
+            (source_workspace / "cover.png").write_bytes(b"cover")
+            asset_name = "b" * 64 + ".png"
+            (source_workspace / "assets" / asset_name).write_bytes(b"asset")
+
+            translated = PDFCraft().translate_extraction(
+                source, root / "translated.pcex", _Identity()
+            )
+
+            with source._materialize() as original, translated._materialize() as result:
+                for name in ("manifest.json", "pages.xml", "toc.xml", "cover.png"):
+                    self.assertEqual((original.root / name).read_bytes(),
+                                     (result.root / name).read_bytes())
+                self.assertEqual((original.assets / asset_name).read_bytes(),
+                                 (result.assets / asset_name).read_bytes())

--- a/tests/test_smoke.py
+++ b/tests/test_smoke.py
@@ -1,3 +1,5 @@
+# pylint: disable=protected-access
+
 import json
 import tempfile
 import unittest
@@ -6,7 +8,7 @@ from pathlib import Path
 from typing import cast
 from unittest.mock import patch
 
-from pdf_craft.document import DocumentPackage
+from pdf_craft.document import ExtractionPaths, PDFCraftExtraction
 from pdf_craft.extractor import PDFExtractor
 from pdf_craft.common import save_xml
 from pdf_craft.markdown.render import render_markdown_file
@@ -25,6 +27,7 @@ from pdf_craft_tool.smoke.runner import (
     run_smoke,
 )
 from pdf_craft.extractor.chapter.chapter import AssetLayout, BlockLayout, Chapter, ParagraphLayout, encode
+from tests.extraction_helpers import make_extraction
 
 encode_chapter = encode
 
@@ -35,10 +38,9 @@ class _CaptureTransform:
 
     def extract_package(self, *, analysing_path, **kwargs):
         self.kwargs = kwargs
-        (analysing_path / "chapters").mkdir(parents=True)
-        (analysing_path / "assets").mkdir()
-        (analysing_path / "toc.xml").write_text("<toc/>")
-        DocumentPackage.from_path(analysing_path).write_metadata(page_pixel_sizes={1: (1, 1)})
+        make_extraction(
+            analysing_path / "extraction", page_pixel_sizes={1: (1, 1)}, with_toc=True
+        )
         return None, None, None, None, None
 
 
@@ -105,8 +107,8 @@ class TestSmokeMatrix(unittest.TestCase):
             root = Path(directory)
             package = _package_with_image(root / "package")
             markdown = root / "output" / "book.md"
-            render_markdown_file(package.chapters_path, package.assets_path, markdown,
-                                 Path("assets"), package.cover_path, lambda: False)
+            render_markdown_file(package.chapters, package.assets, markdown,
+                                 Path("assets"), package.cover, lambda: False)
             self.assertTrue((root / "output" / "assets" / "image.png").is_file())
             self.assertTrue((root / "output" / "assets" / "cover.png").is_file())
             self.assertIn("![](assets/image.png)", markdown.read_text())
@@ -118,7 +120,7 @@ class TestSmokeMatrix(unittest.TestCase):
             package = _package_with_image(root / "package")
             markdown = root / "output" / "book.md"
             destination = root / "external-assets"
-            render_markdown_file(package.chapters_path, package.assets_path, markdown,
+            render_markdown_file(package.chapters, package.assets, markdown,
                                  destination, None, lambda: False)
             self.assertTrue((destination / "image.png").is_file())
             self.assertIn("![](../external-assets/image.png)", markdown.read_text())
@@ -129,7 +131,7 @@ class TestSmokeMatrix(unittest.TestCase):
             root = Path(directory)
             package = _package_without_assets(root / "package")
             markdown = root / "output" / "book.md"
-            render_markdown_file(package.chapters_path, package.assets_path, markdown,
+            render_markdown_file(package.chapters, package.assets, markdown,
                                  Path("assets"), None, lambda: False)
             self.assertEqual(check_markdown(markdown), [])
 
@@ -146,11 +148,12 @@ class TestSmokeMatrix(unittest.TestCase):
     def test_pdf_run_records_ocr_events_and_stage_timeline(self):
         with tempfile.TemporaryDirectory() as directory:
             root = Path(directory)
-            package = _package_without_assets(root / "fixture-package")
+            package_paths = _package_without_assets(root / "fixture-package")
+            package = PDFCraftExtraction._from_workspace(package_paths.root)
             metering = OCRTokensMetering(5, 7)
             with patch("pdf_craft_tool.smoke.runner.PDFCraft") as craft_class:
                 craft = craft_class.return_value
-                def extract(_source, _path, options):
+                def extract(_source, _path, options, **_kwargs):
                     options.on_ocr_event(OCREvent(OCREventKind.COMPLETE, 1, 1, 12, 5, 7))
                     return package, metering
                 craft.extract_pdf_with_metering.side_effect = extract
@@ -185,7 +188,7 @@ class TestSmokeMatrix(unittest.TestCase):
                  patch("pdf_craft_tool.smoke.runner.PDFCraft") as craft_class:
                 craft = craft_class.return_value
 
-                def extract(_source, _path, options):
+                def extract(_source, _path, options, **_kwargs):
                     options.on_ocr_event(OCREvent(
                         OCREventKind.FAILED, 1, 1,
                         error=ValueError("OCR rejected api-secret and access-secret"),
@@ -259,7 +262,9 @@ class TestSmokeMatrix(unittest.TestCase):
     def test_page_indexes_are_forwarded_to_public_extractor(self):
         with tempfile.TemporaryDirectory() as directory:
             transform = _CaptureTransform()
-            PDFExtractor(transform).extract(Path("source.pdf"), Path(directory), page_indexes=(2, 4))
+            PDFExtractor(transform).extract(
+                Path("source.pdf"), Path(directory) / "book.pcex", page_indexes=(2, 4)
+            )
             kwargs = transform.kwargs
             assert kwargs is not None
             self.assertEqual(kwargs["page_indexes"], (2, 4))
@@ -267,10 +272,7 @@ class TestSmokeMatrix(unittest.TestCase):
     def test_pdf_patch_geometry_rejects_partial_page_metadata(self):
         with tempfile.TemporaryDirectory() as directory:
             root = Path(directory)
-            package = DocumentPackage.from_path(root)
-            package.chapters_path.mkdir()
-            package.assets_path.mkdir()
-            package.write_metadata(page_pixel_sizes={1: (100, 100)})
+            package = make_extraction(root, page_pixel_sizes={1: (100, 100)})
             chapter = Chapter(None, -1, [ParagraphLayout("text", 0, [
                 BlockLayout(2, 1, (1, 1, 20, 20), ["will be replaced"])
             ])])
@@ -281,7 +283,7 @@ class TestSmokeMatrix(unittest.TestCase):
     def test_pdf_route_skips_when_local_ocr_has_no_cuda_device(self):
         with tempfile.TemporaryDirectory() as directory:
             root = Path(directory)
-            (root / "package").mkdir()
+            (root / "analysis").mkdir()
             (root / "output").mkdir()
 
             class UnavailableCraft:
@@ -300,18 +302,16 @@ class TestSmokeMatrix(unittest.TestCase):
                 errors,
                 ["OCR backend unavailable: local OCR requires CUDA, but no CUDA device is available"],
             )
-            self.assertEqual(details["package"], str(root / "package"))
+            self.assertEqual(details["package"], str(root / "book.pcex"))
 
     def test_markdown_route_inserts_deterministic_package_step(self):
         with tempfile.TemporaryDirectory() as directory:
             root = Path(directory)
             (root / "output").mkdir()
-            package_path = root / "package"
-            package_path.joinpath("chapters").mkdir(parents=True)
-            package_path.joinpath("assets").mkdir()
-            package_path.joinpath("toc.xml").write_text("<toc />")
-            package = DocumentPackage.from_path(package_path)
-            package.write_metadata(page_pixel_sizes={1: (10, 10)})
+            package_path = root / "fixture-extraction"
+            package = make_extraction(
+                package_path, page_pixel_sizes={1: (10, 10)}, with_toc=True
+            )
             chapter = Chapter(None, -1, [ParagraphLayout("text", 0, [
                 BlockLayout(1, 1, (1, 1, 2, 2), ["original"])
             ])])
@@ -353,21 +353,18 @@ def _opf(manifest: str, spine: str, spine_attrs: str) -> str:
     return f'<package version="2.0"><manifest>{manifest}</manifest><spine {spine_attrs}>{spine}</spine></package>'
 
 
-def _package_with_image(root: Path) -> DocumentPackage:
+def _package_with_image(root: Path) -> ExtractionPaths:
     package = _package_without_assets(root)
-    (package.assets_path / "image.png").write_bytes(b"image")
-    cover = root / "cover.png"
-    cover.write_bytes(b"cover")
-    package = DocumentPackage(package.chapters_path, package.assets_path, None, cover, package.metadata_path)
+    (package.assets / "image.png").write_bytes(b"image")
+    package.cover.write_bytes(b"cover")
     chapter = Chapter(None, -1, [AssetLayout(1, "image", (0, 0, 1, 1), [], [], [], "image")])
-    save_xml(encode(chapter), package.chapters_path / "chapter_head.xml")
+    save_xml(encode(chapter), package.chapters / "chapter_head.xml")
     return package
 
 
-def _package_without_assets(root: Path) -> DocumentPackage:
-    package = DocumentPackage.from_path(root)
-    package.chapters_path.mkdir(parents=True)
-    package.assets_path.mkdir()
+def _package_without_assets(root: Path) -> ExtractionPaths:
+    make_extraction(root)
+    package = ExtractionPaths.at(root)
     chapter = Chapter(None, -1, [ParagraphLayout("text", 0, [BlockLayout(1, 1, (0, 0, 1, 1), ["content"])])])
-    save_xml(encode(chapter), package.chapters_path / "chapter_head.xml")
+    save_xml(encode(chapter), package.chapters / "chapter_head.xml")
     return package

--- a/tests/test_tool.py
+++ b/tests/test_tool.py
@@ -175,7 +175,7 @@ class TestPDFCraftTool(unittest.TestCase):
             source = root / "source.pdf"
             source.write_bytes(b"%PDF source")
             work_dir = root / "work"
-            (work_dir / "package" / "ocr").mkdir(parents=True)
+            (work_dir / "analysis" / "ocr").mkdir(parents=True)
             args = Namespace(
                 source=source,
                 dpi=None,

--- a/tests/test_translation_events.py
+++ b/tests/test_translation_events.py
@@ -3,24 +3,22 @@ import unittest
 from pathlib import Path
 from xml.etree.ElementTree import tostring
 
-from pdf_craft import ChapterPackageTransformer, TranslationEventKind, TranslationItemKind
+from pdf_craft import ChapterExtractionTransformer, TranslationEventKind, TranslationItemKind
 from pdf_craft.craft import PDFCraft
-from pdf_craft.document import DocumentPackage
 from pdf_craft.extractor.chapter.chapter import BlockLayout, Chapter, ParagraphLayout, encode
+from tests.extraction_helpers import make_extraction
 
 
 class TestTranslationEvents(unittest.TestCase):
-    def test_direct_package_transform_does_not_claim_translation_events(self):
+    def test_direct_extraction_transform_does_not_claim_translation_events(self):
         with tempfile.TemporaryDirectory() as directory:
             root = Path(directory)
-            source = DocumentPackage.from_path(root / "source")
-            source.chapters_path.mkdir(parents=True)
-            source.assets_path.mkdir()
-            source.write_metadata(page_pixel_sizes={1: (10, 10)})
+            source_root = root / "source"
+            source = make_extraction(source_root, page_pixel_sizes={1: (10, 10)})
             chapter = Chapter(None, -1, [ParagraphLayout(
                 "text", 0, [BlockLayout(1, 1, (1, 1, 5, 5), ["source"])]
             )])
-            (source.chapters_path / "chapter_head.xml").write_text(
+            (source_root / "chapters/chapter_head.xml").write_text(
                 '<?xml version="1.0" encoding="UTF-8"?>\n'
                 + tostring(encode(chapter), encoding="unicode")
             )
@@ -30,18 +28,16 @@ class TestTranslationEvents(unittest.TestCase):
                     return chapter
 
             events = []
-            ChapterPackageTransformer(Identity()).transform(
-                source, root / "target", on_translation_event=events.append
+            ChapterExtractionTransformer(Identity()).transform(
+                source, root / "target.pcex", on_translation_event=events.append
             )
             self.assertEqual(events, [])
 
-    def test_package_translation_reports_format_neutral_chapter_events(self):
+    def test_extraction_translation_reports_format_neutral_chapter_events(self):
         with tempfile.TemporaryDirectory() as directory:
             root = Path(directory)
-            source = DocumentPackage.from_path(root / "source")
-            source.chapters_path.mkdir(parents=True)
-            source.assets_path.mkdir()
-            source.write_metadata(page_pixel_sizes={1: (10, 10)})
+            source_root = root / "source"
+            source = make_extraction(source_root, page_pixel_sizes={1: (10, 10)})
 
             chapters = [
                 Chapter(None, -1, [ParagraphLayout(
@@ -53,7 +49,7 @@ class TestTranslationEvents(unittest.TestCase):
                 Chapter(8, 1, []),
             ]
             for name, chapter in zip(("chapter_head.xml", "chapter_7.xml", "chapter_8.xml"), chapters):
-                (source.chapters_path / name).write_text(
+                (source_root / "chapters" / name).write_text(
                     '<?xml version="1.0" encoding="UTF-8"?>\n'
                     + tostring(encode(chapter), encoding="unicode")
                 )
@@ -63,8 +59,8 @@ class TestTranslationEvents(unittest.TestCase):
                     return chapter
 
             events = []
-            PDFCraft().translate_package(
-                source, root / "target", Identity(), on_translation_event=events.append
+            PDFCraft().translate_extraction(
+                source, root / "target.pcex", Identity(), on_translation_event=events.append
             )
 
             self.assertEqual(events[0].kind, TranslationEventKind.START)


### PR DESCRIPTION
## Summary

- introduce the public PDFCraftExtraction intermediate format and .pcex ZIP interchange artifact
- add manifest metadata, pages geometry, archive validation, and workspace-backed one-shot conversions
- restrict downstream Markdown, EPUB, translation, and PDF patch flows to extraction-owned data
- update public APIs, CLI paths, documentation, and boundary tests

## Verification

- poetry run pyright pdf_craft tests
- poetry run pylint pdf_craft tests
- poetry run python test.py
- git diff --check origin/main...HEAD