### PR TITLE
feat: sample local PDF background for erasure

### DIFF
--- a/docs/changelog/v2.1.1.md
+++ b/docs/changelog/v2.1.1.md
@@ -1,0 +1,15 @@
+# PDF Craft v2.1.1
+
+## What's Changed
+
+### PDF Translation Overlays
+
+- Write translated paragraphs as a scalable, extractable Qt PDF text layer over the original PDF page instead of rasterizing translated text.
+- Keep paragraph layout and visual erasure independent so future erasers do not need to change text fitting or placement.
+
+### Local-background Basic Erasure
+
+- Replace fixed white erasure with padded rectangles filled by a frequency-weighted median RGB color sampled from the original page. This supports ordinary white, dark, and lightly colored paper backgrounds without an OCR mask or neural inpainting model.
+- Add public `EraseOptions` for configuring erasure padding. The basic eraser deliberately does not reconstruct paper texture, rules, formulae, or artwork.
+
+**Full Changelog**: https://github.com/oomol-lab/pdf-craft/compare/v2.1.0...v2.1.1

--- a/docs/en/API_REFERENCE.md
+++ b/docs/en/API_REFERENCE.md
@@ -167,7 +167,7 @@ LLM(
 For patch layout beyond the convenience methods, use these public types:
 
 ```python
-from pdf_craft import PDFPatcher, PDFTranslationPipeline, PatchTextOptions, PatchTextStyle
+from pdf_craft import EraseOptions, PDFPatcher, PDFTranslationPipeline, PatchTextOptions, PatchTextStyle
 
 patcher = PDFPatcher(options=PatchTextOptions(
     font_name="Noto Sans CJK SC",  # preferred family; Qt falls back when absent
@@ -178,13 +178,13 @@ patcher = PDFPatcher(options=PatchTextOptions(
     vertical_padding=1,
     styles={"sub_title": PatchTextStyle(max_font_size=18, min_font_size=8)},
     overflow="error",
-))
+), erase_options=EraseOptions(padding=2))
 pipeline = PDFTranslationPipeline(patcher=patcher)
 ```
 
 `PatchTextOptions` controls the default Qt text style and optional `PatchTextStyle` overrides by semantic layout key (`"text"`, `"sub_title"`, or `"sub_title:2"`). A paragraph receives one fitted font size, then flows through its ordered `PDFReplacement.regions` without splitting a line across boxes. Qt handles shaping, wrapping, fallback fonts and glyph positions; missing configured fonts do not stop a patch. `overflow="error"` (the default) stops if the complete paragraph cannot fit; `overflow="skip"` records skipped replacements in `PDFPatcher.skipped_replacements`.
 
-The patcher preserves the source PDF page and merges two independent overlays: a temporary white rectangle erasure layer and a Qt-generated PDF text layer. It does not rasterize the page or the translated text. The current erasure is visual only: source text hidden by its rectangle may remain extractable beneath it. Qt/PySide6 and the required fonts must be available on the machine producing the PDF.
+The patcher preserves the source PDF page and merges two independent overlays: a local-background RGB rectangle erasure layer and a Qt-generated PDF text layer. `EraseOptions(padding=2)` expands each source box in its OCR-pixel coordinates before sampling and painting it. The supplied `PDFHandler` (or the default Poppler handler) renders original pages only for color sampling; it is never used as an output page image. The erasure is visual only and deliberately does not restore texture, rules, formulae, or artwork; source text hidden by it may remain extractable beneath it. Qt/PySide6, a PDF renderer such as Poppler, and the required fonts must be available on the machine producing the PDF.
 
 `PDFTranslationPipeline` can perform lower-level translation or patching when the application owns the complete layout and output lifecycle. Prefer `PDFCraft.translate_pdf()` and `PDFCraft.patch_pdf_with_extraction()` when their fixed layout policy is sufficient.
 

--- a/docs/en/PDF_TRANSLATION.md
+++ b/docs/en/PDF_TRANSLATION.md
@@ -154,11 +154,11 @@ craft.patch_pdf_with_extraction(
 
 ### What PDF patching can and cannot preserve
 
-PDF patching is a page-overlay workflow, not a general-purpose PDF layout engine. It preserves each source page and merges a rectangular visual-erasure layer followed by a Qt-generated PDF text layer. The translated text remains scalable and extractable; source vector text, links, annotations and other page objects are not flattened. The current erasure is only a white rectangle, so hidden source text may still be extractable underneath it. It replaces text and subtitle layouts only; tables and images are not translated in place.
+PDF patching is a page-overlay workflow, not a general-purpose PDF layout engine. It preserves each source page and merges a rectangular visual-erasure layer followed by a Qt-generated PDF text layer. The translated text remains scalable and extractable; source vector text, links, annotations and other page objects are not flattened. For each padded source box, the eraser renders the original page only to estimate a local, frequency-weighted median RGB background color, then covers the complete rectangle with that color. It intentionally does not restore paper texture, rules, formulae, or artwork, and hidden source text may still be extractable underneath it. It replaces text and subtitle layouts only; tables and images are not translated in place.
 
 The source PDF and extraction must match. `pages.xml` must contain geometry for every chapter page and its page numbers must be valid for the source file. There is no fallback to OCR caches or re-rendering to recover missing geometry. `APPEND_BLOCK` is rejected for PDF output because new block-level content cannot safely be added to a fixed page. Text that cannot fit its original bounding box fails before a partial output PDF is left behind.
 
-For custom fonts, semantic title/body styles, fit rules, alignment, padding, or overflow handling, use the lower-level public `PDFPatcher`, `PatchTextOptions`, `PatchTextStyle`, and `PDFTranslationPipeline` APIs described in the [API reference](API_REFERENCE.md). PDF patching requires the local Qt/PySide6 runtime and suitable fonts.
+For custom fonts, semantic title/body styles, fit rules, alignment, erase padding, or overflow handling, use the lower-level public `PDFPatcher`, `PatchTextOptions`, `PatchTextStyle`, `EraseOptions`, and `PDFTranslationPipeline` APIs described in the [API reference](API_REFERENCE.md). PDF patching requires the local Qt/PySide6 runtime, Poppler (or a supplied `PDFHandler`), and suitable fonts.
 
 ## Extraction controls
 

--- a/docs/zh-CN/API_REFERENCE.md
+++ b/docs/zh-CN/API_REFERENCE.md
@@ -24,7 +24,7 @@ from pdf_craft import PDFCraft, PDFOptions
   `TranslationEventKind`、`TranslationItemKind`、`FillFailedEvent`
 - `PDFHandler`、`DefaultPDFHandler`、`PDFDocument`、`DefaultPDFDocument`、
   `PDFDocumentMetadata`
-- `PDFPatcher`、`PDFReplacement`、`PDFReplacementRegion`、`PDFSkippedReplacement`、`PatchTextOptions`、
+- `PDFPatcher`、`PDFReplacement`、`PDFReplacementRegion`、`PDFSkippedReplacement`、`PatchTextOptions`、`EraseOptions`、
   `PDFTranslationPipeline`
 - `PDFError`、`OCRError`、`IgnorePDFErrorsChecker`、
   `IgnoreOCRErrorsChecker`
@@ -383,11 +383,13 @@ translate_epub(
   `page_pixel_size`，以及可选的 `dpi`、`reading_order`。PDF 翻译会以一个 `ParagraphLayout` 为单位
   调用翻译器一次，并将该段落全部、有序的来源框保存在 `regions`（`PDFReplacementRegion`）中，而不是把
   同一译文复制到每个框。
-- `PDFPatcher(options=PatchTextOptions(...), pdf_handler=...)` 通过 `.patch(source_path,
+- `PDFPatcher(options=PatchTextOptions(...), erase_options=EraseOptions(...), pdf_handler=...)` 通过 `.patch(source_path,
   target_path, replacements)` 写出 PDF。它接受任意通过字段校验的 `PDFReplacement`，不要求这些
   替换项来自 `PDFCraftExtraction` 或 OCR；`page_pixel_size` 仅用于把像素 `bbox` 换算为 PDF 坐标，
   patcher 不会验证它是否等于源页的实际渲染尺寸。调用方必须自行保证页码、坐标与尺寸对应源 PDF。
-  `PatchTextOptions` 控制默认字体、字号、内边距、对齐和 `overflow` 策略；可用
+  `PatchTextOptions` 控制默认字体、字号、内边距、对齐和 `overflow` 策略；`EraseOptions.padding` 在
+  OCR 像素坐标中扩大来源框，并用原始页面对应区域按频次加权的 RGB 中位色完整覆盖扩展矩形。`pdf_handler`
+  仅为这个颜色估计渲染原始页，输出仍以原始 PDF 页面为底。可用
   `PatchTextStyle` 以 `"text"`、`"sub_title"` 或 `"sub_title:2"` 为键覆盖不同文字等级。
   同一个段落统一搜索字号，随后按顺序流入所有 `regions`；放不下的整行会进入下一个框，绝不局部跨框。
   `overflow="error"`（默认）在整段无法容纳时失败，`"skip"` 则把对应项记录在

--- a/docs/zh-CN/PDF_TRANSLATION.md
+++ b/docs/zh-CN/PDF_TRANSLATION.md
@@ -207,12 +207,12 @@ PySide6/Qt；在依赖被移除或非标准安装的环境中，底层导入失�
 
 `PDFCraft.translate_pdf` 与 `PDFCraft.patch_pdf_with_extraction` 为简化调用而设计，不提供字体、
 字号、对齐、padding 或 overflow 策略参数。需要调整这些规则时，使用公开的低层
-`PDFPatcher` 与 `PatchTextOptions`，再交给 `PDFTranslationPipeline`：
+`PDFPatcher`、`PatchTextOptions` 与 `EraseOptions`，再交给 `PDFTranslationPipeline`：
 
 ```python
 from pathlib import Path
 
-from pdf_craft import PDFPatcher, PDFTranslationPipeline, PatchTextOptions, PatchTextStyle
+from pdf_craft import EraseOptions, PDFPatcher, PDFTranslationPipeline, PatchTextOptions, PatchTextStyle
 
 patcher = PDFPatcher(options=PatchTextOptions(
     font_name="Noto Sans CJK SC",  # 优先字体；缺失时由 Qt fallback
@@ -223,7 +223,7 @@ patcher = PDFPatcher(options=PatchTextOptions(
     vertical_padding=1,
     styles={"sub_title": PatchTextStyle(max_font_size=18, min_font_size=8)},
     overflow="error",
-))
+), erase_options=EraseOptions(padding=2))
 pipeline = PDFTranslationPipeline(patcher=patcher)
 pipeline.translate(Path("input.pdf"), Path("translated.pdf"), extraction, translator)
 ```
@@ -238,9 +238,10 @@ pipeline.translate(Path("input.pdf"), Path("translated.pdf"), extraction, transl
 矩形擦除 overlay 和由 Qt `QTextLayout` / PDF paint device 生成的译文文本 overlay。因此扫描页
 仍会自然保留扫描背景，原生 PDF 页也不会因写回而压扁；译文则是可缩放、可提取的 PDF 文字。
 
-当前擦除只负责视觉上的白色矩形遮蔽，底层的原文字内容流可能仍可被提取。精细擦字或内容感知修复
-不属于此写回器。写回需要本机具备 PySide6/Qt 运行时和可用字体；字体配置是优先选择，Qt 找不到
-指定字体或字形时会使用系统 fallback。
+擦除会先以 padding 扩大每个来源 bbox，然后只渲染原始页来计算该矩形内按频次加权的 RGB 中位背景色，
+再以这个颜色完整覆盖扩展矩形。渲染页不会作为输出页，写回仍保留原始 PDF 页。当前擦除不恢复纸张纹理、
+表格线、公式或插图，底层的原文字内容流也可能仍可被提取。写回需要本机具备 PySide6/Qt、Poppler（或
+调用方提供的 `PDFHandler`）和可用字体；字体配置是优先选择，Qt 找不到指定字体或字形时会使用系统 fallback。
 
 ## 原子 API
 

--- a/pdf_craft/__init__.py
+++ b/pdf_craft/__init__.py
@@ -17,6 +17,7 @@ from .pipeline.pdf import (
     PDFReplacementRegion,
     PDFSkippedReplacement,
     PDFTranslationPipeline,
+    EraseOptions,
     PatchTextOptions,
     PatchTextStyle,
     QTextParagraphFiller,

--- a/pdf_craft/pipeline/pdf/__init__.py
+++ b/pdf_craft/pipeline/pdf/__init__.py
@@ -1,4 +1,4 @@
-from .eraser import EraseRectangle, RectangularEraser
+from .eraser import EraseOptions, EraseRectangle, RectangularEraser
 from .models import PDFReplacement, PDFReplacementRegion, PDFSkippedReplacement
 from .patcher import PDFPatcher
 from .pipeline import PDFTranslationPipeline
@@ -8,7 +8,7 @@ from .text_layout import (
 )
 
 __all__ = [
-    "EraseRectangle", "FittedParagraph", "PatchTextOptions", "PatchTextStyle", "PDFPatcher",
+    "EraseOptions", "EraseRectangle", "FittedParagraph", "PatchTextOptions", "PatchTextStyle", "PDFPatcher",
     "PDFReplacement", "PDFReplacementRegion", "PDFSkippedReplacement", "PDFTranslationPipeline",
     "QTextParagraphFiller", "RectangularEraser", "RegionTextPlacement",
 ]

--- a/pdf_craft/pipeline/pdf/eraser.py
+++ b/pdf_craft/pipeline/pdf/eraser.py
@@ -5,44 +5,90 @@ content-aware inpainting belong to a future eraser implementation, not the
 paragraph text filler.
 """
 
-from collections.abc import Iterable
+from collections import Counter
+from collections.abc import Iterable, Mapping
 from dataclasses import dataclass
+from math import ceil, floor
+from typing import TypeAlias, cast
 
-from .geometry import PageRectangle, region_in_page_points
+from PIL import Image
+
+from .geometry import PageRectangle, pixel_rectangle_in_page_points
 from .models import PDFReplacementRegion
+
+
+RGBColor: TypeAlias = tuple[int, int, int]
+_LUMINANCE_SCALE = 10_000
+_LUMINANCE_WINDOW = 8 * _LUMINANCE_SCALE
+
+
+@dataclass(frozen=True)
+class EraseOptions:
+    """Options for the intentionally simple, rectangular visual eraser.
+
+    ``padding`` is measured in the OCR/page-image pixel coordinate system,
+    before the rectangle is mapped to PDF points.
+    """
+
+    padding: int = 2
+
+    def __post_init__(self) -> None:
+        if self.padding < 0:
+            raise ValueError("erase padding must be non-negative")
 
 
 @dataclass(frozen=True)
 class EraseRectangle:
-    """One visual mask in PDF-point coordinates with a top-left origin."""
+    """One colored visual mask in PDF-point coordinates with a top-left origin."""
 
     page_index: int
     rectangle: PageRectangle
+    color: RGBColor
 
 
 class RectangularEraser:
-    """Plan and paint the legacy white rectangle masks independently of text."""
+    """Plan and paint background-colored rectangle masks independently of text.
+
+    This is deliberately not a text-pixel detector. Each source bbox may cover
+    multiple lines; the whole padded rectangle is covered with a robust local
+    background RGB estimate from the unmodified source page image.
+    """
+
+    def __init__(self, options: EraseOptions | None = None) -> None:
+        self.options = options or EraseOptions()
 
     def plan(
         self,
         regions: Iterable[PDFReplacementRegion],
         page_sizes: dict[int, tuple[float, float]],
+        page_images: Mapping[int, Image.Image],
     ) -> tuple[EraseRectangle, ...]:
+        """Create all masks from the same, unmodified source-page images."""
         rectangles: list[EraseRectangle] = []
         for region in regions:
             page_width, page_height = page_sizes[region.page_index]
+            try:
+                page_image = page_images[region.page_index]
+            except KeyError as error:
+                raise ValueError(
+                    f"missing source page image for erasure on page {region.page_index}"
+                ) from error
+            bbox = self._expanded_bbox(region)
             rectangles.append(EraseRectangle(
                 region.page_index,
-                region_in_page_points(region, page_width, page_height),
+                pixel_rectangle_in_page_points(
+                    bbox, region.page_pixel_size, page_width, page_height,
+                ),
+                self.estimate_background_color(page_image, bbox, region.page_pixel_size),
             ))
         return tuple(rectangles)
 
     @staticmethod
     def draw(overlay, rectangles: Iterable[EraseRectangle], page_height: float) -> None:
         """Draw the masks on a ReportLab overlay (whose origin is bottom-left)."""
-        overlay.setFillColorRGB(1, 1, 1)
         for erase in rectangles:
             rectangle = erase.rectangle
+            overlay.setFillColorRGB(*(component / 255 for component in erase.color))
             overlay.rect(
                 rectangle.x,
                 page_height - rectangle.bottom,
@@ -51,3 +97,101 @@ class RectangularEraser:
                 stroke=0,
                 fill=1,
             )
+
+    def _expanded_bbox(self, region: PDFReplacementRegion) -> tuple[int, int, int, int]:
+        """Expand one OCR bbox by the configured source-pixel padding."""
+        left, top, right, bottom = region.bbox
+        page_width, page_height = region.page_pixel_size
+        padding = self.options.padding
+        return (
+            max(left - padding, 0),
+            max(top - padding, 0),
+            min(right + padding, page_width),
+            min(bottom + padding, page_height),
+        )
+
+    @staticmethod
+    def estimate_background_color(
+        image: Image.Image,
+        bbox: tuple[int, int, int, int],
+        page_pixel_size: tuple[int, int],
+    ) -> RGBColor:
+        """Return a robust, hue-preserving RGB median for one source rectangle.
+
+        The luminance-weighted median follows the rectangle's actual pixel
+        frequencies, so a mostly beige page remains beige and a mostly black
+        page remains black. A small luminance neighbourhood is then reduced by
+        weighted component medians to avoid selecting one noisy JPEG pixel.
+        """
+        crop = _crop_in_page_coordinates(image, bbox, page_pixel_size)
+        rgb_crop = crop.convert("RGB")
+        pixels: list[RGBColor] = [
+            cast(RGBColor, rgb_crop.getpixel((x, y)))
+            for y in range(rgb_crop.height)
+            for x in range(rgb_crop.width)
+        ]
+        if not pixels:
+            raise ValueError("cannot estimate background color from an empty erasure rectangle")
+
+        frequencies: Counter[RGBColor] = Counter(pixels)
+        ordered = sorted(frequencies, key=lambda color: (_luminance(color), color))
+        midpoint = (len(pixels) - 1) // 2
+        cumulative = 0
+        median_color = ordered[-1]
+        for color in ordered:
+            cumulative += frequencies[color]
+            if cumulative > midpoint:
+                median_color = color
+                break
+
+        median_luminance = _luminance(median_color)
+        nearby = Counter({
+            color: count
+            for color, count in frequencies.items()
+            if abs(_luminance(color) - median_luminance) <= _LUMINANCE_WINDOW
+        })
+        if not nearby:  # Defensive: the median color itself is always nearby.
+            return median_color
+        return (
+            _weighted_component_median(nearby, 0),
+            _weighted_component_median(nearby, 1),
+            _weighted_component_median(nearby, 2),
+        )
+
+
+def _crop_in_page_coordinates(
+    image: Image.Image,
+    bbox: tuple[int, int, int, int],
+    page_pixel_size: tuple[int, int],
+) -> Image.Image:
+    """Map OCR pixel coordinates onto a rendered page image and crop safely."""
+    page_width, page_height = page_pixel_size
+    left, top, right, bottom = bbox
+    image_width, image_height = image.size
+    crop_left = max(0, min(image_width, floor(left * image_width / page_width)))
+    crop_top = max(0, min(image_height, floor(top * image_height / page_height)))
+    crop_right = max(0, min(image_width, ceil(right * image_width / page_width)))
+    crop_bottom = max(0, min(image_height, ceil(bottom * image_height / page_height)))
+    if crop_right <= crop_left or crop_bottom <= crop_top:
+        raise ValueError("erasure rectangle has no pixels after page-image mapping")
+    return image.crop((crop_left, crop_top, crop_right, crop_bottom))
+
+
+def _luminance(color: RGBColor) -> int:
+    """Return deterministic Rec. 709 luminance in fixed-point units."""
+    red, green, blue = color
+    return 2126 * red + 7152 * green + 722 * blue
+
+
+def _weighted_component_median(colors: Counter[RGBColor], component: int) -> int:
+    """Compute one RGB channel's weighted median without selecting a noise pixel."""
+    values: Counter[int] = Counter()
+    for color, count in colors.items():
+        values[color[component]] += count
+    midpoint = (sum(values.values()) - 1) // 2
+    cumulative = 0
+    for value in sorted(values):
+        cumulative += values[value]
+        if cumulative > midpoint:
+            return value
+    raise RuntimeError("weighted component median has no values")

--- a/pdf_craft/pipeline/pdf/geometry.py
+++ b/pdf_craft/pipeline/pdf/geometry.py
@@ -23,8 +23,18 @@ def region_in_page_points(
     region: PDFReplacementRegion, page_width: float, page_height: float,
 ) -> PageRectangle:
     """Map OCR pixels to PDF points, retaining the OCR top-left convention."""
-    pixel_width, pixel_height = region.page_pixel_size
-    left, top, right, bottom = region.bbox
+    return pixel_rectangle_in_page_points(
+        region.bbox, region.page_pixel_size, page_width, page_height,
+    )
+
+
+def pixel_rectangle_in_page_points(
+    bbox: tuple[int, int, int, int], page_pixel_size: tuple[int, int],
+    page_width: float, page_height: float,
+) -> PageRectangle:
+    """Map one top-left OCR-pixel rectangle into PDF-point coordinates."""
+    pixel_width, pixel_height = page_pixel_size
+    left, top, right, bottom = bbox
     scale_x = page_width / pixel_width
     scale_y = page_height / pixel_height
     return PageRectangle(

--- a/pdf_craft/pipeline/pdf/patcher.py
+++ b/pdf_craft/pipeline/pdf/patcher.py
@@ -4,9 +4,11 @@ from collections.abc import Iterable
 from pathlib import Path
 from tempfile import NamedTemporaryFile, TemporaryDirectory
 
-from pdf_craft.pdf.handler import PDFHandler
+from PIL import Image
 
-from .eraser import EraseRectangle, RectangularEraser
+from pdf_craft.pdf.handler import DefaultPDFHandler, PDFHandler
+
+from .eraser import EraseOptions, EraseRectangle, RectangularEraser
 from .models import PDFReplacement, PDFReplacementRegion, PDFSkippedReplacement
 from .text_layout import FittedParagraph, PatchTextOptions, QTextParagraphFiller
 
@@ -14,10 +16,11 @@ from .text_layout import FittedParagraph, PatchTextOptions, QTextParagraphFiller
 class PDFPatcher:
     """Replace OCR-backed paragraph regions without flattening source pages.
 
-    The source page remains the base PDF page. The eraser owns a visual white
-    rectangle overlay for now; the filler owns a separate Qt-generated PDF text
-    overlay. Keeping those layers separate makes a future image-aware eraser a
-    local replacement rather than a typography rewrite.
+    The source page remains the base PDF page. The eraser owns a locally
+    sampled background-color rectangle overlay; the filler owns a separate
+    Qt-generated PDF text overlay. Keeping those layers separate makes a
+    future image-aware eraser a local replacement rather than a typography
+    rewrite.
     """
 
     def __init__(
@@ -27,13 +30,14 @@ class PDFPatcher:
         options: PatchTextOptions | None = None,
         pdf_handler: PDFHandler | None = None,
         dpi: int = 300,
+        erase_options: EraseOptions | None = None,
     ) -> None:
         """Create a patcher.
 
-        ``pdf_handler`` remains accepted for source compatibility but is no
-        longer used: patching must not render source pages to a bitmap.
+        ``pdf_handler`` renders source pages only to sample local background
+        colors for erasure. The source PDF page remains the output base and is
+        never replaced with that raster image.
         """
-        del pdf_handler
         if options is not None and (font_name is not None or font_size is not None):
             raise ValueError("pass either options or legacy font_name/font_size arguments")
         if options is None:
@@ -47,8 +51,9 @@ class PDFPatcher:
                 ),
             )
         self.options = options
-        self._eraser = RectangularEraser()
+        self._eraser = RectangularEraser(erase_options)
         self._filler = QTextParagraphFiller(options)
+        self._pdf_handler = pdf_handler or DefaultPDFHandler()
         self.dpi = dpi
         self.skipped_replacements: tuple[PDFSkippedReplacement, ...] = ()
 
@@ -70,9 +75,13 @@ class PDFPatcher:
             for index, page in enumerate(reader.pages, 1)
         }
         fitted, skipped = self._preflight(replacement_list, page_sizes)
+        erasure_regions = tuple(
+            region for replacement, _ in fitted for region in replacement.source_regions()
+        )
         erasures = self._eraser.plan(
-            (region for replacement, _ in fitted for region in replacement.source_regions()),
+            erasure_regions,
             page_sizes,
+            self._render_erasure_pages(source_path, erasure_regions),
         )
 
         erasures_by_page = self._group_erasures(erasures)
@@ -102,6 +111,30 @@ class PDFPatcher:
             writer.write(output)
         temporary_path.replace(target_path)
         self.skipped_replacements = tuple(skipped)
+
+    def _render_erasure_pages(
+        self,
+        source_path: Path,
+        regions: tuple[PDFReplacementRegion, ...],
+    ) -> dict[int, Image.Image]:
+        """Render only pages that need color sampling, never for PDF output."""
+        page_dpi: dict[int, int] = {}
+        for region in regions:
+            previous = page_dpi.setdefault(region.page_index, region.dpi)
+            if previous != region.dpi:
+                raise ValueError(
+                    f"page {region.page_index} has incompatible erasure render DPI values"
+                )
+        if not page_dpi:
+            return {}
+        document = self._pdf_handler.open(source_path)
+        try:
+            return {
+                page_index: document.render_page(page_index, dpi)
+                for page_index, dpi in page_dpi.items()
+            }
+        finally:
+            document.close()
 
     def validate(self, replacement: PDFReplacement, pages_count: int | None = None) -> None:
         if not replacement.text.strip():

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "poetry.core.masonry.api"
 
 [project]
 name = "pdf-craft"
-version = "2.1.0"
+version = "2.1.1"
 description = "PDF craft can convert PDF files into various other formats. This project will focus on processing PDF files of scanned books."
 license = {text = "MIT"}
 authors = [{name = "Tao Zeyu", email = "i@taozeyu.com"}]

--- a/tests/test_pdf_eraser.py
+++ b/tests/test_pdf_eraser.py
@@ -1,18 +1,71 @@
 import unittest
 
-from pdf_craft.pipeline.pdf import PDFReplacementRegion, RectangularEraser
+from PIL import Image, ImageDraw
+
+from pdf_craft.pipeline.pdf import EraseOptions, PDFReplacementRegion, RectangularEraser
 
 
 class TestRectangularEraser(unittest.TestCase):
-    def test_plans_visual_masks_without_any_text_input(self):
+    def test_plans_padded_beige_mask_from_the_unmodified_page_image(self):
+        page_image = Image.new("RGB", (100, 200), (234, 220, 183))
+        drawing = ImageDraw.Draw(page_image)
+        # Simulate multiple dark source lines. They remain a minority of the
+        # padded rectangle, so the background RGB should retain its beige hue.
+        drawing.rectangle((12, 25, 45, 28), fill=(20, 20, 20))
+        drawing.rectangle((12, 36, 45, 39), fill=(20, 20, 20))
         region = PDFReplacementRegion(2, (10, 20, 50, 70), (100, 200))
 
-        planned = RectangularEraser().plan((region,), {2: (300, 400)})
+        planned = RectangularEraser(EraseOptions(padding=3)).plan(
+            (region,), {2: (300, 400)}, {2: page_image},
+        )
 
         self.assertEqual(len(planned), 1)
         erase = planned[0]
         self.assertEqual(erase.page_index, 2)
-        self.assertEqual(erase.rectangle.x, 30)
-        self.assertEqual(erase.rectangle.top, 40)
-        self.assertEqual(erase.rectangle.width, 120)
-        self.assertEqual(erase.rectangle.height, 100)
+        self.assertEqual(erase.color, (234, 220, 183))
+        self.assertEqual(erase.rectangle.x, 21)
+        self.assertEqual(erase.rectangle.top, 34)
+        self.assertEqual(erase.rectangle.width, 138)
+        self.assertEqual(erase.rectangle.height, 112)
+        self.assertEqual(page_image.getpixel((20, 26)), (20, 20, 20))
+
+    def test_uses_black_background_for_light_text(self):
+        page_image = Image.new("RGB", (100, 100), (4, 7, 9))
+        drawing = ImageDraw.Draw(page_image)
+        drawing.rectangle((25, 30, 74, 34), fill=(245, 245, 245))
+        region = PDFReplacementRegion(1, (20, 20, 80, 80), (100, 100))
+
+        erase = RectangularEraser().plan((region,), {1: (100, 100)}, {1: page_image})[0]
+
+        self.assertEqual(erase.color, (4, 7, 9))
+
+    def test_clips_padding_at_page_edges_and_rejects_negative_padding(self):
+        page_image = Image.new("RGB", (100, 100), (210, 200, 170))
+        region = PDFReplacementRegion(1, (0, 0, 10, 10), (100, 100))
+
+        erase = RectangularEraser(EraseOptions(padding=20)).plan(
+            (region,), {1: (100, 100)}, {1: page_image},
+        )[0]
+
+        self.assertEqual(erase.rectangle.x, 0)
+        self.assertEqual(erase.rectangle.top, 0)
+        self.assertEqual(erase.rectangle.width, 30)
+        self.assertEqual(erase.rectangle.height, 30)
+        with self.assertRaisesRegex(ValueError, "padding"):
+            EraseOptions(padding=-1)
+
+    def test_noise_uses_a_stable_background_color_not_one_random_pixel(self):
+        page_image = Image.new("RGB", (20, 20), (231, 214, 170))
+        pixels = page_image.load()
+        assert pixels is not None
+        for y in range(20):
+            for x in range(20):
+                if (x + y) % 3 == 0:
+                    pixels[x, y] = (232, 215, 171)
+                elif (x + y) % 3 == 1:
+                    pixels[x, y] = (230, 213, 169)
+        region = PDFReplacementRegion(1, (0, 0, 20, 20), (20, 20))
+
+        erase = RectangularEraser().plan((region,), {1: (20, 20)}, {1: page_image})[0]
+
+        self.assertEqual(erase.color, (231, 214, 170))

--- a/tests/test_pdf_eraser.py
+++ b/tests/test_pdf_eraser.py
@@ -1,4 +1,5 @@
 import unittest
+from unittest.mock import Mock
 
 from PIL import Image, ImageDraw
 
@@ -6,6 +7,48 @@ from pdf_craft.pipeline.pdf import EraseOptions, PDFReplacementRegion, Rectangul
 
 
 class TestRectangularEraser(unittest.TestCase):
+    def test_samples_overlapping_regions_from_one_unmodified_page_image(self):
+        """Planning and drawing one mask must not affect another mask's sample."""
+        beige = (234, 220, 183)
+        charcoal = (4, 7, 9)
+        page_image = Image.new("RGB", (100, 100), beige)
+        # The regions overlap at (40, 40)-(50, 50). The first still has a
+        # beige majority after padding; the second has a charcoal majority.
+        ImageDraw.Draw(page_image).rectangle((40, 40, 99, 99), fill=charcoal)
+        first = PDFReplacementRegion(1, (0, 0, 50, 50), (100, 100))
+        second = PDFReplacementRegion(1, (40, 40, 90, 90), (100, 100))
+        eraser = RectangularEraser(EraseOptions(padding=5))
+
+        planned = eraser.plan(
+            (first, second), {1: (200, 200)}, {1: page_image},
+        )
+
+        self.assertEqual([erase.color for erase in planned], [beige, charcoal])
+        # First padding clips at the page edge; second keeps its full padding.
+        self.assertEqual(
+            (planned[0].rectangle.x, planned[0].rectangle.top,
+             planned[0].rectangle.width, planned[0].rectangle.height),
+            (0, 0, 110, 110),
+        )
+        self.assertEqual(
+            (planned[1].rectangle.x, planned[1].rectangle.top,
+             planned[1].rectangle.width, planned[1].rectangle.height),
+            (70, 70, 120, 120),
+        )
+
+        overlay = Mock()
+        eraser.draw(overlay, (planned[0],), page_height=200)
+        self.assertEqual(page_image.getpixel((10, 10)), beige)
+        self.assertEqual(page_image.getpixel((45, 45)), charcoal)
+        # Re-planning the overlapping second box after drawing the first mask
+        # yields the same source-page color: the overlay never contaminates
+        # source pixels used by subsequent estimates.
+        replanned_second = eraser.plan(
+            (second,), {1: (200, 200)}, {1: page_image},
+        )[0]
+        self.assertEqual(replanned_second.color, charcoal)
+        self.assertEqual(replanned_second.rectangle, planned[1].rectangle)
+
     def test_plans_padded_beige_mask_from_the_unmodified_page_image(self):
         page_image = Image.new("RGB", (100, 200), (234, 220, 183))
         drawing = ImageDraw.Draw(page_image)

--- a/tests/test_pdf_patcher.py
+++ b/tests/test_pdf_patcher.py
@@ -4,8 +4,10 @@ import tempfile
 import unittest
 from pathlib import Path
 from typing import Any
+from unittest.mock import Mock
 
 import pypdf
+from PIL import Image
 from reportlab.pdfgen import canvas
 
 from pdf_craft.pipeline.pdf import (
@@ -15,6 +17,32 @@ from pdf_craft.pipeline.pdf import (
 
 
 class TestPDFPatcher(unittest.TestCase):
+    def test_samples_colored_background_from_the_source_page_handler(self):
+        with tempfile.TemporaryDirectory() as temp_dir:
+            root = Path(temp_dir)
+            source = root / "source.pdf"
+            target = root / "target.pdf"
+            doc = canvas.Canvas(str(source), pagesize=(100, 100))
+            doc.drawString(1, 1, "source")
+            doc.save()
+            document: Any = Mock()
+            document.render_page.return_value = Image.new("RGB", (100, 100), (234, 220, 183))
+            handler: Any = Mock()
+            handler.open.return_value = document
+
+            PDFPatcher(font_size=8, pdf_handler=handler).patch(
+                source,
+                target,
+                [PDFReplacement(1, (20, 20, 80, 80), "translated", (100, 100))],
+            )
+
+            document.render_page.assert_called_once_with(1, 300)
+            document.close.assert_called_once_with()
+            page_contents = pypdf.PdfReader(str(target)).pages[0].get_contents()
+            assert page_contents is not None
+            contents = page_contents.get_data()
+            self.assertIn(b"0.917647 0.862745 0.717647 rg", contents)
+
     def test_replaces_region_and_preserves_page_count(self):
         with tempfile.TemporaryDirectory() as temp_dir:
             root = Path(temp_dir)


### PR DESCRIPTION
## Summary
- sample a padded source bbox to select a local RGB background color for vector erasure overlays
- retain the independent Qt PDF text layer and document the new `EraseOptions`
- add coverage for dark, beige, clipped, and overlapping source regions; release 2.1.1

## Verification
- poetry run python test.py
- poetry run pyright pdf_craft tests
- poetry run pylint pdf_craft tests
- poetry build