### PR TITLE
feat: prioritize body layout before headlines

### DIFF
--- a/docs/en/PDF_TRANSLATION.md
+++ b/docs/en/PDF_TRANSLATION.md
@@ -160,6 +160,31 @@ The source PDF and extraction must match. `pages.xml` must contain geometry for 
 
 For custom fonts, semantic title/body styles, fit rules, alignment, erase padding, or overflow handling, use the lower-level public `PDFPatcher`, `PatchTextOptions`, `PatchTextStyle`, `EraseOptions`, and `PDFTranslationPipeline` APIs described in the [API reference](API_REFERENCE.md). PDF patching requires the local Qt/PySide6 runtime, Poppler (or a supplied `PDFHandler`), and suitable fonts.
 
+### Headline hierarchy and bounded layout windows
+
+PDF patching treats each `ParagraphLayout` as one text flow, even when it has source boxes on more than one page. Each paragraph receives one uniform fitted font size; a full wrapped line always moves to the next source box rather than overflowing a box boundary.
+
+Within a releasable page window, `text` paragraphs are fitted before `sub_title` paragraphs. The largest fitted body size on every page touched by a headline becomes the headline's lower bound, multiplied by `headline_min_body_ratio` (default `1.2`). A semantic style can override that ratio with `minimum_body_font_ratio`; the normal fitting search may still choose a larger title size when its boxes permit it.
+
+```python
+options = PatchTextOptions(
+    styles={
+        "text": PatchTextStyle(font_name="Noto Serif CJK SC", max_font_size=11),
+        "sub_title": PatchTextStyle(
+            font_name="Noto Sans CJK SC",
+            max_font_size=24,
+            minimum_body_font_ratio=1.35,
+        ),
+    },
+    headline_min_body_ratio=1.2,
+    headline_fallback_font_size=14,
+)
+```
+
+If a title page has no drawn body text, its reference is chosen deterministically: a preceding body on the current window, then the preceding completed window, then a following body in the current window, then `headline_fallback_font_size` (or the title style's own minimum). A title that cannot meet its required lower bound raises `HeadlineConstraintError`; set `overflow="skip"` to record it in `patcher.skipped_replacements` and leave that replacement untouched instead.
+
+The window closes after all paragraphs that can touch its pages have been planned. The patcher then renders, samples for erasure, composes, and releases one source page image at a time. Thus a very long cross-page paragraph does not retain a book-wide collection of page rasters; the independent eraser and Qt text layers remain separate.
+
 ## Extraction controls
 
 Pass `ExtractionOptions` through the `extraction=` argument to tune a single extraction run:

--- a/docs/zh-CN/PDF_TRANSLATION.md
+++ b/docs/zh-CN/PDF_TRANSLATION.md
@@ -232,6 +232,41 @@ pipeline.translate(Path("input.pdf"), Path("translated.pdf"), extraction, transl
 并将原因记录在 `patcher.skipped_replacements`。低层 API 适用于愿意自行处理排版策略、
 跳过结果和输出文件生命周期的高级调用方。
 
+### 标题层级与有界布局窗口
+
+PDF 写回把一个 `ParagraphLayout` 视为一段连续文本流，即使它的来源 bbox 跨多个页面也如此。
+每个自然段只会选择一个统一字号；一整行若放不下当前 bbox，会整体移入下一个 bbox，绝不会在
+单个 bbox 的边界局部溢出。
+
+在一个可释放的页面窗口中，`text` 正文会先于 `sub_title` 标题完成排版。标题涉及的每一页中，
+已排版正文的最大字号乘以 `headline_min_body_ratio`（默认 `1.2`）后，构成标题字号的下限。
+某个语义样式可以通过 `minimum_body_font_ratio` 覆盖此比例；如果标题 bbox 仍有空间，常规的
+字号搜索仍会选择大于该下限的字号。
+
+```python
+options = PatchTextOptions(
+    styles={
+        "text": PatchTextStyle(font_name="Noto Serif CJK SC", max_font_size=11),
+        "sub_title": PatchTextStyle(
+            font_name="Noto Sans CJK SC",
+            max_font_size=24,
+            minimum_body_font_ratio=1.35,
+        ),
+    },
+    headline_min_body_ratio=1.2,
+    headline_fallback_font_size=14,
+)
+```
+
+若标题所在页没有实际排版出的正文，字号参考按确定顺序选择：当前窗口中较早页面的正文、此前
+已完成窗口的正文、当前窗口中较晚页面的正文，最后才是 `headline_fallback_font_size`（未设置时
+使用标题样式自身的最小字号）。标题无法满足这个硬性下限时会抛出 `HeadlineConstraintError`；
+设置 `overflow="skip"` 则会跳过该 replacement，并把原因写入 `patcher.skipped_replacements`。
+
+窗口会在所有仍可能触及其中页面的自然段完成规划后关闭。之后 patcher 会逐页渲染原始图、
+取色、合成并释放该页图片。因此即使一个很长的跨页自然段覆盖整本书，也不会在内存中累计整本书的
+页面 raster；独立的擦除层和 Qt 文本层依然互不耦合。
+
 ### 写回的页面与文本层
 
 写回不会将整页通过 `PDFHandler.render_page()` 栅格化。它保留原始 PDF 页，再依次合并独立的

--- a/pdf_craft/pipeline/pdf/__init__.py
+++ b/pdf_craft/pipeline/pdf/__init__.py
@@ -3,12 +3,15 @@ from .models import PDFReplacement, PDFReplacementRegion, PDFSkippedReplacement
 from .patcher import PDFPatcher
 from .pipeline import PDFTranslationPipeline
 from .text_layout import (
-    FittedParagraph, PatchTextOptions, PatchTextStyle, QTextParagraphFiller,
-    RegionTextPlacement,
+    FillWindowPlan, FittedParagraph, HeadlineConstraintError, PatchTextOptions,
+    PatchTextStyle, PlannedParagraph, QTextParagraphFiller, RegionTextPlacement,
+    WindowedParagraphPlanner,
 )
 
 __all__ = [
-    "EraseOptions", "EraseRectangle", "FittedParagraph", "PatchTextOptions", "PatchTextStyle", "PDFPatcher",
+    "EraseOptions", "EraseRectangle", "FillWindowPlan", "FittedParagraph", "HeadlineConstraintError",
+    "PatchTextOptions", "PatchTextStyle", "PDFPatcher",
     "PDFReplacement", "PDFReplacementRegion", "PDFSkippedReplacement", "PDFTranslationPipeline",
-    "QTextParagraphFiller", "RectangularEraser", "RegionTextPlacement",
+    "PlannedParagraph", "QTextParagraphFiller", "RectangularEraser", "RegionTextPlacement",
+    "WindowedParagraphPlanner",
 ]

--- a/pdf_craft/pipeline/pdf/patcher.py
+++ b/pdf_craft/pipeline/pdf/patcher.py
@@ -4,13 +4,13 @@ from collections.abc import Iterable
 from pathlib import Path
 from tempfile import NamedTemporaryFile, TemporaryDirectory
 
-from PIL import Image
-
 from pdf_craft.pdf.handler import DefaultPDFHandler, PDFHandler
 
 from .eraser import EraseOptions, EraseRectangle, RectangularEraser
 from .models import PDFReplacement, PDFReplacementRegion, PDFSkippedReplacement
-from .text_layout import FittedParagraph, PatchTextOptions, QTextParagraphFiller
+from .text_layout import (
+    FittedParagraph, PatchTextOptions, QTextParagraphFiller, WindowedParagraphPlanner,
+)
 
 
 class PDFPatcher:
@@ -66,32 +66,66 @@ class PDFPatcher:
             raise RuntimeError("PDF patching requires pypdf and reportlab") from error
 
         reader = pypdf.PdfReader(str(source_path))
-        replacement_list = list(replacements)
-        for replacement in replacement_list:
-            self.validate(replacement, pages_count=len(reader.pages))
-
         page_sizes = {
             index: (float(page.mediabox.width), float(page.mediabox.height))
             for index, page in enumerate(reader.pages, 1)
         }
-        fitted, skipped = self._preflight(replacement_list, page_sizes)
-        erasure_regions = tuple(
-            region for replacement, _ in fitted for region in replacement.source_regions()
-        )
-        erasures = self._eraser.plan(
-            erasure_regions,
-            page_sizes,
-            self._render_erasure_pages(source_path, erasure_regions),
-        )
+        def validated_replacements():
+            for replacement in replacements:
+                self.validate(replacement, pages_count=len(reader.pages))
+                yield replacement
 
-        erasures_by_page = self._group_erasures(erasures)
-        text_by_page = self._group_text_placements(fitted)
+        planner = WindowedParagraphPlanner(self._filler, page_sizes, self.options)
         writer = pypdf.PdfWriter()
+        next_page_index = 1
         with TemporaryDirectory() as temp_dir:
             root = Path(temp_dir)
-            for index, page in enumerate(reader.pages, 1):
+            for window in planner.plan(validated_replacements()):
+                for index in range(next_page_index, window.first_page_index):
+                    writer.add_page(reader.pages[index - 1])
+                self._compose_window(
+                    pypdf, canvas, source_path, reader, writer, root, page_sizes, window,
+                )
+                next_page_index = window.last_page_index + 1
+            for index in range(next_page_index, len(reader.pages) + 1):
+                writer.add_page(reader.pages[index - 1])
+
+        target_path.parent.mkdir(parents=True, exist_ok=True)
+        with NamedTemporaryFile(dir=target_path.parent, suffix=".pdf", delete=False) as output:
+            temporary_path = Path(output.name)
+            writer.write(output)
+        temporary_path.replace(target_path)
+        self.skipped_replacements = tuple(
+            PDFSkippedReplacement(replacement.page_index, replacement.bbox, str(reason))
+            for replacement, reason in planner.skipped
+        )
+
+    def _compose_window(
+        self, pypdf, canvas, source_path: Path, reader, writer, root: Path,
+        page_sizes: dict[int, tuple[float, float]], window,
+    ) -> None:
+        """Compose one window, retaining at most one source-page raster.
+
+        A cross-page paragraph can span an arbitrarily large number of pages,
+        so a completed typography plan is deliberately lightweight.  Its
+        erasure source rasters are rendered, sampled and closed per page here,
+        rather than collected in a window-wide image dictionary.
+        """
+        regions_by_page: dict[int, list[PDFReplacementRegion]] = {}
+        for planned in window.paragraphs:
+            for region in planned.replacement.source_regions():
+                regions_by_page.setdefault(region.page_index, []).append(region)
+        text_by_page = self._group_text_placements(
+            (planned.replacement, planned.paragraph) for planned in window.paragraphs
+        )
+        document = self._pdf_handler.open(source_path) if regions_by_page else None
+        try:
+            for index in range(window.first_page_index, window.last_page_index + 1):
+                page = reader.pages[index - 1]
                 page_width, page_height = page_sizes[index]
-                page_erasures = erasures_by_page.get(index, ())
+                page_erasures = self._plan_page_erasures(
+                    document, index, regions_by_page.get(index, ()), page_sizes,
+                )
                 if page_erasures:
                     erasure_path = root / f"erase-{index}.pdf"
                     self._write_erasure_overlay(canvas, erasure_path, page_width, page_height, page_erasures)
@@ -99,42 +133,34 @@ class PDFPatcher:
                 page_placements = text_by_page.get(index, ())
                 if page_placements:
                     text_path = root / f"text-{index}.pdf"
-                    self._filler.draw_pdf_overlay(
-                        text_path, (page_width, page_height), page_placements,
-                    )
+                    self._filler.draw_pdf_overlay(text_path, (page_width, page_height), page_placements)
                     page.merge_page(pypdf.PdfReader(str(text_path)).pages[0])
                 writer.add_page(page)
-
-        target_path.parent.mkdir(parents=True, exist_ok=True)
-        with NamedTemporaryFile(dir=target_path.parent, suffix=".pdf", delete=False) as output:
-            temporary_path = Path(output.name)
-            writer.write(output)
-        temporary_path.replace(target_path)
-        self.skipped_replacements = tuple(skipped)
-
-    def _render_erasure_pages(
-        self,
-        source_path: Path,
-        regions: tuple[PDFReplacementRegion, ...],
-    ) -> dict[int, Image.Image]:
-        """Render only pages that need color sampling, never for PDF output."""
-        page_dpi: dict[int, int] = {}
-        for region in regions:
-            previous = page_dpi.setdefault(region.page_index, region.dpi)
-            if previous != region.dpi:
-                raise ValueError(
-                    f"page {region.page_index} has incompatible erasure render DPI values"
-                )
-        if not page_dpi:
-            return {}
-        document = self._pdf_handler.open(source_path)
-        try:
-            return {
-                page_index: document.render_page(page_index, dpi)
-                for page_index, dpi in page_dpi.items()
-            }
         finally:
-            document.close()
+            if document is not None:
+                document.close()
+
+    def _plan_page_erasures(
+        self,
+        document,
+        page_index: int,
+        regions: Iterable[PDFReplacementRegion],
+        page_sizes: dict[int, tuple[float, float]],
+    ) -> tuple[EraseRectangle, ...]:
+        """Sample one source raster, plan that page's masks, then release it."""
+        page_regions = tuple(regions)
+        if not page_regions:
+            return ()
+        if document is None:  # Defensive: non-empty regions always opened it.
+            raise RuntimeError("source document is required for erasure")
+        dpi = page_regions[0].dpi
+        if any(region.dpi != dpi for region in page_regions[1:]):
+            raise ValueError(f"page {page_index} has incompatible erasure render DPI values")
+        page_image = document.render_page(page_index, dpi)
+        try:
+            return self._eraser.plan(page_regions, page_sizes, {page_index: page_image})
+        finally:
+            page_image.close()
 
     def validate(self, replacement: PDFReplacement, pages_count: int | None = None) -> None:
         if not replacement.text.strip():
@@ -144,27 +170,6 @@ class PDFPatcher:
             self._validate_single_region_matches_replacement(replacement, regions[0])
         for region in regions:
             self._validate_region(region, pages_count)
-
-    def _preflight(
-        self,
-        replacements: Iterable[PDFReplacement],
-        page_sizes: dict[int, tuple[float, float]],
-    ) -> tuple[tuple[tuple[PDFReplacement, FittedParagraph], ...], list[PDFSkippedReplacement]]:
-        fitted: list[tuple[PDFReplacement, FittedParagraph]] = []
-        skipped: list[PDFSkippedReplacement] = []
-        for replacement in replacements:
-            try:
-                fitted.append((replacement, self._filler.fit(replacement, page_sizes)))
-            except ValueError as error:
-                if self.options.overflow == "skip":
-                    skipped.append(PDFSkippedReplacement(
-                        replacement.page_index, replacement.bbox, str(error),
-                    ))
-                    continue
-                raise ValueError(
-                    f"page {replacement.page_index}, bbox {replacement.bbox}: {error}"
-                ) from error
-        return tuple(fitted), skipped
 
     @staticmethod
     def _validate_single_region_matches_replacement(

--- a/pdf_craft/pipeline/pdf/pipeline.py
+++ b/pdf_craft/pipeline/pdf/pipeline.py
@@ -1,6 +1,6 @@
 # pylint: disable=protected-access
 
-from collections.abc import Callable
+from collections.abc import Callable, Iterator
 from pathlib import Path
 from typing import cast
 
@@ -35,76 +35,86 @@ class PDFTranslationPipeline:
     ) -> None:
         extraction = _ensure_extraction(extraction)
         extraction.validate()
-        replacements: list[PDFReplacement] = []
         pages = extraction.page_pixel_sizes()
         render_dpi = extraction.render_dpi()
         with extraction._materialize() as paths:
             reader = create_chapters_reader(paths.chapters)
-            chapters = list(reader())
-            chapter_tasks = []
-            for chapter in chapters:
+            chapter_count = 0
+            total_characters = 0
+            for chapter in reader():
                 segments = list(search_text_segments(encode(chapter)))
                 if any(segment.text.strip() for segment in segments):
-                    chapter_tasks.append((chapter, sum(len(segment.text) for segment in segments)))
-            total_characters = sum(item[1] for item in chapter_tasks)
+                    chapter_count += 1
+                    total_characters += sum(len(segment.text) for segment in segments)
             if on_translation_event is not None:
                 on_translation_event(TranslationEvent(
                     kind=TranslationEventKind.START,
-                    chapter_count=len(chapter_tasks),
+                    chapter_count=chapter_count,
                     has_toc=False,
                     has_metadata=False,
                     total_characters=total_characters,
                     completed_characters=0,
                 ))
             completed_characters = 0
-            for chapter, character_count in chapter_tasks:
-                structured = not callable(transformer)
-                item_id = chapter.id if chapter.id is not None else "head"
-                is_xml_transformer = isinstance(transformer, ChapterXMLTransformer)
-                if on_translation_event is not None and not is_xml_transformer:
-                    on_translation_event(TranslationEvent(
-                        kind=TranslationEventKind.ITEM_START,
-                        item_kind=TranslationItemKind.CHAPTER,
-                        item_id=item_id,
-                        item_completed_characters=0,
-                        item_total_characters=character_count,
-                    ))
-                if is_xml_transformer:
-                    transformed = cast(ChapterXMLTransformer, transformer).transform(
-                        chapter,
-                        on_translation_event=on_translation_event,
-                        item_id=item_id,
-                        completed_characters=completed_characters,
-                        total_characters=total_characters,
-                        emit_scope_events=False,
+
+            def translated_replacements() -> Iterator[PDFReplacement]:
+                nonlocal completed_characters
+                for chapter in reader():
+                    segments = list(search_text_segments(encode(chapter)))
+                    if not any(segment.text.strip() for segment in segments):
+                        continue
+                    character_count = sum(len(segment.text) for segment in segments)
+                    structured = not callable(transformer)
+                    item_id = chapter.id if chapter.id is not None else "head"
+                    is_xml_transformer = isinstance(transformer, ChapterXMLTransformer)
+                    if on_translation_event is not None and not is_xml_transformer:
+                        on_translation_event(TranslationEvent(
+                            kind=TranslationEventKind.ITEM_START,
+                            item_kind=TranslationItemKind.CHAPTER,
+                            item_id=item_id,
+                            item_completed_characters=0,
+                            item_total_characters=character_count,
+                        ))
+                    if is_xml_transformer:
+                        transformed = cast(ChapterXMLTransformer, transformer).transform(
+                            chapter,
+                            on_translation_event=on_translation_event,
+                            item_id=item_id,
+                            completed_characters=completed_characters,
+                            total_characters=total_characters,
+                            emit_scope_events=False,
+                        )
+                    else:
+                        transformed = (
+                            cast(ChapterTransformer, transformer).transform(chapter)
+                            if structured else chapter
+                        )
+                    callback = transformer if callable(transformer) else (lambda text: text)
+                    yield from self._iter_chapter_replacements(
+                        transformed, callback, pages, render_dpi, structured,
                     )
-                else:
-                    transformed = transformer.transform(chapter) if structured else chapter
-                callback = transformer if callable(transformer) else (lambda text: text)
-                self._collect_chapter(
-                    transformed, callback, pages, replacements, render_dpi, structured
-                )
-                completed_characters += character_count
-                if on_translation_event is not None and not is_xml_transformer:
-                    on_translation_event(TranslationEvent(
-                        kind=TranslationEventKind.PROGRESS,
-                        item_kind=TranslationItemKind.CHAPTER,
-                        item_id=item_id,
-                        item_completed_characters=character_count,
-                        item_total_characters=character_count,
-                        completed_characters=completed_characters,
-                        total_characters=total_characters,
-                    ))
-                    on_translation_event(TranslationEvent(
-                        kind=TranslationEventKind.ITEM_COMPLETE,
-                        item_kind=TranslationItemKind.CHAPTER,
-                        item_id=item_id,
-                        item_completed_characters=character_count,
-                        item_total_characters=character_count,
-                        completed_characters=completed_characters,
-                        total_characters=total_characters,
-                    ))
-        self.patcher.patch(pdf_path, target_path, replacements)
+                    completed_characters += character_count
+                    if on_translation_event is not None and not is_xml_transformer:
+                        on_translation_event(TranslationEvent(
+                            kind=TranslationEventKind.PROGRESS,
+                            item_kind=TranslationItemKind.CHAPTER,
+                            item_id=item_id,
+                            item_completed_characters=character_count,
+                            item_total_characters=character_count,
+                            completed_characters=completed_characters,
+                            total_characters=total_characters,
+                        ))
+                        on_translation_event(TranslationEvent(
+                            kind=TranslationEventKind.ITEM_COMPLETE,
+                            item_kind=TranslationItemKind.CHAPTER,
+                            item_id=item_id,
+                            item_completed_characters=character_count,
+                            item_total_characters=character_count,
+                            completed_characters=completed_characters,
+                            total_characters=total_characters,
+                        ))
+
+            self.patcher.patch(pdf_path, target_path, translated_replacements())
         if on_translation_event is not None:
             on_translation_event(TranslationEvent(
                 kind=TranslationEventKind.COMPLETE,
@@ -126,21 +136,22 @@ class PDFTranslationPipeline:
         """
         extraction = _ensure_extraction(extraction)
         extraction.validate()
-        replacements: list[PDFReplacement] = []
         pages = extraction.page_pixel_sizes()
         render_dpi = extraction.render_dpi()
         with extraction._materialize() as paths:
             reader = create_chapters_reader(paths.chapters)
-            for chapter in reader():
-                self._collect_chapter(
-                    chapter, lambda text: text, pages, replacements, render_dpi, structured=True,
-                )
-        self.patcher.patch(pdf_path, target_path, replacements)
+            def replacements() -> Iterator[PDFReplacement]:
+                for chapter in reader():
+                    yield from self._iter_chapter_replacements(
+                        chapter, lambda text: text, pages, render_dpi, structured=True,
+                    )
 
-    def _collect_chapter(
-        self, chapter: Chapter, transformer, pages, replacements,
+            self.patcher.patch(pdf_path, target_path, replacements())
+
+    def _iter_chapter_replacements(
+        self, chapter: Chapter, transformer, pages,
         render_dpi: int, structured: bool = False,
-    ) -> None:
+    ) -> Iterator[PDFReplacement]:
         for layout in chapter.layouts:
             if not isinstance(layout, ParagraphLayout) or layout.ref not in {"text", "sub_title"}:
                 continue
@@ -165,11 +176,11 @@ class PDFTranslationPipeline:
                 continue
 
             first = regions[0]
-            replacements.append(PDFReplacement(
+            yield PDFReplacement(
                 first.page_index, first.bbox, translated, first.page_pixel_size, first.dpi,
                 reading_order=first.reading_order, regions=tuple(regions),
                 layout_ref=layout.ref, layout_level=layout.level,
-            ))
+            )
 
 
 def _to_patch_text(items) -> str:

--- a/pdf_craft/pipeline/pdf/text_layout.py
+++ b/pdf_craft/pipeline/pdf/text_layout.py
@@ -1,7 +1,7 @@
 """Paragraph flow backed by Qt's native ``QTextLayout`` engine."""
 # pylint: disable=no-member,c-extension-no-member
 
-from collections.abc import Mapping
+from collections.abc import Iterable, Iterator, Mapping
 from dataclasses import dataclass, field
 import os
 from pathlib import Path
@@ -29,6 +29,7 @@ class PatchTextStyle:
     vertical_padding: float = 1.0
     alignment: Alignment = "left"
     vertical_alignment: VerticalAlignment = "top"
+    minimum_body_font_ratio: float | None = None
 
 
 @dataclass(frozen=True)
@@ -51,6 +52,8 @@ class PatchTextOptions:
     alignment: Alignment = "left"
     vertical_alignment: VerticalAlignment = "top"
     styles: Mapping[str, PatchTextStyle] = field(default_factory=dict)
+    headline_min_body_ratio: float = 1.2
+    headline_fallback_font_size: float | None = None
     overflow: Literal["error", "skip"] = "error"
 
     def style_for(self, layout_ref: str, layout_level: int) -> PatchTextStyle:
@@ -68,6 +71,16 @@ class PatchTextOptions:
             vertical_alignment=self.vertical_alignment,
         )
         return self.styles.get(f"{layout_ref}:{layout_level}", self.styles.get(layout_ref, default))
+
+    def headline_ratio_for(self, layout_ref: str, layout_level: int) -> float:
+        """Return the configured lower-bound ratio for one headline level."""
+        style = self.style_for(layout_ref, layout_level)
+        ratio = style.minimum_body_font_ratio
+        if ratio is None:
+            ratio = self.headline_min_body_ratio
+        if ratio <= 0:
+            raise ValueError("headline minimum body font ratio must be positive")
+        return ratio
 
 
 @dataclass(frozen=True)
@@ -97,6 +110,42 @@ class FittedParagraph:
     placements: tuple[RegionTextPlacement, ...]
 
 
+@dataclass(frozen=True)
+class PlannedParagraph:
+    """One replacement and its finished paragraph-level fill plan."""
+
+    replacement: PDFReplacement
+    paragraph: FittedParagraph
+
+
+@dataclass(frozen=True)
+class FillWindowPlan:
+    """A contiguous, releasable set of pages planned in two layout phases.
+
+    The plan intentionally contains no page image or live Qt object. The PDF
+    composer can render and release each window without coupling typography to
+    erasure or retaining a whole book of page rasters.
+    """
+
+    first_page_index: int
+    last_page_index: int
+    paragraphs: tuple[PlannedParagraph, ...]
+
+
+class HeadlineConstraintError(ValueError):
+    """A headline cannot satisfy its configured body-relative font lower bound."""
+
+    def __init__(self, replacement: PDFReplacement, minimum_font_size: float, cause: ValueError) -> None:
+        self.replacement = replacement
+        self.minimum_font_size = minimum_font_size
+        self.__cause__ = cause
+        super().__init__(
+            f"page {replacement.page_index}, bbox {replacement.bbox}: "
+            "headline cannot satisfy body-relative minimum font size "
+            f"{minimum_font_size:.2f}: {cause}"
+        )
+
+
 class QTextParagraphFiller:
     """Lay one paragraph through ordered rectangles without splitting a line.
 
@@ -112,6 +161,7 @@ class QTextParagraphFiller:
         self,
         replacement: PDFReplacement,
         page_sizes: dict[int, tuple[float, float]],
+        minimum_font_size: float | None = None,
     ) -> FittedParagraph:
         """Return the largest quarter-point paragraph fitting every region."""
         text = " ".join(replacement.text.split())
@@ -120,7 +170,13 @@ class QTextParagraphFiller:
         style = self.options.style_for(replacement.layout_ref, replacement.layout_level)
         self._validate_style(style)
 
-        low = int(round(style.min_font_size * 4))
+        effective_minimum = max(style.min_font_size, minimum_font_size or style.min_font_size)
+        if effective_minimum > style.max_font_size:
+            raise ValueError(
+                f"requested minimum font size {effective_minimum:.2f} exceeds style maximum "
+                f"{style.max_font_size:.2f}"
+            )
+        low = int(round(effective_minimum * 4))
         high = int(round(style.max_font_size * 4))
         best: FittedParagraph | None = None
         while low <= high:
@@ -134,7 +190,7 @@ class QTextParagraphFiller:
         if best is None:
             raise ValueError(
                 "replacement text cannot fit paragraph source regions at minimum font size "
-                f"{style.min_font_size}"
+                f"{effective_minimum}"
             )
         return best
 
@@ -309,6 +365,160 @@ class QTextParagraphFiller:
             raise ValueError(f"unsupported text alignment: {style.alignment}")
         if style.vertical_alignment not in {"top", "center", "bottom"}:
             raise ValueError(f"unsupported vertical alignment: {style.vertical_alignment}")
+
+
+class WindowedParagraphPlanner:
+    """Plan body text before headlines while retaining only a page window.
+
+    Input replacements must be in reading order by their first source page.
+    A window closes as soon as no future paragraph can touch one of its pages;
+    this keeps page rasters and transient Qt layouts out of the book-wide
+    working set. Paragraphs themselves still retain one uniform font size over
+    every source region, including regions on later pages.
+    """
+
+    def __init__(
+        self,
+        filler: QTextParagraphFiller,
+        page_sizes: dict[int, tuple[float, float]],
+        options: PatchTextOptions | None = None,
+    ) -> None:
+        self._filler = filler
+        self._page_sizes = page_sizes
+        self._options = options or filler.options
+        self.skipped: list[tuple[PDFReplacement, ValueError]] = []
+        self._previous_body_font_size: float | None = None
+
+    def plan(self, replacements: Iterable[PDFReplacement]) -> Iterator[FillWindowPlan]:
+        """Yield completed windows in page order without retaining the full book."""
+        window: list[PDFReplacement] = []
+        first_page: int | None = None
+        last_page = 0
+        previous_first_page = 0
+        for replacement in replacements:
+            replacement_first, replacement_last = _replacement_page_span(replacement)
+            if replacement_first < previous_first_page:
+                raise ValueError("PDF replacements must be ordered by first source page")
+            previous_first_page = replacement_first
+            if window and replacement_first > last_page:
+                assert first_page is not None
+                yield self._plan_window(first_page, last_page, window)
+                window = []
+                first_page = None
+                last_page = 0
+            if first_page is None:
+                first_page = replacement_first
+            window.append(replacement)
+            last_page = max(last_page, replacement_last)
+        if window:
+            assert first_page is not None
+            yield self._plan_window(first_page, last_page, window)
+
+    def _plan_window(
+        self,
+        first_page: int,
+        last_page: int,
+        replacements: list[PDFReplacement],
+    ) -> FillWindowPlan:
+        body = [replacement for replacement in replacements if not _is_headline(replacement)]
+        headlines = [replacement for replacement in replacements if _is_headline(replacement)]
+        planned: list[PlannedParagraph] = []
+        body_font_sizes: dict[int, float] = {}
+
+        for replacement in body:
+            paragraph = self._fit_or_skip(replacement)
+            if paragraph is None:
+                continue
+            planned.append(PlannedParagraph(replacement, paragraph))
+            for placement in paragraph.placements:
+                body_font_sizes[placement.page_index] = max(
+                    body_font_sizes.get(placement.page_index, 0.0), paragraph.font_size,
+                )
+
+        for replacement in headlines:
+            minimum = self._headline_minimum(replacement, body_font_sizes)
+            try:
+                paragraph = self._filler.fit(replacement, self._page_sizes, minimum)
+            except ValueError as error:
+                constraint = HeadlineConstraintError(replacement, minimum, error)
+                if self._options.overflow == "skip":
+                    self.skipped.append((replacement, constraint))
+                    continue
+                raise constraint from error
+            planned.append(PlannedParagraph(replacement, paragraph))
+
+        if body_font_sizes:
+            latest_page = max(body_font_sizes)
+            self._previous_body_font_size = body_font_sizes[latest_page]
+        return FillWindowPlan(first_page, last_page, tuple(planned))
+
+    def _fit_or_skip(self, replacement: PDFReplacement) -> FittedParagraph | None:
+        try:
+            return self._filler.fit(replacement, self._page_sizes)
+        except ValueError as error:
+            if self._options.overflow == "skip":
+                self.skipped.append((replacement, error))
+                return None
+            raise _replacement_error(replacement, error) from error
+
+    def _headline_minimum(
+        self,
+        replacement: PDFReplacement,
+        body_font_sizes: Mapping[int, float],
+    ) -> float:
+        references = [
+            reference
+            for page_index in _replacement_pages(replacement)
+            if (reference := self._body_reference_for_page(page_index, body_font_sizes)) is not None
+        ]
+        reference = max(references) if references else None
+        style = self._options.style_for(replacement.layout_ref, replacement.layout_level)
+        if reference is None:
+            return max(style.min_font_size, self._options.headline_fallback_font_size or 0.0)
+        return max(
+            style.min_font_size,
+            reference * self._options.headline_ratio_for(
+                replacement.layout_ref, replacement.layout_level,
+            ),
+        )
+
+    def _body_reference_for_page(
+        self,
+        page_index: int,
+        body_font_sizes: Mapping[int, float],
+    ) -> float | None:
+        if page_index in body_font_sizes:
+            return body_font_sizes[page_index]
+        preceding = [page for page in body_font_sizes if page < page_index]
+        if preceding:
+            return body_font_sizes[max(preceding)]
+        if self._previous_body_font_size is not None:
+            return self._previous_body_font_size
+        following = [page for page in body_font_sizes if page > page_index]
+        if following:
+            return body_font_sizes[min(following)]
+        return None
+
+
+def _is_headline(replacement: PDFReplacement) -> bool:
+    """Use semantic chapter metadata, never image appearance, for title roles."""
+    return replacement.layout_ref == "sub_title"
+
+
+def _replacement_pages(replacement: PDFReplacement) -> tuple[int, ...]:
+    return tuple(sorted({region.page_index for region in replacement.source_regions()}))
+
+
+def _replacement_page_span(replacement: PDFReplacement) -> tuple[int, int]:
+    pages = _replacement_pages(replacement)
+    if not pages:  # source_regions always provides a legacy region, defensive only.
+        raise ValueError("PDF replacement has no source regions")
+    return pages[0], pages[-1]
+
+
+def _replacement_error(replacement: PDFReplacement, error: ValueError) -> ValueError:
+    """Give deferred streaming layout failures the old patcher context."""
+    return ValueError(f"page {replacement.page_index}, bbox {replacement.bbox}: {error}")
 
 
 def _python_index_for_utf16(text: str, utf16_index: int) -> int:

--- a/tests/test_pdf_layer_boundaries.py
+++ b/tests/test_pdf_layer_boundaries.py
@@ -1,0 +1,37 @@
+"""Static guards for the independent erasure and paragraph-fill layers."""
+
+import ast
+from pathlib import Path
+import unittest
+
+
+_PDF_PIPELINE = Path(__file__).parents[1] / "pdf_craft" / "pipeline" / "pdf"
+
+
+def _imports(path: Path) -> set[str]:
+    tree = ast.parse(path.read_text())
+    names: set[str] = set()
+    for node in ast.walk(tree):
+        if isinstance(node, ast.Import):
+            names.update(alias.name for alias in node.names)
+        elif isinstance(node, ast.ImportFrom) and node.module:
+            names.add(node.module)
+    return names
+
+
+class TestPDFLayerBoundaries(unittest.TestCase):
+    def test_text_filler_has_no_image_or_eraser_dependency(self):
+        imports = _imports(_PDF_PIPELINE / "text_layout.py")
+
+        self.assertFalse(any(name.startswith("PIL") for name in imports))
+        self.assertNotIn("eraser", imports)
+
+    def test_eraser_has_no_paragraph_or_translation_dependency(self):
+        path = _PDF_PIPELINE / "eraser.py"
+        imports = _imports(path)
+        source = path.read_text()
+
+        self.assertFalse(any(name.startswith("pdf_craft.extractor") for name in imports))
+        self.assertFalse(any(name.startswith("pdf_craft.transformer") for name in imports))
+        self.assertNotIn("ParagraphLayout", source)
+        self.assertNotIn("Translation", source)

--- a/tests/test_pdf_patcher.py
+++ b/tests/test_pdf_patcher.py
@@ -1,17 +1,18 @@
-# pylint: disable=no-member
+# pylint: disable=no-member,protected-access
 
 import tempfile
 import unittest
 from pathlib import Path
-from typing import Any
+from typing import Any, cast
 from unittest.mock import Mock
 
 import pypdf
 from PIL import Image
 from reportlab.pdfgen import canvas
 
+from pdf_craft.pdf.handler import PDFHandler
 from pdf_craft.pipeline.pdf import (
-    PDFPatcher, PDFReplacement, PDFReplacementRegion, PatchTextOptions,
+    FittedParagraph, PDFPatcher, PDFReplacement, PDFReplacementRegion, PatchTextOptions,
     QTextParagraphFiller,
 )
 
@@ -200,3 +201,84 @@ class TestPDFPatcher(unittest.TestCase):
 
             self.assertEqual(len(patcher.skipped_replacements), 1)
             self.assertIn("cannot fit paragraph source regions", patcher.skipped_replacements[0].reason)
+
+    def test_long_cross_page_window_releases_each_source_image_before_the_next(self):
+        """A single ParagraphLayout must not retain every page raster it spans."""
+        class TrackingImage:
+            def __init__(self, page_index):
+                self.page_index = page_index
+                self.closed = False
+
+            def close(self):
+                self.closed = True
+
+        class TrackingDocument:
+            def __init__(self):
+                self.images = []
+                self.closed = False
+
+            def render_page(self, page_index, _dpi):
+                if any(not image.closed for image in self.images):
+                    raise AssertionError("previous source image was retained")
+                image = TrackingImage(page_index)
+                self.images.append(image)
+                return image
+
+            def close(self):
+                self.closed = True
+
+        class TrackingHandler:
+            def __init__(self):
+                self.document = TrackingDocument()
+
+            def open(self, _source):
+                return self.document
+
+        class LightweightFiller:
+            def __init__(self, options):
+                self.options = options
+
+            @staticmethod
+            def fit(replacement, _page_sizes, _minimum_font_size=None):
+                return FittedParagraph(replacement.text, 10, ())
+
+        class RecordingEraser:
+            def __init__(self):
+                self.image_map_sizes = []
+
+            def plan(self, regions, _page_sizes, page_images):
+                self.image_map_sizes.append(len(page_images))
+                if len(tuple(regions)) != 1:
+                    raise AssertionError("page image must only serve its own regions")
+                return ()
+
+        with tempfile.TemporaryDirectory() as temp_dir:
+            root = Path(temp_dir)
+            source = root / "source.pdf"
+            target = root / "target.pdf"
+            doc = canvas.Canvas(str(source), pagesize=(100, 100))
+            for _ in range(8):
+                doc.showPage()
+            doc.save()
+            handler = TrackingHandler()
+            patcher = PDFPatcher(
+                options=PatchTextOptions(max_font_size=10, min_font_size=10),
+                pdf_handler=cast(PDFHandler, handler),
+            )
+            patcher._filler = LightweightFiller(patcher.options)  # type: ignore[assignment]
+            eraser = RecordingEraser()
+            patcher._eraser = eraser  # type: ignore[assignment]
+            regions = tuple(
+                PDFReplacementRegion(page_index, (1, 1, 99, 99), (100, 100))
+                for page_index in range(1, 9)
+            )
+            replacement = PDFReplacement(
+                1, regions[0].bbox, "long paragraph", (100, 100), regions=regions,
+            )
+
+            patcher.patch(source, target, [replacement])
+
+            self.assertEqual([image.page_index for image in handler.document.images], list(range(1, 9)))
+            self.assertTrue(all(image.closed for image in handler.document.images))
+            self.assertEqual(eraser.image_map_sizes, [1] * 8)
+            self.assertTrue(handler.document.closed)

--- a/tests/test_pdf_windowed_layout.py
+++ b/tests/test_pdf_windowed_layout.py
@@ -1,0 +1,137 @@
+import unittest
+
+from pdf_craft.pipeline.pdf import (
+    HeadlineConstraintError, PDFReplacement, PDFReplacementRegion,
+    PatchTextOptions, PatchTextStyle, QTextParagraphFiller, WindowedParagraphPlanner,
+)
+
+
+def _replacement(
+    text: str,
+    regions: list[PDFReplacementRegion],
+    *,
+    layout_ref: str = "text",
+    layout_level: int = 0,
+) -> PDFReplacement:
+    first = regions[0]
+    return PDFReplacement(
+        first.page_index, first.bbox, text, first.page_pixel_size,
+        regions=tuple(regions), layout_ref=layout_ref, layout_level=layout_level,
+    )
+
+
+def _region(page_index: int) -> PDFReplacementRegion:
+    return PDFReplacementRegion(page_index, (0, 0, 200, 100), (200, 100))
+
+
+def _line_region(page_index: int) -> PDFReplacementRegion:
+    return PDFReplacementRegion(page_index, (0, 0, 240, 32), (240, 100))
+
+
+class TestWindowedParagraphPlanner(unittest.TestCase):
+    def test_plans_body_before_headline_and_applies_page_body_minimum(self):
+        options = PatchTextOptions(
+            styles={
+                "text": PatchTextStyle(max_font_size=10, min_font_size=10),
+                "sub_title": PatchTextStyle(max_font_size=20, min_font_size=4),
+            },
+            headline_min_body_ratio=1.2,
+        )
+        planner = WindowedParagraphPlanner(
+            QTextParagraphFiller(options), {1: (200, 100)}, options,
+        )
+        headline = _replacement("Heading", [_region(1)], layout_ref="sub_title")
+        body = _replacement("Body", [_region(1)])
+
+        window = next(planner.plan([headline, body]))
+
+        self.assertEqual([item.replacement for item in window.paragraphs], [body, headline])
+        headline_plan = window.paragraphs[1].paragraph
+        self.assertGreaterEqual(headline_plan.font_size, 12)
+
+    def test_cross_page_body_and_headline_use_their_drawn_pages(self):
+        options = PatchTextOptions(
+            styles={
+                "text": PatchTextStyle(max_font_size=10, min_font_size=10),
+                "text:1": PatchTextStyle(max_font_size=12, min_font_size=12),
+                "sub_title": PatchTextStyle(max_font_size=16, min_font_size=4),
+            },
+            headline_min_body_ratio=1.3,
+        )
+        planner = WindowedParagraphPlanner(
+            QTextParagraphFiller(options), {1: (240, 100), 2: (240, 100)}, options,
+        )
+        headline = _replacement(
+            "one two three four five six seven eight",
+            [_line_region(1), _line_region(2)], layout_ref="sub_title",
+        )
+        body = _replacement(
+            "one two three four five six seven eight nine ten",
+            [_line_region(1), _line_region(2)],
+        )
+        larger_second_page_body = _replacement(
+            "extra", [_line_region(2)], layout_level=1,
+        )
+
+        window = next(planner.plan([headline, body, larger_second_page_body]))
+
+        body_plan = next(
+            item.paragraph for item in window.paragraphs if item.replacement is body
+        )
+        headline_plan = next(
+            item.paragraph for item in window.paragraphs if item.replacement is headline
+        )
+        self.assertEqual({placement.page_index for placement in body_plan.placements}, {1, 2})
+        self.assertEqual({placement.page_index for placement in headline_plan.placements}, {1, 2})
+        self.assertGreaterEqual(headline_plan.font_size, 15.6)
+
+    def test_headline_without_a_body_uses_configured_deterministic_fallback(self):
+        options = PatchTextOptions(
+            styles={"sub_title": PatchTextStyle(max_font_size=20, min_font_size=4)},
+            headline_fallback_font_size=14,
+        )
+        planner = WindowedParagraphPlanner(
+            QTextParagraphFiller(options), {1: (200, 100)}, options,
+        )
+
+        window = next(planner.plan([
+            _replacement("Heading", [_region(1)], layout_ref="sub_title"),
+        ]))
+
+        self.assertGreaterEqual(window.paragraphs[0].paragraph.font_size, 14)
+
+    def test_fails_explicitly_when_headline_cannot_meet_body_constraint(self):
+        options = PatchTextOptions(
+            styles={
+                "text": PatchTextStyle(max_font_size=10, min_font_size=10),
+                "sub_title": PatchTextStyle(max_font_size=11, min_font_size=4),
+            },
+            headline_min_body_ratio=1.2,
+        )
+        planner = WindowedParagraphPlanner(
+            QTextParagraphFiller(options), {1: (200, 100)}, options,
+        )
+
+        with self.assertRaises(HeadlineConstraintError):
+            list(planner.plan([
+                _replacement("Body", [_region(1)]),
+                _replacement("Heading", [_region(1)], layout_ref="sub_title"),
+            ]))
+
+    def test_emits_a_closed_window_before_consuming_later_pages(self):
+        options = PatchTextOptions(max_font_size=10, min_font_size=10)
+        planner = WindowedParagraphPlanner(
+            QTextParagraphFiller(options), {1: (200, 100), 2: (200, 100), 3: (200, 100)}, options,
+        )
+        consumed: list[int] = []
+
+        def source():
+            for page_index in (1, 2, 3):
+                consumed.append(page_index)
+                yield _replacement(f"page {page_index}", [_region(page_index)])
+
+        windows = planner.plan(source())
+        first = next(windows)
+
+        self.assertEqual((first.first_page_index, first.last_page_index), (1, 1))
+        self.assertEqual(consumed, [1, 2])


### PR DESCRIPTION
## Summary
- plan body paragraphs before subtitles in bounded page windows
- enforce configurable headline-to-body font-size lower bounds
- release each erasure source raster page-by-page, including long cross-page paragraphs
- document configuration and add coverage for cross-page layout and layer boundaries

## Verification
- `pytest` selected PDF layout/patching suite: 42 passed
- `ruff`, `pylint`, and `pyright` passed