### PR TITLE
feat: group PDF translation by paragraph

### DIFF
--- a/docs/en/API_REFERENCE.md
+++ b/docs/en/API_REFERENCE.md
@@ -181,7 +181,7 @@ patcher = PDFPatcher(options=PatchTextOptions(
 pipeline = PDFTranslationPipeline(patcher=patcher)
 ```
 
-`PatchTextOptions` controls text fitting. `overflow="error"` (the default) stops if translated text cannot fit; `overflow="skip"` records skipped replacements in `PDFPatcher.skipped_replacements`. `PDFReplacement` and `PDFSkippedReplacement` describe individual patch outcomes.
+`PatchTextOptions` controls text fitting. `overflow="error"` (the default) stops if translated text cannot fit; `overflow="skip"` records skipped replacements in `PDFPatcher.skipped_replacements`. `PDFReplacement` and `PDFSkippedReplacement` describe individual patch outcomes. PDF translation collects each `ParagraphLayout` once and retains its ordered source boxes as `PDFReplacement.regions` (`PDFReplacementRegion` values). The current box patcher accepts one-region replacements only; multi-region paragraph flow is intentionally left to the paragraph filler.
 
 `PDFTranslationPipeline` can perform lower-level translation or patching when the application owns the complete layout and output lifecycle. Prefer `PDFCraft.translate_pdf()` and `PDFCraft.patch_pdf_with_extraction()` when their fixed layout policy is sufficient.
 

--- a/docs/zh-CN/API_REFERENCE.md
+++ b/docs/zh-CN/API_REFERENCE.md
@@ -24,7 +24,7 @@ from pdf_craft import PDFCraft, PDFOptions
   `TranslationEventKind`、`TranslationItemKind`、`FillFailedEvent`
 - `PDFHandler`、`DefaultPDFHandler`、`PDFDocument`、`DefaultPDFDocument`、
   `PDFDocumentMetadata`
-- `PDFPatcher`、`PDFReplacement`、`PDFSkippedReplacement`、`PatchTextOptions`、
+- `PDFPatcher`、`PDFReplacement`、`PDFReplacementRegion`、`PDFSkippedReplacement`、`PatchTextOptions`、
   `PDFTranslationPipeline`
 - `PDFError`、`OCRError`、`IgnorePDFErrorsChecker`、
   `IgnoreOCRErrorsChecker`
@@ -380,13 +380,17 @@ translate_epub(
 写回组件，供已经能自行生成替换坐标与文字的集成方使用：
 
 - `PDFReplacement` 描述一段待替换文本：`page_index`、像素坐标 `bbox`、`text`、OCR 画布尺寸
-  `page_pixel_size`，以及可选的 `dpi`、`reading_order`。
+  `page_pixel_size`，以及可选的 `dpi`、`reading_order`。PDF 翻译会以一个 `ParagraphLayout` 为单位
+  调用翻译器一次，并将该段落全部、有序的来源框保存在 `regions`（`PDFReplacementRegion`）中，而不是把
+  同一译文复制到每个框。
 - `PDFPatcher(options=PatchTextOptions(...), pdf_handler=...)` 通过 `.patch(source_path,
   target_path, replacements)` 写出 PDF。它接受任意通过字段校验的 `PDFReplacement`，不要求这些
   替换项来自 `PDFCraftExtraction` 或 OCR；`page_pixel_size` 仅用于把像素 `bbox` 换算为 PDF 坐标，
   patcher 不会验证它是否等于源页的实际渲染尺寸。调用方必须自行保证页码、坐标与尺寸对应源 PDF。
   `PatchTextOptions` 控制字体、字号、内边距、对齐和 `overflow` 策略；`overflow="error"`（默认）
   在文字无法放入原框时失败，`"skip"` 则把对应项记录在 `patcher.skipped_replacements` 中。
+  当前 `PDFPatcher` 仍是单框实现；若 `regions` 含多个来源框，它会明确报错，等待段落填充器决定跨框排版，
+  不会悄悄把整段文字重复写入每个框。
 - `PDFTranslationPipeline` 可将一个 `PDFCraftExtraction` 与 `ChapterTransformer` 或
   `Callable[[str], str]` 直接写回 PDF；其 `.patch()` 则把 extraction 已有的文字写回。这是
   facade 的底层组成部分，普通应用无需直接构造。它只从 extraction 中带来源坐标的 `text` 和

--- a/pdf_craft/__init__.py
+++ b/pdf_craft/__init__.py
@@ -11,7 +11,14 @@ from .error import (
 from .functions import predownload_models
 from .craft import ExtractionOptions, PDFCraft, PDFOptions
 from .pipeline.epub import translate_epub
-from .pipeline.pdf import PDFPatcher, PDFReplacement, PDFSkippedReplacement, PDFTranslationPipeline, PatchTextOptions
+from .pipeline.pdf import (
+    PDFPatcher,
+    PDFReplacement,
+    PDFReplacementRegion,
+    PDFSkippedReplacement,
+    PDFTranslationPipeline,
+    PatchTextOptions,
+)
 from .transformer import (
     ChapterExtractionTransformer,
     ChapterXMLTransformer,

--- a/pdf_craft/craft.py
+++ b/pdf_craft/craft.py
@@ -311,7 +311,7 @@ def _analysis_workspace(analysing_path: PathLike | str | None) -> Iterator[Path]
 
 
 class _TextChapterTransformer:
-    """Adapt the block-text callback to the extraction transformer shape."""
+    """Adapt a paragraph-text callback to the extraction transformer shape."""
 
     def __init__(self, callback: Callable[[str], str]) -> None:
         self._callback = callback
@@ -320,11 +320,16 @@ class _TextChapterTransformer:
         for layout in chapter.layouts:
             if not isinstance(layout, ParagraphLayout):
                 continue
-            for block in layout.blocks:
-                text = _to_patch_text(block.content)
-                translated = self._callback(text)
-                if translated != text:
-                    block.content = [translated]
+            text = "".join(_to_patch_text(block.content) for block in layout.blocks)
+            translated = self._callback(text)
+            if translated != text and layout.blocks:
+                # Geometry remains on every source block.  Keeping the single
+                # translated paragraph on the first block avoids duplicating it
+                # into each bbox; the PDF paragraph filler consumes the full
+                # ordered block list in a later stage.
+                layout.blocks[0].content = [translated]
+                for block in layout.blocks[1:]:
+                    block.content = []
         return chapter
 
 

--- a/pdf_craft/pipeline/pdf/__init__.py
+++ b/pdf_craft/pipeline/pdf/__init__.py
@@ -1,8 +1,8 @@
-from .patcher import PDFPatcher, PDFReplacement, PDFSkippedReplacement
+from .patcher import PDFPatcher, PDFReplacement, PDFReplacementRegion, PDFSkippedReplacement
 from .pipeline import PDFTranslationPipeline
 from .text_layout import BoxTextLayout, PatchTextOptions
 
 __all__ = [
-    "BoxTextLayout", "PatchTextOptions", "PDFPatcher", "PDFReplacement",
+    "BoxTextLayout", "PatchTextOptions", "PDFPatcher", "PDFReplacement", "PDFReplacementRegion",
     "PDFSkippedReplacement", "PDFTranslationPipeline",
 ]

--- a/pdf_craft/pipeline/pdf/patcher.py
+++ b/pdf_craft/pipeline/pdf/patcher.py
@@ -158,6 +158,8 @@ class PDFPatcher:
             raise ValueError(
                 "replacement spans multiple source boxes; paragraph filling is not available"
             )
+        if replacement.regions:
+            self._validate_single_region_matches_replacement(replacement, replacement.regions[0])
         regions = replacement.regions or (PDFReplacementRegion(
             replacement.page_index,
             replacement.bbox,
@@ -167,6 +169,21 @@ class PDFPatcher:
         ),)
         for region in regions:
             self._validate_region(region, pages_count)
+
+    @staticmethod
+    def _validate_single_region_matches_replacement(
+        replacement: PDFReplacement, region: PDFReplacementRegion,
+    ) -> None:
+        if (
+            replacement.page_index != region.page_index
+            or replacement.bbox != region.bbox
+            or replacement.page_pixel_size != region.page_pixel_size
+            or replacement.dpi != region.dpi
+            or replacement.reading_order != region.reading_order
+        ):
+            raise ValueError(
+                "replacement geometry must match its only source region"
+            )
 
     @staticmethod
     def _validate_region(region: PDFReplacementRegion, pages_count: int | None = None) -> None:

--- a/pdf_craft/pipeline/pdf/patcher.py
+++ b/pdf_craft/pipeline/pdf/patcher.py
@@ -9,13 +9,34 @@ from .text_layout import BoxTextLayout, PatchTextOptions
 
 
 @dataclass(frozen=True)
+class PDFReplacementRegion:
+    """One OCR source region belonging to a logical replacement."""
+
+    page_index: int
+    bbox: tuple[int, int, int, int]
+    page_pixel_size: tuple[int, int]
+    dpi: int = 300
+    reading_order: int = 0
+
+
+@dataclass(frozen=True)
 class PDFReplacement:
+    """Replacement text and the ordered OCR regions it replaces.
+
+    The legacy top-level geometry identifies the first region, so callers that
+    replace a single box keep their existing API.  ``regions`` carries the
+    complete paragraph geometry for the PDF translation pipeline.  The
+    current box patcher deliberately only renders one-region replacements;
+    multi-region flow belongs to the paragraph filler.
+    """
+
     page_index: int
     bbox: tuple[int, int, int, int]
     text: str
     page_pixel_size: tuple[int, int]
     dpi: int = 300
     reading_order: int = 0
+    regions: tuple[PDFReplacementRegion, ...] = ()
 
 
 @dataclass(frozen=True)
@@ -132,19 +153,39 @@ class PDFPatcher:
         self.skipped_replacements = tuple(skipped)
 
     def validate(self, replacement: PDFReplacement, pages_count: int | None = None) -> None:
-        left, top, right, bottom = replacement.bbox
-        if replacement.page_index < 1:
+        self._validate_text(replacement)
+        if len(replacement.regions) > 1:
+            raise ValueError(
+                "replacement spans multiple source boxes; paragraph filling is not available"
+            )
+        regions = replacement.regions or (PDFReplacementRegion(
+            replacement.page_index,
+            replacement.bbox,
+            replacement.page_pixel_size,
+            replacement.dpi,
+            replacement.reading_order,
+        ),)
+        for region in regions:
+            self._validate_region(region, pages_count)
+
+    @staticmethod
+    def _validate_region(region: PDFReplacementRegion, pages_count: int | None = None) -> None:
+        left, top, right, bottom = region.bbox
+        if region.page_index < 1:
             raise ValueError("page_index must be positive")
-        if pages_count is not None and replacement.page_index > pages_count:
-            raise ValueError(f"page_index {replacement.page_index} exceeds source page count {pages_count}")
+        if pages_count is not None and region.page_index > pages_count:
+            raise ValueError(f"page_index {region.page_index} exceeds source page count {pages_count}")
         if left < 0 or top < 0 or right <= left or bottom <= top:
-            raise ValueError(f"invalid bbox: {replacement.bbox}")
+            raise ValueError(f"invalid bbox: {region.bbox}")
+        if region.page_pixel_size[0] <= 0 or region.page_pixel_size[1] <= 0:
+            raise ValueError("page_pixel_size must be positive")
+        if right > region.page_pixel_size[0] or bottom > region.page_pixel_size[1]:
+            raise ValueError("bbox exceeds page_pixel_size")
+
+    @staticmethod
+    def _validate_text(replacement: PDFReplacement) -> None:
         if not replacement.text.strip():
             raise ValueError("replacement text must not be empty")
-        if replacement.page_pixel_size[0] <= 0 or replacement.page_pixel_size[1] <= 0:
-            raise ValueError("page_pixel_size must be positive")
-        if right > replacement.page_pixel_size[0] or bottom > replacement.page_pixel_size[1]:
-            raise ValueError("bbox exceeds page_pixel_size")
 
     def _fit_replacement(self, replacement: PDFReplacement, width: float, height: float):
         _, _, box_width, box_height = self._box_in_points(replacement, width, height)

--- a/pdf_craft/pipeline/pdf/pipeline.py
+++ b/pdf_craft/pipeline/pdf/pipeline.py
@@ -14,7 +14,7 @@ from pdf_craft.transformer.events import TranslationEvent, TranslationEventKind,
 from pdf_craft.transformer.chapter_xml import ChapterXMLTransformer
 from pdf_craft.transformer.xml_translator.segment import search_text_segments
 from pdf_craft.pdf.handler import PDFHandler
-from pdf_craft.pipeline.pdf.patcher import PDFPatcher, PDFReplacement
+from pdf_craft.pipeline.pdf.patcher import PDFPatcher, PDFReplacement, PDFReplacementRegion
 from pdf_craft.transformer import ChapterTransformer
 
 
@@ -143,21 +143,31 @@ class PDFTranslationPipeline:
         for layout in chapter.layouts:
             if not isinstance(layout, ParagraphLayout) or layout.ref not in {"text", "sub_title"}:
                 continue
+            source = "".join(_to_patch_text(block.content) for block in layout.blocks).strip()
+            if not source:
+                continue
+            translated = transformer(source)
+            if not translated or (translated == source and not structured):
+                continue
+
+            regions: list[PDFReplacementRegion] = []
             for block in layout.blocks:
-                source = _to_patch_text(block.content).strip()
-                if not source:
-                    continue
-                translated = transformer(source)
-                if not translated or (translated == source and not structured):
-                    continue
                 if block.page_index not in pages:
                     raise ValueError(
                         f"PDFCraftExtraction pages.xml is missing page {block.page_index}"
                     )
-                replacements.append(PDFReplacement(
-                    block.page_index, block.det, translated, pages[block.page_index], render_dpi,
+                regions.append(PDFReplacementRegion(
+                    block.page_index, block.det, pages[block.page_index], render_dpi,
                     reading_order=block.order,
                 ))
+            if not regions:  # A ParagraphLayout without blocks has no source geometry.
+                continue
+
+            first = regions[0]
+            replacements.append(PDFReplacement(
+                first.page_index, first.bbox, translated, first.page_pixel_size, first.dpi,
+                reading_order=first.reading_order, regions=tuple(regions),
+            ))
 
 
 def _to_patch_text(items) -> str:

--- a/tests/test_composable_boundaries.py
+++ b/tests/test_composable_boundaries.py
@@ -220,6 +220,35 @@ class TestComposableBoundaries(unittest.TestCase):
             self.assertIn("[1]", replacement.text)
             self.assertIn("T:heading", patcher.replacements[1].text)
 
+    def test_pdf_pipeline_translates_once_per_paragraph_and_keeps_all_source_regions(self):
+        with tempfile.TemporaryDirectory() as directory:
+            root = Path(directory)
+            extraction = make_extraction(root, page_pixel_sizes={1: (100, 100)})
+            chapter = Chapter(None, -1, [ParagraphLayout("text", 0, [
+                BlockLayout(1, 3, (1, 1, 40, 20), ["first "]),
+                BlockLayout(1, 4, (1, 22, 40, 41), ["paragraph"]),
+            ])])
+            translated: list[str] = []
+
+            def translate(text: str) -> str:
+                translated.append(text)
+                return "translated paragraph"
+
+            patcher = _CapturePatcher()
+            with patch("pdf_craft.pipeline.pdf.pipeline.create_chapters_reader", return_value=lambda: iter([chapter])):
+                PDFTranslationPipeline(patcher=cast(PDFPatcher, patcher)).translate(
+                    root / "input.pdf", root / "out.pdf", extraction, translate
+                )
+
+            self.assertEqual(translated, ["first paragraph"])
+            self.assertEqual(len(patcher.replacements), 1)
+            replacement = patcher.replacements[0]
+            self.assertEqual(replacement.text, "translated paragraph")
+            self.assertEqual(
+                [(region.page_index, region.reading_order, region.bbox) for region in replacement.regions],
+                [(1, 3, (1, 1, 40, 20)), (1, 4, (1, 22, 40, 41))],
+            )
+
     def test_pdf_pipeline_forwards_translation_events_to_structured_transformer(self):
         with tempfile.TemporaryDirectory() as directory:
             root = Path(directory)

--- a/tests/test_craft.py
+++ b/tests/test_craft.py
@@ -7,7 +7,7 @@ from unittest.mock import Mock, patch
 
 from epub_generator import BookMeta
 
-from pdf_craft.craft import ExtractionOptions, PDFCraft, PDFOptions
+from pdf_craft.craft import ExtractionOptions, PDFCraft, PDFOptions, _TextChapterTransformer
 from pdf_craft.document import PDFCraftExtraction
 from pdf_craft.extractor import PDFExtractor
 from pdf_craft.extractor.chapter.chapter import BlockLayout, Chapter, ParagraphLayout, encode
@@ -61,6 +61,22 @@ class _Identity:
 
 
 class TestPDFCraft(unittest.TestCase):
+    def test_text_pdf_translation_callback_receives_each_paragraph_once(self):
+        chapter = Chapter(None, -1, [ParagraphLayout("text", 0, [
+            BlockLayout(1, 1, (1, 1, 5, 5), ["first "]),
+            BlockLayout(1, 2, (1, 6, 5, 10), ["paragraph"]),
+        ])])
+        calls: list[str] = []
+
+        _TextChapterTransformer(lambda text: calls.append(text) or "translated").transform(chapter)
+
+        self.assertEqual(calls, ["first paragraph"])
+        paragraph = chapter.layouts[0]
+        assert isinstance(paragraph, ParagraphLayout)
+        self.assertEqual(paragraph.blocks[0].content, ["translated"])
+        self.assertEqual(paragraph.blocks[1].content, [])
+        self.assertEqual(paragraph.blocks[1].det, (1, 6, 5, 10))
+
     def test_translate_extraction_is_the_public_translation_entry(self):
         with tempfile.TemporaryDirectory() as directory:
             root = Path(directory)

--- a/tests/test_pdf_patcher.py
+++ b/tests/test_pdf_patcher.py
@@ -6,7 +6,9 @@ from typing import Any
 import pypdf
 from reportlab.pdfgen import canvas
 
-from pdf_craft.pipeline.pdf import BoxTextLayout, PDFPatcher, PDFReplacement, PatchTextOptions
+from pdf_craft.pipeline.pdf import (
+    BoxTextLayout, PDFPatcher, PDFReplacement, PDFReplacementRegion, PatchTextOptions,
+)
 
 
 class TestPDFPatcher(unittest.TestCase):
@@ -39,6 +41,17 @@ class TestPDFPatcher(unittest.TestCase):
     def test_rejects_bbox_outside_page_pixels(self):
         with self.assertRaises(ValueError):
             PDFPatcher().validate(PDFReplacement(1, (1, 1, 101, 20), "text", (100, 100)))
+
+    def test_rejects_multi_region_paragraph_until_paragraph_filler_is_available(self):
+        first = PDFReplacementRegion(1, (1, 1, 20, 20), (100, 100), reading_order=1)
+        second = PDFReplacementRegion(1, (1, 22, 20, 41), (100, 100), reading_order=2)
+        replacement = PDFReplacement(
+            1, first.bbox, "translated paragraph", first.page_pixel_size,
+            regions=(first, second),
+        )
+
+        with self.assertRaisesRegex(ValueError, "spans multiple source boxes"):
+            PDFPatcher().validate(replacement)
 
     def test_rejects_missing_source_page(self):
         with tempfile.TemporaryDirectory() as temp_dir:

--- a/tests/test_pdf_patcher.py
+++ b/tests/test_pdf_patcher.py
@@ -53,6 +53,19 @@ class TestPDFPatcher(unittest.TestCase):
         with self.assertRaisesRegex(ValueError, "spans multiple source boxes"):
             PDFPatcher().validate(replacement)
 
+    def test_rejects_single_region_that_disagrees_with_patch_geometry(self):
+        region = PDFReplacementRegion(1, (1, 1, 20, 20), (100, 100), reading_order=1)
+        cases = (
+            PDFReplacement(1, (1, 1, 0, 0), "text", (100, 100), reading_order=1, regions=(region,)),
+            PDFReplacement(2, region.bbox, "text", region.page_pixel_size, reading_order=1, regions=(region,)),
+        )
+
+        for replacement in cases:
+            with self.subTest(replacement=replacement), self.assertRaisesRegex(
+                ValueError, "must match its only source region",
+            ):
+                PDFPatcher().validate(replacement)
+
     def test_rejects_missing_source_page(self):
         with tempfile.TemporaryDirectory() as temp_dir:
             root = Path(temp_dir)


### PR DESCRIPTION
## Summary
- translate each ParagraphLayout once instead of translating individual blocks
- retain ordered OCR regions on one replacement without duplicating translated text
- reject multi-region flow until the paragraph filler is available

## Verification
- .venv/bin/python test.py
- .venv/bin/pylint pdf_craft/craft.py pdf_craft/pipeline/pdf tests/test_craft.py tests/test_composable_boundaries.py tests/test_pdf_patcher.py