### PR TITLE
docs: prepare v2.1.0 release notes

### DIFF
--- a/docs/changelog/v2.1.0.md
+++ b/docs/changelog/v2.1.0.md
@@ -4,14 +4,24 @@
 
 ### Portable PDFCraftExtraction Artifacts
 
-- Replace the internal DocumentPackage handoff with the public `PDFCraftExtraction` API and portable `.pcex` archives.
-- Support extracting, validating, exporting, translating, and rendering `.pcex` artifacts as separate workflow stages.
-- Make downstream rendering and PDF patching depend only on extraction data, including page geometry stored in `pages.xml`.
-- Preserve document metadata in `manifest.json` for later EPUB rendering.
+- Introduce `PDFCraftExtraction`, a public, source-mapped intermediate document that can be exchanged as a portable `.pcex` ZIP archive.
+- Allow extraction, validation, export, translation, Markdown/EPUB rendering, and PDF patching to run as independent workflow stages. Rendering and translation accept either a `PDFCraftExtraction` object or a `.pcex` path.
+- Validate archive structure, format version, required files, XML content, page and bounding-box mappings, and asset references before an extraction is used.
+- Make downstream operations depend only on extraction contents. Page geometry now lives in `pages.xml`, while `manifest.json` carries format, producer, creation, and document metadata.
+- Keep one-shot PDF conversions efficient by passing an unpacked extraction workspace internally, while optionally exporting a `.pcex` through `extraction_path` for reuse or transfer.
+
+### API Migration
+
+- Replace `DocumentPackage` with `PDFCraftExtraction`, `translate_package()` with `translate_extraction()`, and `patch_pdf_with_package()` with `patch_pdf_with_extraction()`.
+- Rename the public package transformer types to `ExtractionTransformer` and `ChapterExtractionTransformer`.
+- Split the former `package_path` option into `analysing_path` for retained OCR diagnostics and `extraction_path` for a portable `.pcex` artifact.
+- Ordinary extraction directories are no longer accepted as public backend inputs; use a `.pcex` path or an opened `PDFCraftExtraction` instead.
 
 ### Documentation
 
-- Add complete English and Chinese field-level references for PDFCraftExtraction v1.
-- Link each format reference from its corresponding README.
+- Add complete English and Chinese field-level references for PDFCraftExtraction format version 1, linked from the corresponding README.
+- Expand the README conversion examples and refresh the English and Chinese website previews.
+
+See [#419](https://github.com/oomol-lab/pdf-craft/pull/419), [#420](https://github.com/oomol-lab/pdf-craft/pull/420), and [#421](https://github.com/oomol-lab/pdf-craft/pull/421) for the main implementation and format-reference work.
 
 **Full Changelog**: https://github.com/oomol-lab/pdf-craft/compare/v2.0.2...v2.1.0


### PR DESCRIPTION
## Summary

- expand the v2.1.0 release notes for PDFCraftExtraction and portable .pcex artifacts
- document the public API migration from DocumentPackage and directory-backed inputs
- include the documentation updates and links to the implementation and reference PRs

## Verification

- poetry run pyright pdf_craft tests
- poetry run pylint pdf_craft tests
- poetry run python test.py (320 tests passed)
- poetry build