### PR TITLE
feat: flow PDF paragraph translations with Qt

### DIFF
--- a/.github/workflows/pr-check.yml
+++ b/.github/workflows/pr-check.yml
@@ -28,8 +28,8 @@ jobs:
           poetry config virtualenvs.create true
           poetry config virtualenvs.in-project true
 
-      - name: Install Poppler
-        run: sudo apt-get update && sudo apt-get install --yes poppler-utils
+      - name: Install PDF and Qt runtime
+        run: sudo apt-get update && sudo apt-get install --yes poppler-utils libegl1
 
       - name: Install dependencies
         run: |

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -71,8 +71,8 @@ jobs:
           echo "changelog_path=${CHANGELOG_PATH}" >> "${GITHUB_OUTPUT}"
         id: release-inputs
 
-      - name: Install Poppler
-        run: sudo apt-get update && sudo apt-get install --yes poppler-utils
+      - name: Install PDF and Qt runtime
+        run: sudo apt-get update && sudo apt-get install --yes poppler-utils libegl1
 
       - name: Install dependencies
         run: poetry install --with dev

--- a/docs/en/API_REFERENCE.md
+++ b/docs/en/API_REFERENCE.md
@@ -167,21 +167,24 @@ LLM(
 For patch layout beyond the convenience methods, use these public types:
 
 ```python
-from pdf_craft import PDFPatcher, PDFTranslationPipeline, PatchTextOptions
+from pdf_craft import PDFPatcher, PDFTranslationPipeline, PatchTextOptions, PatchTextStyle
 
 patcher = PDFPatcher(options=PatchTextOptions(
-    font_name="STSong-Light",
+    font_name="Noto Sans CJK SC",  # preferred family; Qt falls back when absent
     max_font_size=14,
     min_font_size=5,
     alignment="left",
     horizontal_padding=1,
     vertical_padding=1,
+    styles={"sub_title": PatchTextStyle(max_font_size=18, min_font_size=8)},
     overflow="error",
 ))
 pipeline = PDFTranslationPipeline(patcher=patcher)
 ```
 
-`PatchTextOptions` controls text fitting. `overflow="error"` (the default) stops if translated text cannot fit; `overflow="skip"` records skipped replacements in `PDFPatcher.skipped_replacements`. `PDFReplacement` and `PDFSkippedReplacement` describe individual patch outcomes. PDF translation collects each `ParagraphLayout` once and retains its ordered source boxes as `PDFReplacement.regions` (`PDFReplacementRegion` values). The current box patcher accepts one-region replacements only; multi-region paragraph flow is intentionally left to the paragraph filler.
+`PatchTextOptions` controls the default Qt text style and optional `PatchTextStyle` overrides by semantic layout key (`"text"`, `"sub_title"`, or `"sub_title:2"`). A paragraph receives one fitted font size, then flows through its ordered `PDFReplacement.regions` without splitting a line across boxes. Qt handles shaping, wrapping, fallback fonts and glyph positions; missing configured fonts do not stop a patch. `overflow="error"` (the default) stops if the complete paragraph cannot fit; `overflow="skip"` records skipped replacements in `PDFPatcher.skipped_replacements`.
+
+The patcher preserves the source PDF page and merges two independent overlays: a temporary white rectangle erasure layer and a Qt-generated PDF text layer. It does not rasterize the page or the translated text. The current erasure is visual only: source text hidden by its rectangle may remain extractable beneath it. Qt/PySide6 and the required fonts must be available on the machine producing the PDF.
 
 `PDFTranslationPipeline` can perform lower-level translation or patching when the application owns the complete layout and output lifecycle. Prefer `PDFCraft.translate_pdf()` and `PDFCraft.patch_pdf_with_extraction()` when their fixed layout policy is sufficient.
 

--- a/docs/en/INSTALLATION.md
+++ b/docs/en/INSTALLATION.md
@@ -23,7 +23,8 @@ The extra supplies the Python runtime for local models. It does not choose a PyT
 ## Requirements
 
 - Python `>=3.11,<3.14`
-- Poppler for PDF conversion and the standard PDF translation/patch workflow
+- Poppler for PDF conversion and OCR extraction; patching an existing `.pcex`
+  back onto its source PDF does not render pages
 - Network and valid credentials for vendor OCR
 - A CUDA-capable NVIDIA GPU, matching PyTorch, model storage, and adequate VRAM for local OCR
 

--- a/docs/en/PDF_TRANSLATION.md
+++ b/docs/en/PDF_TRANSLATION.md
@@ -154,11 +154,11 @@ craft.patch_pdf_with_extraction(
 
 ### What PDF patching can and cannot preserve
 
-PDF patching is a page-overlay workflow, not a general-purpose PDF layout engine. Each source page is rendered as an image and translated text is placed over its OCR bounding boxes. The output therefore does not retain the source PDF's selectable vector text, links, annotations, or other page objects. It replaces text and subtitle layouts only; tables and images are not translated in place.
+PDF patching is a page-overlay workflow, not a general-purpose PDF layout engine. It preserves each source page and merges a rectangular visual-erasure layer followed by a Qt-generated PDF text layer. The translated text remains scalable and extractable; source vector text, links, annotations and other page objects are not flattened. The current erasure is only a white rectangle, so hidden source text may still be extractable underneath it. It replaces text and subtitle layouts only; tables and images are not translated in place.
 
 The source PDF and extraction must match. `pages.xml` must contain geometry for every chapter page and its page numbers must be valid for the source file. There is no fallback to OCR caches or re-rendering to recover missing geometry. `APPEND_BLOCK` is rejected for PDF output because new block-level content cannot safely be added to a fixed page. Text that cannot fit its original bounding box fails before a partial output PDF is left behind.
 
-For custom fonts, fit rules, alignment, padding, or overflow handling, use the lower-level public `PDFPatcher`, `PatchTextOptions`, and `PDFTranslationPipeline` APIs described in the [API reference](API_REFERENCE.md).
+For custom fonts, semantic title/body styles, fit rules, alignment, padding, or overflow handling, use the lower-level public `PDFPatcher`, `PatchTextOptions`, `PatchTextStyle`, and `PDFTranslationPipeline` APIs described in the [API reference](API_REFERENCE.md). PDF patching requires the local Qt/PySide6 runtime and suitable fonts.
 
 ## Extraction controls
 

--- a/docs/en/TROUBLESHOOTING.md
+++ b/docs/en/TROUBLESHOOTING.md
@@ -95,8 +95,9 @@ If an output is absent, make sure its parent directory exists and is writable, t
 PDF patching requires the original PDF plus a `.pcex` extracted from that same
 document. `pages.xml` must include the relevant page geometry; missing data is not
 recovered from OCR caches or by re-rendering. Translated text must fit the original
-OCR bounding boxes. Patch output is rendered from page images, so it does not
-preserve source vector text, annotations, or links. `APPEND_BLOCK` is unsupported.
+OCR bounding boxes. Patching preserves the source page and adds a white visual
+erasure overlay plus a Qt PDF text layer; it does not rasterize source vector text,
+annotations, or links. `APPEND_BLOCK` is unsupported.
 
 ## What to include in a bug report
 

--- a/docs/zh-CN/API_REFERENCE.md
+++ b/docs/zh-CN/API_REFERENCE.md
@@ -387,10 +387,12 @@ translate_epub(
   target_path, replacements)` 写出 PDF。它接受任意通过字段校验的 `PDFReplacement`，不要求这些
   替换项来自 `PDFCraftExtraction` 或 OCR；`page_pixel_size` 仅用于把像素 `bbox` 换算为 PDF 坐标，
   patcher 不会验证它是否等于源页的实际渲染尺寸。调用方必须自行保证页码、坐标与尺寸对应源 PDF。
-  `PatchTextOptions` 控制字体、字号、内边距、对齐和 `overflow` 策略；`overflow="error"`（默认）
-  在文字无法放入原框时失败，`"skip"` 则把对应项记录在 `patcher.skipped_replacements` 中。
-  当前 `PDFPatcher` 仍是单框实现；若 `regions` 含多个来源框，它会明确报错，等待段落填充器决定跨框排版，
-  不会悄悄把整段文字重复写入每个框。
+  `PatchTextOptions` 控制默认字体、字号、内边距、对齐和 `overflow` 策略；可用
+  `PatchTextStyle` 以 `"text"`、`"sub_title"` 或 `"sub_title:2"` 为键覆盖不同文字等级。
+  同一个段落统一搜索字号，随后按顺序流入所有 `regions`；放不下的整行会进入下一个框，绝不局部跨框。
+  `overflow="error"`（默认）在整段无法容纳时失败，`"skip"` 则把对应项记录在
+  `patcher.skipped_replacements` 中。Qt 负责断行、字形位置与字体 fallback；用户填写的缺失字体
+  不会阻断运行。
 - `PDFTranslationPipeline` 可将一个 `PDFCraftExtraction` 与 `ChapterTransformer` 或
   `Callable[[str], str]` 直接写回 PDF；其 `.patch()` 则把 extraction 已有的文字写回。这是
   facade 的底层组成部分，普通应用无需直接构造。它只从 extraction 中带来源坐标的 `text` 和

--- a/docs/zh-CN/INSTALLATION.md
+++ b/docs/zh-CN/INSTALLATION.md
@@ -31,10 +31,8 @@ CUDA 环境安装匹配的 PyTorch。没有可用 CUDA 设备时，使用标准�
 ## 系统要求
 
 - Python `>=3.11,<3.14`。
-- Poppler：PDF 页面渲染、OCR 提取以及公开的 PDF patch/translation 流程默认需要它，
-  因为这些流程会渲染页面来生成或合成内容。
-- 只有纯粹使用 pypdf 读取并写回 PDF 的自定义流程才不需要 Poppler；这不是
-  `PDFCraft.patch_pdf_with_extraction` 和 `PDFCraft.translate_pdf` 的默认路径。
+- Poppler：PDF 页面渲染和 OCR 提取需要它。已有 `.pcex` 写回原 PDF 的 patch 流程
+  不渲染页面，因此不依赖 Poppler。
 - vendor OCR：网络连接和有效的供应商配置；只要运行 OCR 提取，还需要 Poppler；本机不需要 CUDA。
 - local OCR：支持 CUDA 的 NVIDIA GPU、匹配的 PyTorch、模型缓存、足够的显存和 Poppler。
 

--- a/docs/zh-CN/PDF_TRANSLATION.md
+++ b/docs/zh-CN/PDF_TRANSLATION.md
@@ -11,7 +11,7 @@ pdf-craft 的 PDF 能力可以按使用目标分成三类：
 | --- | --- | --- |
 | 直接转换 | `convert_pdf_to_markdown` / `convert_pdf_to_epub` | Markdown 或 EPUB |
 | 转换时翻译 | 在上述入口传入一个 `translator` | 翻译后的 Markdown 或 EPUB |
-| 翻译并写回 PDF | `translate_pdf` | 以源页渲染图为背景、覆盖译文的新 PDF |
+| 翻译并写回 PDF | `translate_pdf` | 保留源页、覆盖擦除层与可提取译文文本层的新 PDF |
 
 如果只是想完成一次转换，优先使用两个 `convert_pdf_to_*` 方法。它们会在内部完成提取、
 可选内容变换和渲染。只有需要复用提取结果、分别控制每个阶段，或需要写回 PDF 时，才使用
@@ -200,9 +200,8 @@ craft.patch_pdf_with_extraction(
 ```
 
 传入路径时必须是通过校验的 `.pcex`；也可以直接传入 `PDFCraftExtraction` 对象。普通目录
-不是公开输入。这个入口不会调用 OCR 或 LLM。PDF 写回使用 `pypdf` 和
-`reportlab`，它们是 pdf-craft 当前的直接运行时依赖；在依赖被移除或非标准安装的环境中，
-底层导入失败会抛出 `RuntimeError`。
+不是公开输入。这个入口不会调用 OCR 或 LLM。PDF 写回使用 `pypdf`、`reportlab` 和
+PySide6/Qt；在依赖被移除或非标准安装的环境中，底层导入失败会抛出 `RuntimeError`。
 
 ### 调整写回排版
 
@@ -213,15 +212,16 @@ craft.patch_pdf_with_extraction(
 ```python
 from pathlib import Path
 
-from pdf_craft import PDFPatcher, PDFTranslationPipeline, PatchTextOptions
+from pdf_craft import PDFPatcher, PDFTranslationPipeline, PatchTextOptions, PatchTextStyle
 
 patcher = PDFPatcher(options=PatchTextOptions(
-    font_name="STSong-Light",
+    font_name="Noto Sans CJK SC",  # 优先字体；缺失时由 Qt fallback
     max_font_size=14,
     min_font_size=5,
     alignment="left",
     horizontal_padding=1,
     vertical_padding=1,
+    styles={"sub_title": PatchTextStyle(max_font_size=18, min_font_size=8)},
     overflow="error",
 ))
 pipeline = PDFTranslationPipeline(patcher=patcher)
@@ -232,49 +232,15 @@ pipeline.translate(Path("input.pdf"), Path("translated.pdf"), extraction, transl
 并将原因记录在 `patcher.skipped_replacements`。低层 API 适用于愿意自行处理排版策略、
 跳过结果和输出文件生命周期的高级调用方。
 
-### 自定义 PDFHandler 与写回 DPI
+### 写回的页面与文本层
 
-`PDFHandler` 是 PDF 文件访问层的公开协议，它本身只需要提供
-`open(Path) -> PDFDocument`。其返回的 `PDFDocument` 则需要能读取页数、页面尺寸和元数据，
-通过 `render_page(page_index, dpi)` 将页面渲染为图像，并实现 `close()`。pdf-craft 会在提取与
-写回的 `finally` 中调用文档的 `close()`，因此自定义 handler 返回的文档必须在该方法中释放它
-持有的文件、渲染器等资源。默认实现是 `DefaultPDFHandler`。只有需要替换 PDF 渲染实现、指定
-Poppler 位置，或让应用统一管理 PDF 文件访问时，才需要注入自定义 handler；通常无需自行实现它。
+写回不会将整页通过 `PDFHandler.render_page()` 栅格化。它保留原始 PDF 页，再依次合并独立的
+矩形擦除 overlay 和由 Qt `QTextLayout` / PDF paint device 生成的译文文本 overlay。因此扫描页
+仍会自然保留扫描背景，原生 PDF 页也不会因写回而压扁；译文则是可缩放、可提取的 PDF 文字。
 
-在门面 API 中，将 handler 放进 `PDFOptions.pdf_handler`。它会用于 PDF 提取；在
-`translate_pdf` / `patch_pdf_with_extraction` 中也会传入 PDF 写回链路：
-
-```python
-from pdf_craft import DefaultPDFHandler, PDFCraft, PDFOptions
-
-craft = PDFCraft(pdf=PDFOptions(
-    ocr=ocr_config,
-    pdf_handler=DefaultPDFHandler(poppler_path="/opt/poppler/bin"),
-))
-```
-
-PDF 写回的低层入口还提供两个独立的注入点，签名和默认值如下：
-
-| 入口 | 参数 | 默认值 | 用途 |
-| --- | --- | --- | --- |
-| `PDFPatcher` | `pdf_handler`、`dpi` | `None`、`300` | 以 handler 将每个源页渲染为输出 PDF 的图像背景；没有任何替换项的页面使用其 `dpi`。 |
-| `PDFTranslationPipeline` | `pdf_handler`、`patcher`、`dpi` | `None`、`None`、`300` | 构造默认 patcher；替换项的坐标 DPI 始终来自 extraction 的 `pages.xml`，缺失时直接失败。 |
-
-`dpi` 越高，源页背景通常越清晰，但生成的 PDF 也会更大、写回更慢。若传入自定义
-`PDFPatcher`，应在它自身同时设置 `pdf_handler` 与 `dpi`；此时 pipeline 不会用自己的
-handler 或 dpi 重建该 patcher。保持二者使用同一 handler 和 dpi，可统一源页背景渲染策略：
-
-```python
-from pdf_craft import DefaultPDFHandler, PDFPatcher, PDFTranslationPipeline
-
-handler = DefaultPDFHandler(poppler_path="/opt/poppler/bin")
-patcher = PDFPatcher(pdf_handler=handler, dpi=200)
-pipeline = PDFTranslationPipeline(pdf_handler=handler, patcher=patcher, dpi=200)
-```
-
-门面 `PDFCraft` 不公开单独的 PDF 写回 dpi 参数；其标准写回链路使用默认 `300`。不要把
-`ExtractionOptions.dpi` 当作写回背景的设置：前者控制提取/OCR 时的页面渲染，并写入提取结果
-的页面像素元数据；需要控制写回背景清晰度时，使用上述低层 API。
+当前擦除只负责视觉上的白色矩形遮蔽，底层的原文字内容流可能仍可被提取。精细擦字或内容感知修复
+不属于此写回器。写回需要本机具备 PySide6/Qt 运行时和可用字体；字体配置是优先选择，Qt 找不到
+指定字体或字形时会使用系统 fallback。
 
 ## 原子 API
 

--- a/pdf_craft/__init__.py
+++ b/pdf_craft/__init__.py
@@ -18,6 +18,8 @@ from .pipeline.pdf import (
     PDFSkippedReplacement,
     PDFTranslationPipeline,
     PatchTextOptions,
+    PatchTextStyle,
+    QTextParagraphFiller,
 )
 from .transformer import (
     ChapterExtractionTransformer,

--- a/pdf_craft/pipeline/pdf/__init__.py
+++ b/pdf_craft/pipeline/pdf/__init__.py
@@ -1,8 +1,14 @@
-from .patcher import PDFPatcher, PDFReplacement, PDFReplacementRegion, PDFSkippedReplacement
+from .eraser import EraseRectangle, RectangularEraser
+from .models import PDFReplacement, PDFReplacementRegion, PDFSkippedReplacement
+from .patcher import PDFPatcher
 from .pipeline import PDFTranslationPipeline
-from .text_layout import BoxTextLayout, PatchTextOptions
+from .text_layout import (
+    FittedParagraph, PatchTextOptions, PatchTextStyle, QTextParagraphFiller,
+    RegionTextPlacement,
+)
 
 __all__ = [
-    "BoxTextLayout", "PatchTextOptions", "PDFPatcher", "PDFReplacement", "PDFReplacementRegion",
-    "PDFSkippedReplacement", "PDFTranslationPipeline",
+    "EraseRectangle", "FittedParagraph", "PatchTextOptions", "PatchTextStyle", "PDFPatcher",
+    "PDFReplacement", "PDFReplacementRegion", "PDFSkippedReplacement", "PDFTranslationPipeline",
+    "QTextParagraphFiller", "RectangularEraser", "RegionTextPlacement",
 ]

--- a/pdf_craft/pipeline/pdf/eraser.py
+++ b/pdf_craft/pipeline/pdf/eraser.py
@@ -1,0 +1,53 @@
+"""Visual source-text erasure for PDF replacement.
+
+This deliberately remains a simple rectangular layer.  Image segmentation and
+content-aware inpainting belong to a future eraser implementation, not the
+paragraph text filler.
+"""
+
+from collections.abc import Iterable
+from dataclasses import dataclass
+
+from .geometry import PageRectangle, region_in_page_points
+from .models import PDFReplacementRegion
+
+
+@dataclass(frozen=True)
+class EraseRectangle:
+    """One visual mask in PDF-point coordinates with a top-left origin."""
+
+    page_index: int
+    rectangle: PageRectangle
+
+
+class RectangularEraser:
+    """Plan and paint the legacy white rectangle masks independently of text."""
+
+    def plan(
+        self,
+        regions: Iterable[PDFReplacementRegion],
+        page_sizes: dict[int, tuple[float, float]],
+    ) -> tuple[EraseRectangle, ...]:
+        rectangles: list[EraseRectangle] = []
+        for region in regions:
+            page_width, page_height = page_sizes[region.page_index]
+            rectangles.append(EraseRectangle(
+                region.page_index,
+                region_in_page_points(region, page_width, page_height),
+            ))
+        return tuple(rectangles)
+
+    @staticmethod
+    def draw(overlay, rectangles: Iterable[EraseRectangle], page_height: float) -> None:
+        """Draw the masks on a ReportLab overlay (whose origin is bottom-left)."""
+        overlay.setFillColorRGB(1, 1, 1)
+        for erase in rectangles:
+            rectangle = erase.rectangle
+            overlay.rect(
+                rectangle.x,
+                page_height - rectangle.bottom,
+                rectangle.width,
+                rectangle.height,
+                stroke=0,
+                fill=1,
+            )

--- a/pdf_craft/pipeline/pdf/geometry.py
+++ b/pdf_craft/pipeline/pdf/geometry.py
@@ -1,0 +1,35 @@
+"""Coordinate conversion shared by PDF patch layers."""
+
+from dataclasses import dataclass
+
+from .models import PDFReplacementRegion
+
+
+@dataclass(frozen=True)
+class PageRectangle:
+    """A rectangle in PDF points using a top-left origin for Qt drawing."""
+
+    x: float
+    top: float
+    width: float
+    height: float
+
+    @property
+    def bottom(self) -> float:
+        return self.top + self.height
+
+
+def region_in_page_points(
+    region: PDFReplacementRegion, page_width: float, page_height: float,
+) -> PageRectangle:
+    """Map OCR pixels to PDF points, retaining the OCR top-left convention."""
+    pixel_width, pixel_height = region.page_pixel_size
+    left, top, right, bottom = region.bbox
+    scale_x = page_width / pixel_width
+    scale_y = page_height / pixel_height
+    return PageRectangle(
+        x=left * scale_x,
+        top=top * scale_y,
+        width=(right - left) * scale_x,
+        height=(bottom - top) * scale_y,
+    )

--- a/pdf_craft/pipeline/pdf/models.py
+++ b/pdf_craft/pipeline/pdf/models.py
@@ -1,0 +1,55 @@
+"""PDF replacement data shared by erasing, filling and composition."""
+
+from dataclasses import dataclass
+
+
+@dataclass(frozen=True)
+class PDFReplacementRegion:
+    """One ordered OCR rectangle belonging to a logical paragraph."""
+
+    page_index: int
+    bbox: tuple[int, int, int, int]
+    page_pixel_size: tuple[int, int]
+    dpi: int = 300
+    reading_order: int = 0
+
+
+@dataclass(frozen=True)
+class PDFReplacement:
+    """Translated paragraph and the ordered source rectangles it replaces.
+
+    The top-level geometry remains the first region for compatibility with
+    callers that construct a one-rectangle replacement directly.  New callers
+    should populate ``regions`` for every source rectangle in the paragraph.
+    """
+
+    page_index: int
+    bbox: tuple[int, int, int, int]
+    text: str
+    page_pixel_size: tuple[int, int]
+    dpi: int = 300
+    reading_order: int = 0
+    regions: tuple[PDFReplacementRegion, ...] = ()
+    layout_ref: str = "text"
+    layout_level: int = 0
+
+    def source_regions(self) -> tuple[PDFReplacementRegion, ...]:
+        """Return explicit paragraph regions or the legacy single region."""
+        if self.regions:
+            return self.regions
+        return (PDFReplacementRegion(
+            self.page_index,
+            self.bbox,
+            self.page_pixel_size,
+            self.dpi,
+            self.reading_order,
+        ),)
+
+
+@dataclass(frozen=True)
+class PDFSkippedReplacement:
+    """An explicitly skipped overflow, retained for callers to inspect."""
+
+    page_index: int
+    bbox: tuple[int, int, int, int]
+    reason: str

--- a/pdf_craft/pipeline/pdf/patcher.py
+++ b/pdf_craft/pipeline/pdf/patcher.py
@@ -1,59 +1,23 @@
-from dataclasses import dataclass
+"""Compose source PDF pages with independent erasure and text overlays."""
+
+from collections.abc import Iterable
 from pathlib import Path
 from tempfile import NamedTemporaryFile, TemporaryDirectory
-from typing import Iterable
 
-from pdf_craft.pdf.handler import DefaultPDFHandler, PDFHandler
+from pdf_craft.pdf.handler import PDFHandler
 
-from .text_layout import BoxTextLayout, PatchTextOptions
-
-
-@dataclass(frozen=True)
-class PDFReplacementRegion:
-    """One OCR source region belonging to a logical replacement."""
-
-    page_index: int
-    bbox: tuple[int, int, int, int]
-    page_pixel_size: tuple[int, int]
-    dpi: int = 300
-    reading_order: int = 0
-
-
-@dataclass(frozen=True)
-class PDFReplacement:
-    """Replacement text and the ordered OCR regions it replaces.
-
-    The legacy top-level geometry identifies the first region, so callers that
-    replace a single box keep their existing API.  ``regions`` carries the
-    complete paragraph geometry for the PDF translation pipeline.  The
-    current box patcher deliberately only renders one-region replacements;
-    multi-region flow belongs to the paragraph filler.
-    """
-
-    page_index: int
-    bbox: tuple[int, int, int, int]
-    text: str
-    page_pixel_size: tuple[int, int]
-    dpi: int = 300
-    reading_order: int = 0
-    regions: tuple[PDFReplacementRegion, ...] = ()
-
-
-@dataclass(frozen=True)
-class PDFSkippedReplacement:
-    """An explicitly skipped overflow, retained for callers to inspect."""
-
-    page_index: int
-    bbox: tuple[int, int, int, int]
-    reason: str
+from .eraser import EraseRectangle, RectangularEraser
+from .models import PDFReplacement, PDFReplacementRegion, PDFSkippedReplacement
+from .text_layout import FittedParagraph, PatchTextOptions, QTextParagraphFiller
 
 
 class PDFPatcher:
-    """Replace OCR-backed text regions in a PDF with translated text.
+    """Replace OCR-backed paragraph regions without flattening source pages.
 
-    The implementation uses pypdf for page preservation and reportlab for a
-    transparent overlay. Both imports are lazy so normal OCR/Markdown users do
-    not need the patching stack at import time.
+    The source page remains the base PDF page. The eraser owns a visual white
+    rectangle overlay for now; the filler owns a separate Qt-generated PDF text
+    overlay. Keeping those layers separate makes a future image-aware eraser a
+    local replacement rather than a typography rewrite.
     """
 
     def __init__(
@@ -66,9 +30,10 @@ class PDFPatcher:
     ) -> None:
         """Create a patcher.
 
-        ``font_name`` and ``font_size`` remain accepted for compatibility. A
-        supplied font size is the maximum fitted size, not a forced size.
+        ``pdf_handler`` remains accepted for source compatibility but is no
+        longer used: patching must not render source pages to a bitmap.
         """
+        del pdf_handler
         if options is not None and (font_name is not None or font_size is not None):
             raise ValueError("pass either options or legacy font_name/font_size arguments")
         if options is None:
@@ -82,68 +47,54 @@ class PDFPatcher:
                 ),
             )
         self.options = options
-        self._layout = BoxTextLayout(options)
-        self._pdf_handler = pdf_handler or DefaultPDFHandler()
+        self._eraser = RectangularEraser()
+        self._filler = QTextParagraphFiller(options)
         self.dpi = dpi
         self.skipped_replacements: tuple[PDFSkippedReplacement, ...] = ()
 
     def patch(self, source_path: Path, target_path: Path, replacements: Iterable[PDFReplacement]) -> None:
+        """Compose source pages, rectangular erasure, then Qt PDF text layers."""
         try:
             import pypdf
-            from reportlab.lib.utils import ImageReader
             from reportlab.pdfgen import canvas
-        except ImportError as error:
-            raise RuntimeError("PDF patching requires the optional 'reportlab' dependency") from error
+        except ImportError as error:  # pragma: no cover - declared dependencies.
+            raise RuntimeError("PDF patching requires pypdf and reportlab") from error
 
         reader = pypdf.PdfReader(str(source_path))
-        skipped: list[PDFSkippedReplacement] = []
-        replacements_by_page: dict[int, list[PDFReplacement]] = {}
-        for replacement in replacements:
+        replacement_list = list(replacements)
+        for replacement in replacement_list:
             self.validate(replacement, pages_count=len(reader.pages))
-            replacements_by_page.setdefault(replacement.page_index, []).append(replacement)
-        for page_replacements in replacements_by_page.values():
-            page_replacements.sort(key=lambda replacement: replacement.reading_order)
 
-        # Preflight all pages before drawing any white rectangles or creating a
-        # target file. A failed fit must not masquerade as a successful patch.
-        layouts: dict[int, list[tuple[PDFReplacement, object]]] = {}
-        for index, page in enumerate(reader.pages, 1):
-            width = float(page.mediabox.width)
-            height = float(page.mediabox.height)
-            for replacement in replacements_by_page.get(index, []):
-                try:
-                    fitted = self._fit_replacement(replacement, width, height)
-                except ValueError as error:
-                    if self.options.overflow == "skip":
-                        skipped.append(PDFSkippedReplacement(index, replacement.bbox, str(error)))
-                        continue
-                    raise ValueError(
-                        f"page {index}, bbox {replacement.bbox}: {error}"
-                    ) from error
-                layouts.setdefault(index, []).append((replacement, fitted))
+        page_sizes = {
+            index: (float(page.mediabox.width), float(page.mediabox.height))
+            for index, page in enumerate(reader.pages, 1)
+        }
+        fitted, skipped = self._preflight(replacement_list, page_sizes)
+        erasures = self._eraser.plan(
+            (region for replacement, _ in fitted for region in replacement.source_regions()),
+            page_sizes,
+        )
 
+        erasures_by_page = self._group_erasures(erasures)
+        text_by_page = self._group_text_placements(fitted)
         writer = pypdf.PdfWriter()
-        document = self._pdf_handler.open(source_path)
-        try:
+        with TemporaryDirectory() as temp_dir:
+            root = Path(temp_dir)
             for index, page in enumerate(reader.pages, 1):
-                width = float(page.mediabox.width)
-                height = float(page.mediabox.height)
-                with TemporaryDirectory() as temp_dir:
-                    overlay_path = Path(temp_dir) / "overlay.pdf"
-                    overlay = canvas.Canvas(str(overlay_path), pagesize=(width, height))
-                    page_layouts = layouts.get(index, [])
-                    render_dpi = page_layouts[0][0].dpi if page_layouts else self.dpi
-                    raw_page = document.render_page(index, render_dpi)
-                    overlay.drawImage(ImageReader(raw_page), 0, 0, width=width, height=height)
-                    for replacement, _ in page_layouts:
-                        self._draw_background(overlay, replacement, width, height)
-                    for replacement, fitted in page_layouts:
-                        self._draw_text(overlay, replacement, fitted, width, height)
-                    overlay.save()
-                    overlay_reader = pypdf.PdfReader(str(overlay_path))
-                    writer.add_page(overlay_reader.pages[0])
-        finally:
-            document.close()
+                page_width, page_height = page_sizes[index]
+                page_erasures = erasures_by_page.get(index, ())
+                if page_erasures:
+                    erasure_path = root / f"erase-{index}.pdf"
+                    self._write_erasure_overlay(canvas, erasure_path, page_width, page_height, page_erasures)
+                    page.merge_page(pypdf.PdfReader(str(erasure_path)).pages[0])
+                page_placements = text_by_page.get(index, ())
+                if page_placements:
+                    text_path = root / f"text-{index}.pdf"
+                    self._filler.draw_pdf_overlay(
+                        text_path, (page_width, page_height), page_placements,
+                    )
+                    page.merge_page(pypdf.PdfReader(str(text_path)).pages[0])
+                writer.add_page(page)
 
         target_path.parent.mkdir(parents=True, exist_ok=True)
         with NamedTemporaryFile(dir=target_path.parent, suffix=".pdf", delete=False) as output:
@@ -153,22 +104,34 @@ class PDFPatcher:
         self.skipped_replacements = tuple(skipped)
 
     def validate(self, replacement: PDFReplacement, pages_count: int | None = None) -> None:
-        self._validate_text(replacement)
-        if len(replacement.regions) > 1:
-            raise ValueError(
-                "replacement spans multiple source boxes; paragraph filling is not available"
-            )
-        if replacement.regions:
-            self._validate_single_region_matches_replacement(replacement, replacement.regions[0])
-        regions = replacement.regions or (PDFReplacementRegion(
-            replacement.page_index,
-            replacement.bbox,
-            replacement.page_pixel_size,
-            replacement.dpi,
-            replacement.reading_order,
-        ),)
+        if not replacement.text.strip():
+            raise ValueError("replacement text must not be empty")
+        regions = replacement.source_regions()
+        if replacement.regions and len(regions) == 1:
+            self._validate_single_region_matches_replacement(replacement, regions[0])
         for region in regions:
             self._validate_region(region, pages_count)
+
+    def _preflight(
+        self,
+        replacements: Iterable[PDFReplacement],
+        page_sizes: dict[int, tuple[float, float]],
+    ) -> tuple[tuple[tuple[PDFReplacement, FittedParagraph], ...], list[PDFSkippedReplacement]]:
+        fitted: list[tuple[PDFReplacement, FittedParagraph]] = []
+        skipped: list[PDFSkippedReplacement] = []
+        for replacement in replacements:
+            try:
+                fitted.append((replacement, self._filler.fit(replacement, page_sizes)))
+            except ValueError as error:
+                if self.options.overflow == "skip":
+                    skipped.append(PDFSkippedReplacement(
+                        replacement.page_index, replacement.bbox, str(error),
+                    ))
+                    continue
+                raise ValueError(
+                    f"page {replacement.page_index}, bbox {replacement.bbox}: {error}"
+                ) from error
+        return tuple(fitted), skipped
 
     @staticmethod
     def _validate_single_region_matches_replacement(
@@ -181,9 +144,7 @@ class PDFPatcher:
             or replacement.dpi != region.dpi
             or replacement.reading_order != region.reading_order
         ):
-            raise ValueError(
-                "replacement geometry must match its only source region"
-            )
+            raise ValueError("replacement geometry must match its only source region")
 
     @staticmethod
     def _validate_region(region: PDFReplacementRegion, pages_count: int | None = None) -> None:
@@ -199,35 +160,25 @@ class PDFPatcher:
         if right > region.page_pixel_size[0] or bottom > region.page_pixel_size[1]:
             raise ValueError("bbox exceeds page_pixel_size")
 
+    def _write_erasure_overlay(
+        self, canvas, output_path: Path, width: float, height: float,
+        erasures: tuple[EraseRectangle, ...],
+    ) -> None:
+        overlay = canvas.Canvas(str(output_path), pagesize=(width, height))
+        self._eraser.draw(overlay, erasures, height)
+        overlay.save()
+
     @staticmethod
-    def _validate_text(replacement: PDFReplacement) -> None:
-        if not replacement.text.strip():
-            raise ValueError("replacement text must not be empty")
-
-    def _fit_replacement(self, replacement: PDFReplacement, width: float, height: float):
-        _, _, box_width, box_height = self._box_in_points(replacement, width, height)
-        return self._layout.fit(replacement.text, box_width, box_height)
+    def _group_erasures(erasures: Iterable[EraseRectangle]) -> dict[int, tuple[EraseRectangle, ...]]:
+        result: dict[int, list[EraseRectangle]] = {}
+        for erase in erasures:
+            result.setdefault(erase.page_index, []).append(erase)
+        return {page_index: tuple(items) for page_index, items in result.items()}
 
     @staticmethod
-    def _box_in_points(replacement: PDFReplacement, width: float, height: float) -> tuple[float, float, float, float]:
-        pixel_width, pixel_height = replacement.page_pixel_size
-        left, top, right, bottom = replacement.bbox
-        scale_x = width / pixel_width
-        scale_y = height / pixel_height
-        x = left * scale_x
-        y = height - bottom * scale_y
-        return x, y, (right - left) * scale_x, (bottom - top) * scale_y
-
-    def _draw_background(self, overlay, replacement: PDFReplacement, width: float, height: float) -> None:
-        x, y, box_width, box_height = self._box_in_points(replacement, width, height)
-        overlay.setFillColorRGB(1, 1, 1)
-        overlay.rect(x, y, box_width, box_height, stroke=0, fill=1)
-
-    def _draw_text(self, overlay, replacement: PDFReplacement, fitted, width: float, height: float) -> None:
-        x, y, _, box_height = self._box_in_points(replacement, width, height)
-        overlay.setFillColorRGB(0, 0, 0)
-        fitted.paragraph.drawOn(
-            overlay,
-            x + self.options.horizontal_padding,
-            y + box_height - self.options.vertical_padding - fitted.height,
-        )
+    def _group_text_placements(fitted: Iterable[tuple[PDFReplacement, FittedParagraph]]):
+        result = {}
+        for _, paragraph in fitted:
+            for placement in paragraph.placements:
+                result.setdefault(placement.page_index, []).append(placement)
+        return {page_index: tuple(items) for page_index, items in result.items()}

--- a/pdf_craft/pipeline/pdf/pipeline.py
+++ b/pdf_craft/pipeline/pdf/pipeline.py
@@ -14,7 +14,8 @@ from pdf_craft.transformer.events import TranslationEvent, TranslationEventKind,
 from pdf_craft.transformer.chapter_xml import ChapterXMLTransformer
 from pdf_craft.transformer.xml_translator.segment import search_text_segments
 from pdf_craft.pdf.handler import PDFHandler
-from pdf_craft.pipeline.pdf.patcher import PDFPatcher, PDFReplacement, PDFReplacementRegion
+from pdf_craft.pipeline.pdf.models import PDFReplacement, PDFReplacementRegion
+from pdf_craft.pipeline.pdf.patcher import PDFPatcher
 from pdf_craft.transformer import ChapterTransformer
 
 
@@ -167,6 +168,7 @@ class PDFTranslationPipeline:
             replacements.append(PDFReplacement(
                 first.page_index, first.bbox, translated, first.page_pixel_size, first.dpi,
                 reading_order=first.reading_order, regions=tuple(regions),
+                layout_ref=layout.ref, layout_level=layout.level,
             ))
 
 

--- a/pdf_craft/pipeline/pdf/text_layout.py
+++ b/pdf_craft/pipeline/pdf/text_layout.py
@@ -77,7 +77,13 @@ class RegionTextPlacement:
     page_index: int
     rectangle: PageRectangle
     remaining_text: str
+    # These are effective glyph bounds after QTextLayout applies alignment.
+    # They make the otherwise opaque Qt placement decision inspectable in
+    # deterministic tests; drawing still lets Qt perform the shaping.
+    line_text_lefts: tuple[float, ...]
+    line_text_widths: tuple[float, ...]
     line_tops: tuple[float, ...]
+    line_heights: tuple[float, ...]
     font_size: float
     style: PatchTextStyle
 
@@ -202,7 +208,11 @@ class QTextParagraphFiller:
         QtCore, QtGui = _qt_modules()
         _ensure_qt_application(QtGui)
         layout = self._create_layout(QtCore, QtGui, text, style, font_size)
+        content_left = rectangle.x + style.horizontal_padding
         line_tops: list[float] = []
+        line_text_lefts: list[float] = []
+        line_text_widths: list[float] = []
+        line_heights: list[float] = []
         consumed_utf16 = 0
         y = available_top
         last_line_height = 0.0
@@ -217,6 +227,11 @@ class QTextParagraphFiller:
                 if y + line_height > available_bottom + 1e-6:
                     break
                 line_tops.append(y)
+                line_start = _x_coordinate(line.cursorToX(0))
+                line_end = _x_coordinate(line.cursorToX(line.textLength()))
+                line_text_lefts.append(content_left + line_start)
+                line_text_widths.append(line_end - line_start)
+                line_heights.append(line_height)
                 consumed_utf16 = line.textStart() + line.textLength()
                 last_line_height = line_height
                 y += line_height * style.line_height
@@ -237,7 +252,10 @@ class QTextParagraphFiller:
             page_index,
             rectangle,
             text,
+            tuple(line_text_lefts),
+            tuple(line_text_widths),
             tuple(top + shift for top in line_tops),
+            tuple(line_heights),
             font_size,
             style,
         ), _python_index_for_utf16(text, consumed_utf16)
@@ -301,6 +319,18 @@ def _python_index_for_utf16(text: str, utf16_index: int) -> int:
         if units >= utf16_index:
             return index + 1
     return len(text)
+
+
+def _x_coordinate(cursor_position) -> float:
+    """Return PySide's x component from ``QTextLine.cursorToX``.
+
+    PySide exposes ``cursorToX`` as ``(x, edge)`` while some Qt bindings use a
+    scalar. Keeping the conversion here makes the layout plan portable across
+    supported PySide versions.
+    """
+    if isinstance(cursor_position, tuple):
+        return float(cursor_position[0])
+    return float(cursor_position)
 
 
 _QT_APPLICATION = None

--- a/pdf_craft/pipeline/pdf/text_layout.py
+++ b/pdf_craft/pipeline/pdf/text_layout.py
@@ -1,139 +1,325 @@
-"""ReportLab paragraph fitting for OCR source rectangles."""
+"""Paragraph flow backed by Qt's native ``QTextLayout`` engine."""
+# pylint: disable=no-member,c-extension-no-member
 
-from dataclasses import dataclass
-from typing import Any, Literal, cast
-from xml.sax.saxutils import escape
+from collections.abc import Mapping
+from dataclasses import dataclass, field
+import os
+from pathlib import Path
+from typing import Literal
+
+from .geometry import PageRectangle, region_in_page_points
+from .models import PDFReplacement
 
 
 Alignment = Literal["left", "center", "right", "justify"]
+VerticalAlignment = Literal["top", "center", "bottom"]
 
 
 @dataclass(frozen=True)
-class PatchTextOptions:
-    """Typography and failure policy for text replacing an OCR bounding box."""
+class PatchTextStyle:
+    """Font and paragraph settings for one semantic ParagraphLayout level."""
 
-    font_name: str = "STSong-Light"
+    font_name: str = "Sans Serif"
+    fallback_fonts: tuple[str, ...] = ()
     max_font_size: float = 12.0
     min_font_size: float = 4.0
+    font_weight: int = 400
     line_height: float = 1.2
     horizontal_padding: float = 1.0
     vertical_padding: float = 1.0
     alignment: Alignment = "left"
+    vertical_alignment: VerticalAlignment = "top"
+
+
+@dataclass(frozen=True)
+class PatchTextOptions:
+    """Default style plus overrides keyed by ParagraphLayout semantic level.
+
+    The scalar fields retain the previous one-style API. ``styles`` may use
+    ``"text"`` / ``"sub_title"`` keys, or the more specific
+    ``"sub_title:2"`` form. Missing fonts deliberately use Qt/system fallback.
+    """
+
+    font_name: str = "Sans Serif"
+    fallback_fonts: tuple[str, ...] = ()
+    max_font_size: float = 12.0
+    min_font_size: float = 4.0
+    font_weight: int = 400
+    line_height: float = 1.2
+    horizontal_padding: float = 1.0
+    vertical_padding: float = 1.0
+    alignment: Alignment = "left"
+    vertical_alignment: VerticalAlignment = "top"
+    styles: Mapping[str, PatchTextStyle] = field(default_factory=dict)
     overflow: Literal["error", "skip"] = "error"
+
+    def style_for(self, layout_ref: str, layout_level: int) -> PatchTextStyle:
+        """Resolve the most specific configured semantic text style."""
+        default = PatchTextStyle(
+            font_name=self.font_name,
+            fallback_fonts=self.fallback_fonts,
+            max_font_size=self.max_font_size,
+            min_font_size=self.min_font_size,
+            font_weight=self.font_weight,
+            line_height=self.line_height,
+            horizontal_padding=self.horizontal_padding,
+            vertical_padding=self.vertical_padding,
+            alignment=self.alignment,
+            vertical_alignment=self.vertical_alignment,
+        )
+        return self.styles.get(f"{layout_ref}:{layout_level}", self.styles.get(layout_ref, default))
+
+
+@dataclass(frozen=True)
+class RegionTextPlacement:
+    """One consecutive run of a paragraph assigned to a source rectangle."""
+
+    page_index: int
+    rectangle: PageRectangle
+    remaining_text: str
+    line_tops: tuple[float, ...]
+    font_size: float
+    style: PatchTextStyle
 
 
 @dataclass(frozen=True)
 class FittedParagraph:
-    """A paragraph proven to fit within a particular rectangle."""
+    """A complete paragraph layout proven to fit its ordered source regions."""
 
-    paragraph: Any
+    text: str
     font_size: float
-    width: float
-    height: float
+    placements: tuple[RegionTextPlacement, ...]
 
 
-class BoxTextLayout:
-    """Fit continuous text into a fixed ReportLab rectangle without truncation."""
+class QTextParagraphFiller:
+    """Lay one paragraph through ordered rectangles without splitting a line.
+
+    Qt owns shaping, wrapping and glyph positioning. This class only decides
+    each next full line's available rectangle and searches one uniform font
+    size for the entire paragraph.
+    """
 
     def __init__(self, options: PatchTextOptions | None = None) -> None:
         self.options = options or PatchTextOptions()
-        self._validate_options()
 
-    def fit(self, text: str, width: float, height: float) -> FittedParagraph:
-        """Return the largest quarter-point Paragraph that completely fits."""
-        normalized = " ".join(text.split())
-        if not normalized:
+    def fit(
+        self,
+        replacement: PDFReplacement,
+        page_sizes: dict[int, tuple[float, float]],
+    ) -> FittedParagraph:
+        """Return the largest quarter-point paragraph fitting every region."""
+        text = " ".join(replacement.text.split())
+        if not text:
             raise ValueError("replacement text must not be empty")
-        available_width = width - (2 * self.options.horizontal_padding)
-        available_height = height - (2 * self.options.vertical_padding)
-        if available_width <= 0 or available_height <= 0:
-            raise ValueError("bbox is too small after text padding")
+        style = self.options.style_for(replacement.layout_ref, replacement.layout_level)
+        self._validate_style(style)
 
-        self._ensure_font(normalized)
-        minimum = self._paragraph(normalized, self.options.min_font_size)
-        minimum_width, minimum_height = self._natural_size(minimum, available_width)
-        if minimum_width > available_width or minimum_height > available_height:
-            raise ValueError(
-                "replacement text cannot fit bbox at minimum font size "
-                f"{self.options.min_font_size}: required {minimum_width:.2f}x{minimum_height:.2f}, "
-                f"available {available_width:.2f}x{available_height:.2f}"
-            )
-
-        low = int(round(self.options.min_font_size * 4))
-        high = int(round(self.options.max_font_size * 4))
+        low = int(round(style.min_font_size * 4))
+        high = int(round(style.max_font_size * 4))
         best: FittedParagraph | None = None
         while low <= high:
             middle = (low + high) // 2
-            font_size = middle / 4
-            paragraph = self._paragraph(normalized, font_size)
-            natural_width, natural_height = self._natural_size(paragraph, available_width)
-            if natural_width <= available_width and natural_height <= available_height:
-                best = FittedParagraph(paragraph, font_size, natural_width, natural_height)
-                low = middle + 1
-            else:
+            fitted = self._plan(text, replacement, page_sizes, style, middle / 4)
+            if fitted is None:
                 high = middle - 1
-        if best is None:  # Defensive: min size was already checked above.
-            raise ValueError("replacement text cannot fit bbox")
+            else:
+                best = fitted
+                low = middle + 1
+        if best is None:
+            raise ValueError(
+                "replacement text cannot fit paragraph source regions at minimum font size "
+                f"{style.min_font_size}"
+            )
         return best
 
-    def _paragraph(self, text: str, font_size: float):
-        from reportlab.lib.enums import TA_CENTER, TA_JUSTIFY, TA_LEFT, TA_RIGHT
-        from reportlab.lib.styles import ParagraphStyle
-        from reportlab.platypus import Paragraph
+    def draw_pdf_overlay(
+        self,
+        output_path: Path,
+        page_size: tuple[float, float],
+        placements: tuple[RegionTextPlacement, ...],
+    ) -> None:
+        """Write placements as a PDF text layer, never as a raster image."""
+        if not placements:
+            return
+        QtCore, QtGui = _qt_modules()
+        _ensure_qt_application(QtGui)
+        page_width, page_height = page_size
+        writer = QtGui.QPdfWriter(str(output_path))
+        writer.setResolution(72)
+        writer.setPageSize(QtGui.QPageSize(
+            QtCore.QSizeF(page_width, page_height), QtGui.QPageSize.Unit.Point,
+        ))
+        writer.setPageMargins(QtCore.QMarginsF(0, 0, 0, 0))
+        painter = QtGui.QPainter()
+        if not painter.begin(writer):
+            raise RuntimeError("Qt could not create the PDF text overlay")
+        try:
+            for placement in placements:
+                self._draw_placement(QtCore, QtGui, painter, placement)
+        finally:
+            painter.end()
 
-        alignment = {
-            "left": TA_LEFT,
-            "center": TA_CENTER,
-            "right": TA_RIGHT,
-            "justify": TA_JUSTIFY,
-        }[self.options.alignment]
-        style = ParagraphStyle(
-            "pdf-craft-patch",
-            fontName=self.options.font_name,
-            fontSize=font_size,
-            leading=font_size * self.options.line_height,
-            alignment=cast(Any, alignment),
-            wordWrap="CJK",
+    def _plan(
+        self,
+        text: str,
+        replacement: PDFReplacement,
+        page_sizes: dict[int, tuple[float, float]],
+        style: PatchTextStyle,
+        font_size: float,
+    ) -> FittedParagraph | None:
+        remaining = text
+        placements: list[RegionTextPlacement] = []
+        for region in replacement.source_regions():
+            if not remaining:
+                break
+            page_width, page_height = page_sizes[region.page_index]
+            rectangle = region_in_page_points(region, page_width, page_height)
+            placement, consumed = self._fit_region(
+                region.page_index, rectangle, remaining, style, font_size,
+            )
+            if placement is None:
+                continue
+            placements.append(placement)
+            remaining = remaining[consumed:]
+        if remaining:
+            return None
+        return FittedParagraph(text, font_size, tuple(placements))
+
+    def _fit_region(
+        self,
+        page_index: int,
+        rectangle: PageRectangle,
+        text: str,
+        style: PatchTextStyle,
+        font_size: float,
+    ) -> tuple[RegionTextPlacement | None, int]:
+        available_width = rectangle.width - 2 * style.horizontal_padding
+        available_top = rectangle.top + style.vertical_padding
+        available_bottom = rectangle.bottom - style.vertical_padding
+        if available_width <= 0 or available_bottom <= available_top:
+            return None, 0
+
+        QtCore, QtGui = _qt_modules()
+        _ensure_qt_application(QtGui)
+        layout = self._create_layout(QtCore, QtGui, text, style, font_size)
+        line_tops: list[float] = []
+        consumed_utf16 = 0
+        y = available_top
+        last_line_height = 0.0
+        layout.beginLayout()
+        try:
+            while True:
+                line = layout.createLine()
+                if not line.isValid():
+                    break
+                line.setLineWidth(available_width)
+                line_height = line.height()
+                if y + line_height > available_bottom + 1e-6:
+                    break
+                line_tops.append(y)
+                consumed_utf16 = line.textStart() + line.textLength()
+                last_line_height = line_height
+                y += line_height * style.line_height
+        finally:
+            layout.endLayout()
+        if not line_tops or consumed_utf16 <= 0:
+            return None, 0
+
+        content_height = y - available_top - last_line_height * (style.line_height - 1)
+        spare = max(available_bottom - available_top - content_height, 0.0)
+        if style.vertical_alignment == "center":
+            shift = spare / 2
+        elif style.vertical_alignment == "bottom":
+            shift = spare
+        else:
+            shift = 0.0
+        return RegionTextPlacement(
+            page_index,
+            rectangle,
+            text,
+            tuple(top + shift for top in line_tops),
+            font_size,
+            style,
+        ), _python_index_for_utf16(text, consumed_utf16)
+
+    def _draw_placement(self, QtCore, QtGui, painter, placement: RegionTextPlacement) -> None:
+        layout = self._create_layout(
+            QtCore, QtGui, placement.remaining_text, placement.style, placement.font_size,
         )
-        return Paragraph(escape(text), style)
+        available_width = placement.rectangle.width - 2 * placement.style.horizontal_padding
+        x = placement.rectangle.x + placement.style.horizontal_padding
+        layout.beginLayout()
+        try:
+            for top in placement.line_tops:
+                line = layout.createLine()
+                if not line.isValid():
+                    raise RuntimeError("Qt layout changed while drawing a planned paragraph")
+                line.setLineWidth(available_width)
+                line.setPosition(QtCore.QPointF(x, top))
+        finally:
+            layout.endLayout()
+        layout.draw(painter, QtCore.QPointF(0, 0))
 
     @staticmethod
-    def _natural_size(paragraph, width: float) -> tuple[float, float]:
-        # A very tall frame asks Platypus for the full natural height rather
-        # than allowing a too-short frame to split and hide trailing content.
-        return paragraph.wrap(width, 1_000_000)
+    def _create_layout(QtCore, QtGui, text: str, style: PatchTextStyle, font_size: float):
+        font = QtGui.QFont(style.font_name)
+        if style.fallback_fonts:
+            font.setFamilies([style.font_name, *style.fallback_fonts])
+        font.setPointSizeF(font_size)
+        font.setWeight(QtGui.QFont.Weight(style.font_weight))
+        option = QtGui.QTextOption()
+        option.setWrapMode(QtGui.QTextOption.WrapMode.WrapAtWordBoundaryOrAnywhere)
+        option.setAlignment({
+            "left": QtCore.Qt.AlignmentFlag.AlignLeft,
+            "center": QtCore.Qt.AlignmentFlag.AlignHCenter,
+            "right": QtCore.Qt.AlignmentFlag.AlignRight,
+            "justify": QtCore.Qt.AlignmentFlag.AlignJustify,
+        }[style.alignment])
+        layout = QtGui.QTextLayout(text, font)
+        layout.setTextOption(option)
+        return layout
 
-    def _ensure_font(self, text: str) -> None:
-        from reportlab.pdfbase import pdfmetrics
-        from reportlab.pdfbase.cidfonts import UnicodeCIDFont
-
-        if self.options.font_name == "STSong-Light":
-            try:
-                pdfmetrics.getFont(self.options.font_name)
-            except KeyError:
-                pdfmetrics.registerFont(UnicodeCIDFont(self.options.font_name))
-        try:
-            pdfmetrics.getFont(self.options.font_name)
-        except KeyError as error:
-            raise ValueError(f"PDF patch font is unavailable: {self.options.font_name}") from error
-        if any(ord(character) > 255 for character in text) and self.options.font_name in {
-            "Courier", "Courier-Bold", "Courier-Oblique", "Courier-BoldOblique",
-            "Helvetica", "Helvetica-Bold", "Helvetica-Oblique", "Helvetica-BoldOblique",
-            "Times-Roman", "Times-Bold", "Times-Italic", "Times-BoldItalic",
-        }:
-            raise ValueError(
-                f"font {self.options.font_name} cannot reliably draw non-Latin replacement text"
-            )
-
-    def _validate_options(self) -> None:
-        options = self.options
-        if options.min_font_size <= 0 or options.max_font_size < options.min_font_size:
+    @staticmethod
+    def _validate_style(style: PatchTextStyle) -> None:
+        if style.min_font_size <= 0 or style.max_font_size < style.min_font_size:
             raise ValueError("font sizes must be positive and max_font_size >= min_font_size")
-        if options.line_height <= 0:
+        if style.line_height <= 0:
             raise ValueError("line_height must be positive")
-        if options.horizontal_padding < 0 or options.vertical_padding < 0:
-            raise ValueError("text padding must not be negative")
-        if options.alignment not in {"left", "center", "right", "justify"}:
-            raise ValueError(f"unsupported text alignment: {options.alignment}")
-        if options.overflow not in {"error", "skip"}:
-            raise ValueError(f"unsupported overflow policy: {options.overflow}")
+        if style.horizontal_padding < 0 or style.vertical_padding < 0:
+            raise ValueError("text padding must be non-negative")
+        if style.alignment not in {"left", "center", "right", "justify"}:
+            raise ValueError(f"unsupported text alignment: {style.alignment}")
+        if style.vertical_alignment not in {"top", "center", "bottom"}:
+            raise ValueError(f"unsupported vertical alignment: {style.vertical_alignment}")
+
+
+def _python_index_for_utf16(text: str, utf16_index: int) -> int:
+    """Translate Qt's UTF-16 text position to a Python string index."""
+    units = 0
+    for index, character in enumerate(text):
+        units += 2 if ord(character) > 0xFFFF else 1
+        if units >= utf16_index:
+            return index + 1
+    return len(text)
+
+
+_QT_APPLICATION = None
+
+
+def _qt_modules():
+    try:
+        from PySide6 import QtCore, QtGui
+    except ImportError as error:  # pragma: no cover - dependency metadata covers this.
+        raise RuntimeError(
+            "PDF paragraph filling requires the PySide6/Qt runtime; install pdf-craft with its dependencies"
+        ) from error
+    return QtCore, QtGui
+
+
+def _ensure_qt_application(QtGui) -> None:
+    """Initialise Qt's font database for headless library use exactly once."""
+    global _QT_APPLICATION  # pylint: disable=global-statement
+    if QtGui.QGuiApplication.instance() is not None:
+        return
+    os.environ.setdefault("QT_QPA_PLATFORM", "offscreen")
+    _QT_APPLICATION = QtGui.QGuiApplication([])

--- a/poetry.lock
+++ b/poetry.lock
@@ -2303,6 +2303,63 @@ dev = ["twine (>=3.4.1)"]
 nodejs = ["nodejs-wheel-binaries"]
 
 [[package]]
+name = "pyside6"
+version = "6.11.2"
+description = "Python bindings for the Qt cross-platform application and UI framework"
+optional = false
+python-versions = "<3.15,>=3.10"
+groups = ["main"]
+files = [
+    {file = "pyside6-6.11.2-cp310-abi3-macosx_13_0_universal2.whl", hash = "sha256:13a3c79816879d9743672a669f1988f74459a78f89a97a2624fae4fe059ffa3a"},
+    {file = "pyside6-6.11.2-cp310-abi3-manylinux_2_34_x86_64.whl", hash = "sha256:dc6d03990489a5085842770718392ef5de36352d8f608d9a9fe03e60af4d7b66"},
+    {file = "pyside6-6.11.2-cp310-abi3-manylinux_2_39_aarch64.whl", hash = "sha256:57fe867a6c93821a085d74e8a26f863fc2363516848181c466032595b33b1729"},
+    {file = "pyside6-6.11.2-cp310-abi3-win_amd64.whl", hash = "sha256:3201d67e3c10be2eaedd3910ff0f02351eca7e88c95a291cde5e7f2f55ef207f"},
+    {file = "pyside6-6.11.2-cp310-abi3-win_arm64.whl", hash = "sha256:0444ac71d0791a19bded35f6d9a94515941f23a6eb7098ca45a1b64a338be697"},
+]
+
+[package.dependencies]
+PySide6_Addons = "6.11.2"
+PySide6_Essentials = "6.11.2"
+shiboken6 = "6.11.2"
+
+[[package]]
+name = "pyside6-addons"
+version = "6.11.2"
+description = "Python bindings for the Qt cross-platform application and UI framework (Addons)"
+optional = false
+python-versions = "<3.15,>=3.10"
+groups = ["main"]
+files = [
+    {file = "pyside6_addons-6.11.2-cp310-abi3-macosx_13_0_universal2.whl", hash = "sha256:354c574a839f7d0751960ba03f33bec87c95e0f2796dca3287f54d03abe97dac"},
+    {file = "pyside6_addons-6.11.2-cp310-abi3-manylinux_2_34_x86_64.whl", hash = "sha256:a8b00956925fbdeffc7052cf933506391289f35ac4f3f71a0a167ec195cd47b4"},
+    {file = "pyside6_addons-6.11.2-cp310-abi3-manylinux_2_39_aarch64.whl", hash = "sha256:a2ca3c73e5f060d4aca49451abd9fba68dd0e1c66ff40cea3a1fe0415def579a"},
+    {file = "pyside6_addons-6.11.2-cp310-abi3-win_amd64.whl", hash = "sha256:f449ea4431da20e7b86752cca8d166f93434516fe417f981c27e5f8e1b554407"},
+    {file = "pyside6_addons-6.11.2-cp310-abi3-win_arm64.whl", hash = "sha256:d5606af369484b862b4d5741cfc179e19d2b8819c3e04d210b8188e0c9f85988"},
+]
+
+[package.dependencies]
+PySide6_Essentials = "6.11.2"
+shiboken6 = "6.11.2"
+
+[[package]]
+name = "pyside6-essentials"
+version = "6.11.2"
+description = "Python bindings for the Qt cross-platform application and UI framework (Essentials)"
+optional = false
+python-versions = "<3.15,>=3.10"
+groups = ["main"]
+files = [
+    {file = "pyside6_essentials-6.11.2-cp310-abi3-macosx_13_0_universal2.whl", hash = "sha256:77795c145202e65a78d88f7cd409d186e3ba23d159bdb3ba2dcd159ae5e5f0d9"},
+    {file = "pyside6_essentials-6.11.2-cp310-abi3-manylinux_2_34_x86_64.whl", hash = "sha256:aaf9f25f0f324874085fa5b26a610318db8a8e243cf85bb3e5400595191c7778"},
+    {file = "pyside6_essentials-6.11.2-cp310-abi3-manylinux_2_39_aarch64.whl", hash = "sha256:d3ec6e1885c46e57f16364f38ea8040ffc5dc0b18341058f608fede3ba930567"},
+    {file = "pyside6_essentials-6.11.2-cp310-abi3-win_amd64.whl", hash = "sha256:c8a29def77032773a30879f7f24415b5395ad08592d147c170824ef4c735dfc1"},
+    {file = "pyside6_essentials-6.11.2-cp310-abi3-win_arm64.whl", hash = "sha256:fadd75c5c20800d64dd0a586ea8cb337c5e630aa2246df0e5105738afa46e02c"},
+]
+
+[package.dependencies]
+shiboken6 = "6.11.2"
+
+[[package]]
 name = "pytest"
 version = "8.4.2"
 description = "pytest: simple powerful testing with Python"
@@ -2741,6 +2798,21 @@ test = ["build[virtualenv] (>=1.0.3)", "filelock (>=3.4.0)", "ini2toml[lite] (>=
 type = ["importlib_metadata (>=7.0.2) ; python_version < \"3.10\"", "jaraco.develop (>=7.21) ; sys_platform != \"cygwin\"", "mypy (==1.14.*)", "pytest-mypy"]
 
 [[package]]
+name = "shiboken6"
+version = "6.11.2"
+description = "Python/C++ bindings helper module"
+optional = false
+python-versions = "<3.15,>=3.10"
+groups = ["main"]
+files = [
+    {file = "shiboken6-6.11.2-cp310-abi3-macosx_13_0_universal2.whl", hash = "sha256:53659683b1f7a08e9f87eff9b1065f1ceb7110cd7a4bc09fdf5efe43d286604d"},
+    {file = "shiboken6-6.11.2-cp310-abi3-manylinux_2_34_x86_64.whl", hash = "sha256:7a7a0a72a9ed26c9bf77d42246b1c736486befb8f31aa2fb29957ea4cdd1c1c2"},
+    {file = "shiboken6-6.11.2-cp310-abi3-manylinux_2_39_aarch64.whl", hash = "sha256:4bbbd6fa4d7cff5ec5e12bc4c10e1d845fa30c89457ecb13cc64f7bddb77f6f9"},
+    {file = "shiboken6-6.11.2-cp310-abi3-win_amd64.whl", hash = "sha256:6ab0eba1c904455df621f9a6df3ca2bb896bab8670572d2bc4e37804ae91f19a"},
+    {file = "shiboken6-6.11.2-cp310-abi3-win_arm64.whl", hash = "sha256:97c49432488df958f0308736f3d15b6915d8826fc380af17bb4b9ec5c4a5e81b"},
+]
+
+[[package]]
 name = "six"
 version = "1.17.0"
 description = "Python 2 and 3 compatibility utilities"
@@ -3158,4 +3230,4 @@ local = ["doc-page-extractor"]
 [metadata]
 lock-version = "2.1"
 python-versions = ">=3.11,<3.14"
-content-hash = "a032a51042a5e392e8f3c31170f3a9ab85876e0a09ec9643b58ebbc71bc0dd02"
+content-hash = "6a7f81443daa5388ebfaa94fbbf6bd8b1b66b4cb0272a13598b44043ec6fe043"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -36,6 +36,7 @@ dependencies = [
     "pyahocorasick>=2.2.0,<3.0.0",
     "markdownify>=1.2.2,<2.0.0",
     "reportlab>=4.4.0,<5.0.0",
+    "pyside6>=6.8.0,<7.0.0",
     "jinja2>=3.1.6,<4.0.0",
     "resource-segmentation>=0.0.7,<0.1.0",
     "mathml2latex>=0.2.12,<0.3.0",

--- a/tests/assets/README.md
+++ b/tests/assets/README.md
@@ -10,6 +10,10 @@ repository-local smoke CLI. It is not included in the published package.
 - `expected/`: reserved for small checked-in expected outputs; generated conversion
   output belongs in the ignored `pdf-craft-output/` directory instead.
 
+`pdf/friendly.pdf` is also used by `test_pdf_patch_smoke.py` to exercise real PDF
+replacement and Qt text-layer output without running OCR. Run it with
+`poetry run python test.py test_pdf_patch_smoke`.
+
 When adding a real document, record its provenance and confirm that its license
 allows redistribution with the repository. Prefer small, focused fixtures for unit
 tests; use complete books only when a format or integration regression needs them.

--- a/tests/test_pdf_eraser.py
+++ b/tests/test_pdf_eraser.py
@@ -1,0 +1,18 @@
+import unittest
+
+from pdf_craft.pipeline.pdf import PDFReplacementRegion, RectangularEraser
+
+
+class TestRectangularEraser(unittest.TestCase):
+    def test_plans_visual_masks_without_any_text_input(self):
+        region = PDFReplacementRegion(2, (10, 20, 50, 70), (100, 200))
+
+        planned = RectangularEraser().plan((region,), {2: (300, 400)})
+
+        self.assertEqual(len(planned), 1)
+        erase = planned[0]
+        self.assertEqual(erase.page_index, 2)
+        self.assertEqual(erase.rectangle.x, 30)
+        self.assertEqual(erase.rectangle.top, 40)
+        self.assertEqual(erase.rectangle.width, 120)
+        self.assertEqual(erase.rectangle.height, 100)

--- a/tests/test_pdf_patch_smoke.py
+++ b/tests/test_pdf_patch_smoke.py
@@ -9,45 +9,60 @@ import tempfile
 import unittest
 from pathlib import Path
 from typing import Any
+from xml.etree.ElementTree import tostring
 
 import pypdf
 
 from pdf_craft.pipeline.pdf import (
-    PDFPatcher, PDFReplacement, PDFReplacementRegion, PatchTextOptions,
+    PDFPatcher, PatchTextOptions,
 )
+from pdf_craft.pipeline.pdf.pipeline import PDFTranslationPipeline
+from pdf_craft.extractor.chapter.chapter import BlockLayout, Chapter, ParagraphLayout, encode
+from tests.extraction_helpers import make_extraction
 
 
 _ASSET_ROOT = Path(__file__).parent / "assets" / "pdf"
 
 
 class TestPDFPatchSmoke(unittest.TestCase):
-    def test_fills_real_friendly_fixture_as_extractable_pdf_text(self):
-        """Patch two real body-line boxes without OCR or a model download."""
+    def test_pipeline_fills_real_fixture_as_extractable_pdf_text(self):
+        """Exercise ParagraphLayout extraction, erasure, filler, and output."""
         source = _ASSET_ROOT / "friendly.pdf"
         with tempfile.TemporaryDirectory() as temp_dir:
+            root = Path(temp_dir)
             target = Path(temp_dir) / "friendly-translated.pdf"
-            # These 100-DPI boxes cover the first two body lines on page one.
-            regions = (
-                PDFReplacementRegion(1, (85, 270, 785, 303), (827, 1169), reading_order=1),
-                PDFReplacementRegion(1, (85, 309, 785, 342), (827, 1169), reading_order=2),
+            extraction_root = root / "friendly.pcex"
+            extraction = make_extraction(
+                extraction_root, page_pixel_sizes={1: (827, 1169)}, render_dpi=100,
             )
-            replacement = PDFReplacement(
-                1,
-                regions[0].bbox,
+            # These 100-DPI blocks cover two real adjacent body lines on page one.
+            chapter = Chapter(None, -1, [ParagraphLayout("text", 0, [
+                BlockLayout(1, 1, (85, 270, 785, 303), ["source first line "]),
+                BlockLayout(1, 2, (85, 309, 785, 342), ["source second line"]),
+            ])])
+            (extraction_root / "chapters/chapter_1.xml").write_text(
+                '<?xml version="1.0" encoding="UTF-8"?>\n'
+                + tostring(encode(chapter), encoding="unicode")
+            )
+            translated = (
                 "Smoke replacement text intentionally spans two real source boxes so the first full "
-                "line stops at the first rectangle and the next complete line begins in the second rectangle.",
-                regions[0].page_pixel_size,
-                regions=regions,
+                "line stops at the first rectangle and the next complete line begins in the second rectangle."
             )
+            calls: list[str] = []
 
-            PDFPatcher(options=PatchTextOptions(max_font_size=10, min_font_size=8)).patch(
-                source, target, [replacement]
-            )
+            def translate_paragraph(text: str) -> str:
+                calls.append(text)
+                return translated
+
+            PDFTranslationPipeline(patcher=PDFPatcher(
+                options=PatchTextOptions(max_font_size=10, min_font_size=8)
+            )).translate(source, target, extraction, translate_paragraph)
 
             reader = pypdf.PdfReader(str(target))
             self.assertEqual(len(reader.pages), 7)
             first_page: Any = reader.pages[0]
             self.assertIn("Smoke", first_page.extract_text())
+            self.assertEqual(calls, ["source first line source second line"])
             # No page-wide raster image is introduced by patching: existing
             # source images are retained, and Qt's text overlay adds none.
             source_page: Any = pypdf.PdfReader(str(source)).pages[0]

--- a/tests/test_pdf_patch_smoke.py
+++ b/tests/test_pdf_patch_smoke.py
@@ -1,0 +1,55 @@
+"""A real-PDF smoke for the PDF text-layer patch path.
+
+Run manually with ``poetry run python test.py test_pdf_patch_smoke``.  The
+review workflow additionally renders its generated output for visual review.
+"""
+# pylint: disable=no-member
+
+import tempfile
+import unittest
+from pathlib import Path
+from typing import Any
+
+import pypdf
+
+from pdf_craft.pipeline.pdf import (
+    PDFPatcher, PDFReplacement, PDFReplacementRegion, PatchTextOptions,
+)
+
+
+_ASSET_ROOT = Path(__file__).parent / "assets" / "pdf"
+
+
+class TestPDFPatchSmoke(unittest.TestCase):
+    def test_fills_real_friendly_fixture_as_extractable_pdf_text(self):
+        """Patch two real body-line boxes without OCR or a model download."""
+        source = _ASSET_ROOT / "friendly.pdf"
+        with tempfile.TemporaryDirectory() as temp_dir:
+            target = Path(temp_dir) / "friendly-translated.pdf"
+            # These 100-DPI boxes cover the first two body lines on page one.
+            regions = (
+                PDFReplacementRegion(1, (85, 270, 785, 303), (827, 1169), reading_order=1),
+                PDFReplacementRegion(1, (85, 309, 785, 342), (827, 1169), reading_order=2),
+            )
+            replacement = PDFReplacement(
+                1,
+                regions[0].bbox,
+                "Smoke replacement text intentionally spans two real source boxes so the first full "
+                "line stops at the first rectangle and the next complete line begins in the second rectangle.",
+                regions[0].page_pixel_size,
+                regions=regions,
+            )
+
+            PDFPatcher(options=PatchTextOptions(max_font_size=10, min_font_size=8)).patch(
+                source, target, [replacement]
+            )
+
+            reader = pypdf.PdfReader(str(target))
+            self.assertEqual(len(reader.pages), 7)
+            first_page: Any = reader.pages[0]
+            self.assertIn("Smoke", first_page.extract_text())
+            # No page-wide raster image is introduced by patching: existing
+            # source images are retained, and Qt's text overlay adds none.
+            source_page: Any = pypdf.PdfReader(str(source)).pages[0]
+            source_images = len(list(source_page.images))
+            self.assertEqual(len(list(first_page.images)), source_images)

--- a/tests/test_pdf_patcher.py
+++ b/tests/test_pdf_patcher.py
@@ -10,6 +10,7 @@ from reportlab.pdfgen import canvas
 
 from pdf_craft.pipeline.pdf import (
     PDFPatcher, PDFReplacement, PDFReplacementRegion, PatchTextOptions,
+    QTextParagraphFiller,
 )
 
 
@@ -109,13 +110,30 @@ class TestPDFPatcher(unittest.TestCase):
                 1, (60, 60, 360, 360), "\u8fd9\u662f\u4e00\u6bb5\u6ca1\u6709\u7a7a\u683c\u7684\u4e2d\u6587\u8bd1\u6587\uff0c\u5b83\u5e94\u8be5\u5728\u65b9\u6846\u5185\u81ea\u52a8\u6362\u884c\u3002" * 3, (600, 600)
             )
             patcher = PDFPatcher(options=PatchTextOptions(max_font_size=12, min_font_size=4))
+            fitted = QTextParagraphFiller(patcher.options).fit(replacement, {1: (200, 200)})
 
             patcher.patch(source, target, [replacement])
 
+            source_page: Any = pypdf.PdfReader(str(source)).pages[0]
             reader = pypdf.PdfReader(str(target))
             self.assertEqual(len(reader.pages), 1)
             page: Any = reader.pages[0]
-            self.assertIn("\u6ca1\u6709\u7a7a\u683c", page.extract_text())  # pylint: disable=no-member
+            # An absent CJK font is allowed to fall back (even to a missing-glyph
+            # font), so Unicode extraction is platform dependent. The English
+            # patch tests cover extraction; here prove that CJK layout fits and
+            # produces a genuine PDF font/content layer instead of an image.
+            for placement in fitted.placements:
+                self.assertTrue(all(
+                    placement.rectangle.top <= top
+                    and top + height <= placement.rectangle.bottom
+                    for top, height in zip(placement.line_tops, placement.line_heights)
+                ))
+            source_fonts = set(source_page["/Resources"]["/Font"].get_object())
+            result_fonts = set(page["/Resources"]["/Font"].get_object())
+            self.assertGreater(len(result_fonts - source_fonts), 0)
+            self.assertGreater(
+                len(page.get_contents().get_data()), len(source_page.get_contents().get_data()),
+            )
             self.assertEqual(len(list(page.images)), 0)
 
     def test_preflight_failure_leaves_no_partial_target_file(self):

--- a/tests/test_pdf_patcher.py
+++ b/tests/test_pdf_patcher.py
@@ -1,3 +1,5 @@
+# pylint: disable=no-member
+
 import tempfile
 import unittest
 from pathlib import Path
@@ -7,7 +9,7 @@ import pypdf
 from reportlab.pdfgen import canvas
 
 from pdf_craft.pipeline.pdf import (
-    BoxTextLayout, PDFPatcher, PDFReplacement, PDFReplacementRegion, PatchTextOptions,
+    PDFPatcher, PDFReplacement, PDFReplacementRegion, PatchTextOptions,
 )
 
 
@@ -32,7 +34,10 @@ class TestPDFPatcher(unittest.TestCase):
             self.assertEqual(len(reader.pages), 1)
             page = list(reader.pages)[0]
             self.assertIn("Translated", page.extract_text())
-            self.assertNotIn("Original", page.extract_text())
+            # The original page is preserved; rectangular erasure is visual
+            # only and intentionally does not rewrite the source content stream.
+            self.assertIn("Original", page.extract_text())
+            self.assertEqual(len(list(page.images)), 0)
 
     def test_rejects_invalid_bbox(self):
         with self.assertRaises(ValueError):
@@ -42,16 +47,28 @@ class TestPDFPatcher(unittest.TestCase):
         with self.assertRaises(ValueError):
             PDFPatcher().validate(PDFReplacement(1, (1, 1, 101, 20), "text", (100, 100)))
 
-    def test_rejects_multi_region_paragraph_until_paragraph_filler_is_available(self):
+    def test_replaces_multi_region_paragraph_with_one_qt_text_layer(self):
         first = PDFReplacementRegion(1, (1, 1, 20, 20), (100, 100), reading_order=1)
-        second = PDFReplacementRegion(1, (1, 22, 20, 41), (100, 100), reading_order=2)
+        second = PDFReplacementRegion(1, (1, 22, 99, 98), (100, 100), reading_order=2)
         replacement = PDFReplacement(
             1, first.bbox, "translated paragraph", first.page_pixel_size,
             regions=(first, second),
         )
+        with tempfile.TemporaryDirectory() as temp_dir:
+            root = Path(temp_dir)
+            source = root / "source.pdf"
+            target = root / "target.pdf"
+            doc = canvas.Canvas(str(source), pagesize=(100, 100))
+            doc.drawString(1, 90, "Original source page")
+            doc.save()
 
-        with self.assertRaisesRegex(ValueError, "spans multiple source boxes"):
-            PDFPatcher().validate(replacement)
+            PDFPatcher(options=PatchTextOptions(max_font_size=8, min_font_size=8)).patch(
+                source, target, [replacement]
+            )
+
+            page: Any = pypdf.PdfReader(str(target)).pages[0]
+            self.assertIn("translated", page.extract_text().replace("\n", "").lower())
+            self.assertEqual(len(list(page.images)), 0)
 
     def test_rejects_single_region_that_disagrees_with_patch_geometry(self):
         region = PDFReplacementRegion(1, (1, 1, 20, 20), (100, 100), reading_order=1)
@@ -93,15 +110,13 @@ class TestPDFPatcher(unittest.TestCase):
             )
             patcher = PDFPatcher(options=PatchTextOptions(max_font_size=12, min_font_size=4))
 
-            fitted = BoxTextLayout(patcher.options).fit(replacement.text, 100, 100)
-            self.assertGreater(len(fitted.paragraph.blPara.lines), 1)
-            self.assertLessEqual(fitted.height + 2, 100)
             patcher.patch(source, target, [replacement])
 
             reader = pypdf.PdfReader(str(target))
             self.assertEqual(len(reader.pages), 1)
             page: Any = reader.pages[0]
-            self.assertIn("\u8fd9\u662f\u4e00\u6bb5", page.extract_text())  # pylint: disable=no-member
+            self.assertIn("\u6ca1\u6709\u7a7a\u683c", page.extract_text())  # pylint: disable=no-member
+            self.assertEqual(len(list(page.images)), 0)
 
     def test_preflight_failure_leaves_no_partial_target_file(self):
         with tempfile.TemporaryDirectory() as temp_dir:
@@ -138,4 +153,4 @@ class TestPDFPatcher(unittest.TestCase):
             )
 
             self.assertEqual(len(patcher.skipped_replacements), 1)
-            self.assertIn("cannot fit bbox", patcher.skipped_replacements[0].reason)
+            self.assertIn("cannot fit paragraph source regions", patcher.skipped_replacements[0].reason)

--- a/tests/test_pdf_text_layout.py
+++ b/tests/test_pdf_text_layout.py
@@ -1,45 +1,86 @@
 import unittest
 
-from pdf_craft.pipeline.pdf import BoxTextLayout, PatchTextOptions
+from pdf_craft.pipeline.pdf import (
+    PDFReplacement, PDFReplacementRegion, PatchTextOptions, PatchTextStyle,
+    QTextParagraphFiller,
+)
 
 
-class TestBoxTextLayout(unittest.TestCase):
-    def test_wraps_cjk_without_spaces_into_multiple_lines(self):
-        layout = BoxTextLayout(PatchTextOptions(max_font_size=12, min_font_size=4))
-        fitted = layout.fit("这是没有空格的中文文本，需要在固定宽度的边框中自动换行。" * 3, 80, 100)
+def _replacement(text: str, regions, *, layout_ref: str = "text", layout_level: int = 0):
+    first = regions[0]
+    return PDFReplacement(
+        first.page_index, first.bbox, text, first.page_pixel_size,
+        regions=tuple(regions), layout_ref=layout_ref, layout_level=layout_level,
+    )
 
-        self.assertGreater(len(fitted.paragraph.blPara.lines), 1)
-        self.assertLessEqual(fitted.width, 78)
-        self.assertLessEqual(fitted.height, 98)
 
-    def test_normalizes_paragraph_whitespace_but_preserves_english_words(self):
-        layout = BoxTextLayout(PatchTextOptions(max_font_size=12, min_font_size=4))
-        fitted = layout.fit("First paragraph.\n\nSecond   paragraph has words.", 120, 100)
+class TestQTextParagraphFiller(unittest.TestCase):
+    def test_flows_a_paragraph_through_multiple_rectangles_once(self):
+        regions = [
+            PDFReplacementRegion(1, (0, 0, 58, 20), (100, 100)),
+            PDFReplacementRegion(1, (0, 22, 84, 55), (100, 100)),
+            PDFReplacementRegion(1, (0, 57, 84, 100), (100, 100)),
+        ]
+        text = "one two three four five"
+        filler = QTextParagraphFiller(PatchTextOptions(max_font_size=10, min_font_size=10))
 
-        self.assertIn("First paragraph. Second paragraph has words.", fitted.paragraph.text)
+        fitted = filler.fit(_replacement(text, regions), {1: (100, 100)})
 
-    def test_wraps_mixed_cjk_latin_and_numbers(self):
-        layout = BoxTextLayout(PatchTextOptions(max_font_size=12, min_font_size=4))
-        fitted = layout.fit("PDFCraft 2.0 \u6df7\u6392 text with 12345 \u548c\u5e38\u89c1\u6807\u70b9\uff0c\u5fc5\u987b\u5b8c\u6574\u653e\u5165\u8fb9\u6846\u3002" * 2, 100, 100)
+        self.assertEqual(fitted.font_size, 10)
+        self.assertGreaterEqual(len(fitted.placements), 2)
+        self.assertEqual(fitted.placements[0].page_index, 1)
+        self.assertTrue(fitted.placements[0].remaining_text.startswith("one two"))
+        self.assertNotEqual(fitted.placements[1].remaining_text, fitted.placements[0].remaining_text)
 
-        self.assertGreater(len(fitted.paragraph.blPara.lines), 1)
+    def test_moves_a_whole_line_to_the_next_rectangle(self):
+        regions = [
+            PDFReplacementRegion(1, (0, 0, 90, 18), (100, 100)),
+            PDFReplacementRegion(1, (0, 20, 90, 80), (100, 100)),
+        ]
+        filler = QTextParagraphFiller(PatchTextOptions(max_font_size=10, min_font_size=10))
 
-    def test_selects_largest_available_font_size(self):
-        options = PatchTextOptions(max_font_size=16, min_font_size=4)
-        fitted = BoxTextLayout(options).fit("short text", 300, 100)
+        fitted = filler.fit(_replacement("first line second line third line", regions), {1: (100, 100)})
+
+        self.assertEqual(len(fitted.placements[0].line_tops), 1)
+        self.assertGreaterEqual(len(fitted.placements[1].line_tops), 1)
+        self.assertTrue(fitted.placements[1].remaining_text.startswith("second"))
+
+    def test_selects_largest_uniform_font_size_for_the_paragraph(self):
+        regions = [PDFReplacementRegion(1, (0, 0, 100, 0 + 100), (100, 100))]
+        filler = QTextParagraphFiller(PatchTextOptions(max_font_size=16, min_font_size=4))
+
+        fitted = filler.fit(_replacement("short text", regions), {1: (100, 100)})
 
         self.assertEqual(fitted.font_size, 16)
 
-    def test_fails_when_minimum_font_cannot_fit(self):
-        options = PatchTextOptions(max_font_size=8, min_font_size=8)
-        with self.assertRaisesRegex(ValueError, "cannot fit bbox"):
-            BoxTextLayout(options).fit("too much text " * 100, 20, 10)
+    def test_semantic_style_can_override_default_font_size(self):
+        regions = [PDFReplacementRegion(1, (0, 0, 100, 100), (100, 100))]
+        filler = QTextParagraphFiller(PatchTextOptions(
+            max_font_size=8,
+            min_font_size=8,
+            styles={"sub_title:2": PatchTextStyle(max_font_size=15, min_font_size=15)},
+        ))
 
-    def test_default_cjk_font_is_registered_and_latin_font_rejects_cjk(self):
-        self.assertEqual(BoxTextLayout().fit("\u4e2d\u6587", 100, 100).font_size, 12)
-        with self.assertRaisesRegex(ValueError, "cannot reliably draw"):
-            BoxTextLayout(PatchTextOptions(font_name="Helvetica")).fit("\u4e2d\u6587", 100, 100)
+        fitted = filler.fit(
+            _replacement("A heading", regions, layout_ref="sub_title", layout_level=2),
+            {1: (100, 100)},
+        )
 
-    def test_rejects_unavailable_font(self):
-        with self.assertRaisesRegex(ValueError, "font is unavailable"):
-            BoxTextLayout(PatchTextOptions(font_name="not-a-font")).fit("text", 100, 100)
+        self.assertEqual(fitted.font_size, 15)
+
+    def test_missing_or_partial_font_configuration_uses_qt_fallback(self):
+        regions = [PDFReplacementRegion(1, (0, 0, 100, 100), (100, 100))]
+        filler = QTextParagraphFiller(PatchTextOptions(
+            font_name="font-that-is-not-installed", max_font_size=10, min_font_size=10,
+        ))
+
+        fitted = filler.fit(_replacement("中文 mixed text", regions), {1: (100, 100)})
+
+        self.assertEqual(fitted.font_size, 10)
+
+    def test_fails_only_when_even_minimum_size_cannot_fit_any_full_line(self):
+        regions = [PDFReplacementRegion(1, (0, 0, 20, 5), (100, 100))]
+        filler = QTextParagraphFiller(PatchTextOptions(max_font_size=8, min_font_size=8))
+
+        with self.assertRaisesRegex(ValueError, "cannot fit paragraph source regions"):
+            filler.fit(_replacement("too much text", regions), {1: (100, 100)})

--- a/tests/test_pdf_text_layout.py
+++ b/tests/test_pdf_text_layout.py
@@ -78,6 +78,90 @@ class TestQTextParagraphFiller(unittest.TestCase):
 
         self.assertEqual(fitted.font_size, 10)
 
+    def test_qt_horizontal_alignment_exposes_effective_text_coordinates(self):
+        """Qt, not hand-written glyph arithmetic, chooses each line's x offset."""
+        region = PDFReplacementRegion(1, (0, 0, 200, 80), (200, 80))
+        placements = {}
+        for alignment in ("left", "center", "right"):
+            style = PatchTextStyle(
+                max_font_size=10, min_font_size=10, horizontal_padding=10,
+                vertical_padding=5, alignment=alignment,
+            )
+            fitted = QTextParagraphFiller(PatchTextOptions(styles={"text": style})).fit(
+                _replacement("alignment", [region]), {1: (200, 80)},
+            )
+            placements[alignment] = fitted.placements[0]
+
+        left = placements["left"]
+        center = placements["center"]
+        right = placements["right"]
+        content_right = 190.0
+        self.assertAlmostEqual(left.line_text_lefts[0], 10.0)
+        self.assertGreater(center.line_text_lefts[0], left.line_text_lefts[0])
+        self.assertGreater(right.line_text_lefts[0], center.line_text_lefts[0])
+        self.assertAlmostEqual(
+            right.line_text_lefts[0] + right.line_text_widths[0], content_right,
+        )
+        self.assertAlmostEqual(
+            center.line_text_lefts[0] - 10.0,
+            content_right - (center.line_text_lefts[0] + center.line_text_widths[0]),
+            delta=0.1,
+        )
+
+    def test_qt_justifies_a_nonfinal_line_to_the_rectangle_width(self):
+        region = PDFReplacementRegion(1, (0, 0, 80, 80), (80, 80))
+        style = PatchTextStyle(
+            max_font_size=10, min_font_size=10, horizontal_padding=5,
+            alignment="justify",
+        )
+        fitted = QTextParagraphFiller(PatchTextOptions(styles={"text": style})).fit(
+            _replacement("one two three four five six seven", [region]), {1: (80, 80)},
+        )
+
+        placement = fitted.placements[0]
+        self.assertGreaterEqual(len(placement.line_tops), 2)
+        self.assertAlmostEqual(placement.line_text_lefts[0], 5.0)
+        self.assertAlmostEqual(placement.line_text_widths[0], 70.0)
+
+    def test_line_height_and_vertical_alignment_position_complete_lines(self):
+        region = PDFReplacementRegion(1, (0, 0, 120, 100), (120, 100))
+        vertical_placements = {}
+        for alignment in ("top", "center", "bottom"):
+            style = PatchTextStyle(
+                max_font_size=10, min_font_size=10, vertical_padding=10,
+                vertical_alignment=alignment,
+            )
+            fitted = QTextParagraphFiller(PatchTextOptions(styles={"text": style})).fit(
+                _replacement("one line", [region]), {1: (120, 100)},
+            )
+            vertical_placements[alignment] = fitted.placements[0]
+
+        top = vertical_placements["top"]
+        center = vertical_placements["center"]
+        bottom = vertical_placements["bottom"]
+        self.assertAlmostEqual(top.line_tops[0], 10.0)
+        self.assertAlmostEqual(
+            center.line_tops[0], 10.0 + (80.0 - center.line_heights[0]) / 2,
+        )
+        self.assertAlmostEqual(bottom.line_tops[0], 90.0 - bottom.line_heights[0])
+
+        multi_line_style = PatchTextStyle(
+            max_font_size=10, min_font_size=10, line_height=1.6,
+        )
+        multi_line = QTextParagraphFiller(PatchTextOptions(
+            styles={"text": multi_line_style}
+        )).fit(
+            _replacement("one two three", [
+                PDFReplacementRegion(1, (0, 0, 55, 100), (55, 100)),
+            ]),
+            {1: (55, 100)},
+        ).placements[0]
+        self.assertGreaterEqual(len(multi_line.line_tops), 2)
+        self.assertAlmostEqual(
+            multi_line.line_tops[1] - multi_line.line_tops[0],
+            multi_line.line_heights[0] * 1.6,
+        )
+
     def test_fails_only_when_even_minimum_size_cannot_fit_any_full_line(self):
         regions = [PDFReplacementRegion(1, (0, 0, 20, 5), (100, 100))]
         filler = QTextParagraphFiller(PatchTextOptions(max_font_size=8, min_font_size=8))


### PR DESCRIPTION
## Summary

- split visual erasure from Qt-backed PDF text-layer filling
- flow each translated ParagraphLayout through ordered source regions at one fitted font size
- preserve source PDF pages without page rasterization, plus fixture and deterministic placement coverage

## Verification

- `poetry run python test.py`
- `poetry run pyright`
- `poetry run pylint pdf_craft tests`
- `poetry build`
- manual rendered real-fixture smoke and `pdftotext` extraction check