### PR TITLE
fix: reserve default headline font headroom

### DIFF
--- a/docs/en/PDF_TRANSLATION.md
+++ b/docs/en/PDF_TRANSLATION.md
@@ -166,6 +166,8 @@ PDF patching treats each `ParagraphLayout` as one text flow, even when it has so
 
 Within a releasable page window, `text` paragraphs are fitted before `sub_title` paragraphs. The largest fitted body size on every page touched by a headline becomes the headline's lower bound, multiplied by `headline_min_body_ratio` (default `1.2`). A semantic style can override that ratio with `minimum_body_font_ratio`; the normal fitting search may still choose a larger title size when its boxes permit it.
 
+When no `sub_title` style is configured, its default maximum reserves this body-relative headroom automatically. An explicitly configured `sub_title` or `sub_title:<level>` maximum remains a hard limit; set it high enough for the selected ratio or use `overflow="skip"` for titles that cannot fit.
+
 ```python
 options = PatchTextOptions(
     styles={

--- a/docs/zh-CN/PDF_TRANSLATION.md
+++ b/docs/zh-CN/PDF_TRANSLATION.md
@@ -240,6 +240,8 @@ PDF 写回把一个 `ParagraphLayout` 视为一段连续文本流，即使它的
 
 在一个可释放的页面窗口中，`text` 正文会先于 `sub_title` 标题完成排版。标题涉及的每一页中，
 已排版正文的最大字号乘以 `headline_min_body_ratio`（默认 `1.2`）后，构成标题字号的下限。
+
+未配置 `sub_title` 样式时，默认标题字号上限会自动预留这部分相对正文的余量。显式配置的 `sub_title` 或 `sub_title:<level>` 上限仍是硬约束；应将其设为足以容纳所选比例的值，或对无法容纳的标题使用 `overflow="skip"`。
 某个语义样式可以通过 `minimum_body_font_ratio` 覆盖此比例；如果标题 bbox 仍有空间，常规的
 字号搜索仍会选择大于该下限的字号。
 

--- a/pdf_craft/pipeline/pdf/text_layout.py
+++ b/pdf_craft/pipeline/pdf/text_layout.py
@@ -3,6 +3,7 @@
 
 from collections.abc import Iterable, Iterator, Mapping
 from dataclasses import dataclass, field
+from math import ceil
 import os
 from pathlib import Path
 from typing import Literal
@@ -57,7 +58,18 @@ class PatchTextOptions:
     overflow: Literal["error", "skip"] = "error"
 
     def style_for(self, layout_ref: str, layout_level: int) -> PatchTextStyle:
-        """Resolve the most specific configured semantic text style."""
+        """Resolve the most specific configured semantic text style.
+
+        An implicit headline style reserves enough of the scalar default range
+        to meet the default body-relative minimum.  Explicit headline styles
+        remain hard user limits and are therefore returned unchanged.
+        """
+        specific = self.styles.get(f"{layout_ref}:{layout_level}")
+        if specific is not None:
+            return specific
+        generic = self.styles.get(layout_ref)
+        if generic is not None:
+            return generic
         default = PatchTextStyle(
             font_name=self.font_name,
             fallback_fonts=self.fallback_fonts,
@@ -70,7 +82,21 @@ class PatchTextOptions:
             alignment=self.alignment,
             vertical_alignment=self.vertical_alignment,
         )
-        return self.styles.get(f"{layout_ref}:{layout_level}", self.styles.get(layout_ref, default))
+        if layout_ref == "sub_title":
+            minimum_maximum = ceil(self.max_font_size * self.headline_min_body_ratio * 4) / 4
+            return PatchTextStyle(
+                font_name=default.font_name,
+                fallback_fonts=default.fallback_fonts,
+                max_font_size=max(default.max_font_size, minimum_maximum),
+                min_font_size=default.min_font_size,
+                font_weight=default.font_weight,
+                line_height=default.line_height,
+                horizontal_padding=default.horizontal_padding,
+                vertical_padding=default.vertical_padding,
+                alignment=default.alignment,
+                vertical_alignment=default.vertical_alignment,
+            )
+        return default
 
     def headline_ratio_for(self, layout_ref: str, layout_level: int) -> float:
         """Return the configured lower-bound ratio for one headline level."""

--- a/tests/test_pdf_windowed_layout.py
+++ b/tests/test_pdf_windowed_layout.py
@@ -29,6 +29,20 @@ def _line_region(page_index: int) -> PDFReplacementRegion:
 
 
 class TestWindowedParagraphPlanner(unittest.TestCase):
+    def test_default_style_reserves_headline_font_size_headroom(self):
+        options = PatchTextOptions()
+        planner = WindowedParagraphPlanner(
+            QTextParagraphFiller(options), {1: (200, 100)}, options,
+        )
+        headline = _replacement("Heading", [_region(1)], layout_ref="sub_title")
+        body = _replacement("Body", [_region(1)])
+
+        window = next(planner.plan([headline, body]))
+
+        body_plan, headline_plan = (item.paragraph for item in window.paragraphs)
+        self.assertEqual(body_plan.font_size, 12)
+        self.assertGreaterEqual(headline_plan.font_size, body_plan.font_size * 1.2)
+
     def test_plans_body_before_headline_and_applies_page_body_minimum(self):
         options = PatchTextOptions(
             styles={
@@ -117,6 +131,29 @@ class TestWindowedParagraphPlanner(unittest.TestCase):
                 _replacement("Body", [_region(1)]),
                 _replacement("Heading", [_region(1)], layout_ref="sub_title"),
             ]))
+
+    def test_explicit_headline_level_style_remains_a_hard_limit_when_skipped(self):
+        options = PatchTextOptions(
+            styles={
+                "text": PatchTextStyle(max_font_size=10, min_font_size=10),
+                "sub_title:2": PatchTextStyle(max_font_size=11, min_font_size=4),
+            },
+            headline_min_body_ratio=1.2,
+            overflow="skip",
+        )
+        planner = WindowedParagraphPlanner(
+            QTextParagraphFiller(options), {1: (200, 100)}, options,
+        )
+        body = _replacement("Body", [_region(1)])
+        headline = _replacement(
+            "Heading", [_region(1)], layout_ref="sub_title", layout_level=2,
+        )
+
+        window = next(planner.plan([body, headline]))
+
+        self.assertEqual([item.replacement for item in window.paragraphs], [body])
+        self.assertEqual(planner.skipped[0][0], headline)
+        self.assertIsInstance(planner.skipped[0][1], HeadlineConstraintError)
 
     def test_emits_a_closed_window_before_consuming_later_pages(self):
         options = PatchTextOptions(max_font_size=10, min_font_size=10)


### PR DESCRIPTION
## Summary
- reserve an implicit sub_title maximum for the default body-relative headline rule
- preserve explicit headline style maximums as hard limits
- add Qt layout regressions and document the default versus explicit behavior

## Verification
- poetry run python test.py
- poetry run pyright pdf_craft tests
- poetry run pylint pdf_craft tests