### PR TITLE
refactor: stream PDF paragraph layout plans

### DIFF
--- a/pdf_craft/pipeline/pdf/patcher.py
+++ b/pdf_craft/pipeline/pdf/patcher.py
@@ -9,7 +9,7 @@ from pdf_craft.pdf.handler import DefaultPDFHandler, PDFHandler
 from .eraser import EraseOptions, EraseRectangle, RectangularEraser
 from .models import PDFReplacement, PDFReplacementRegion, PDFSkippedReplacement
 from .text_layout import (
-    FittedParagraph, PatchTextOptions, QTextParagraphFiller, WindowedParagraphPlanner,
+    PatchTextOptions, QTextParagraphFiller, WindowedParagraphPlanner,
 )
 
 
@@ -104,33 +104,32 @@ class PDFPatcher:
         self, pypdf, canvas, source_path: Path, reader, writer, root: Path,
         page_sizes: dict[int, tuple[float, float]], window,
     ) -> None:
-        """Compose one window, retaining at most one source-page raster.
-
-        A cross-page paragraph can span an arbitrarily large number of pages,
-        so a completed typography plan is deliberately lightweight.  Its
-        erasure source rasters are rendered, sampled and closed per page here,
-        rather than collected in a window-wide image dictionary.
-        """
-        regions_by_page: dict[int, list[PDFReplacementRegion]] = {}
-        for planned in window.paragraphs:
-            for region in planned.replacement.source_regions():
-                regions_by_page.setdefault(region.page_index, []).append(region)
-        text_by_page = self._group_text_placements(
-            (planned.replacement, planned.paragraph) for planned in window.paragraphs
-        )
-        document = self._pdf_handler.open(source_path) if regions_by_page else None
+        """Compose one window while loading one serialized page plan at a time."""
+        document = None
         try:
+            if window.has_page_contributions:
+                document = self._pdf_handler.open(source_path)
             for index in range(window.first_page_index, window.last_page_index + 1):
                 page = reader.pages[index - 1]
                 page_width, page_height = page_sizes[index]
+                contributions = tuple(window.page_contributions(index))
+                page_regions = tuple(
+                    region
+                    for contribution in contributions
+                    for region in contribution.regions
+                )
                 page_erasures = self._plan_page_erasures(
-                    document, index, regions_by_page.get(index, ()), page_sizes,
+                    document, index, page_regions, page_sizes,
                 )
                 if page_erasures:
                     erasure_path = root / f"erase-{index}.pdf"
                     self._write_erasure_overlay(canvas, erasure_path, page_width, page_height, page_erasures)
                     page.merge_page(pypdf.PdfReader(str(erasure_path)).pages[0])
-                page_placements = text_by_page.get(index, ())
+                page_placements = tuple(
+                    placement
+                    for contribution in contributions
+                    for placement in contribution.placements
+                )
                 if page_placements:
                     text_path = root / f"text-{index}.pdf"
                     self._filler.draw_pdf_overlay(text_path, (page_width, page_height), page_placements)
@@ -139,6 +138,7 @@ class PDFPatcher:
         finally:
             if document is not None:
                 document.close()
+            window.close()
 
     def _plan_page_erasures(
         self,
@@ -205,18 +205,3 @@ class PDFPatcher:
         overlay = canvas.Canvas(str(output_path), pagesize=(width, height))
         self._eraser.draw(overlay, erasures, height)
         overlay.save()
-
-    @staticmethod
-    def _group_erasures(erasures: Iterable[EraseRectangle]) -> dict[int, tuple[EraseRectangle, ...]]:
-        result: dict[int, list[EraseRectangle]] = {}
-        for erase in erasures:
-            result.setdefault(erase.page_index, []).append(erase)
-        return {page_index: tuple(items) for page_index, items in result.items()}
-
-    @staticmethod
-    def _group_text_placements(fitted: Iterable[tuple[PDFReplacement, FittedParagraph]]):
-        result = {}
-        for _, paragraph in fitted:
-            for placement in paragraph.placements:
-                result.setdefault(placement.page_index, []).append(placement)
-        return {page_index: tuple(items) for page_index, items in result.items()}

--- a/pdf_craft/pipeline/pdf/text_layout.py
+++ b/pdf_craft/pipeline/pdf/text_layout.py
@@ -4,11 +4,13 @@
 from collections.abc import Iterable, Iterator, Mapping
 from dataclasses import dataclass, field
 import os
+import pickle
 from pathlib import Path
+from tempfile import TemporaryDirectory
 from typing import Literal
 
 from .geometry import PageRectangle, region_in_page_points
-from .models import PDFReplacement
+from .models import PDFReplacement, PDFReplacementRegion
 
 
 Alignment = Literal["left", "center", "right", "justify"]
@@ -119,17 +121,130 @@ class PlannedParagraph:
 
 
 @dataclass(frozen=True)
+class _PlannedParagraphSummary:
+    """The small, paragraph-wide state retained after placements are spooled."""
+
+    replacement: PDFReplacement
+    text: str
+    font_size: float
+
+
+@dataclass(frozen=True)
+class _PagePlanContribution:
+    """One paragraph's erase and text work for one output page."""
+
+    paragraph_index: int
+    regions: tuple[PDFReplacementRegion, ...]
+    placements: tuple[RegionTextPlacement, ...]
+
+
+class _WindowPlanStorage:
+    """Append serialized page contributions while a window is being measured."""
+
+    def __init__(self) -> None:
+        self._temporary_directory = TemporaryDirectory(prefix="pdf-craft-layout-")
+        self._root = Path(self._temporary_directory.name)
+        self._page_plan_paths: dict[int, Path] = {}
+
+    def append(
+        self,
+        paragraph_index: int,
+        replacement: PDFReplacement,
+        paragraph: FittedParagraph,
+    ) -> None:
+        regions_by_page: dict[int, list[PDFReplacementRegion]] = {}
+        for region in replacement.source_regions():
+            regions_by_page.setdefault(region.page_index, []).append(region)
+        placements_by_page: dict[int, list[RegionTextPlacement]] = {}
+        for placement in paragraph.placements:
+            placements_by_page.setdefault(placement.page_index, []).append(placement)
+        for page_index in sorted(regions_by_page | placements_by_page):
+            contribution = _PagePlanContribution(
+                paragraph_index,
+                tuple(regions_by_page.get(page_index, ())),
+                tuple(placements_by_page.get(page_index, ())),
+            )
+            path = self._page_plan_paths.setdefault(
+                page_index, self._root / f"page-{page_index}.pickle",
+            )
+            with path.open("ab") as stream:
+                pickle.dump(contribution, stream, protocol=pickle.HIGHEST_PROTOCOL)
+
+    def into_plan(
+        self,
+        first_page_index: int,
+        last_page_index: int,
+        summaries: tuple[_PlannedParagraphSummary, ...],
+    ) -> "FillWindowPlan":
+        return FillWindowPlan(
+            first_page_index,
+            last_page_index,
+            summaries,
+            self._page_plan_paths,
+            self._temporary_directory,
+        )
+
+    def close(self) -> None:
+        self._temporary_directory.cleanup()
+
+
+@dataclass
 class FillWindowPlan:
     """A contiguous, releasable set of pages planned in two layout phases.
 
-    The plan intentionally contains no page image or live Qt object. The PDF
-    composer can render and release each window without coupling typography to
-    erasure or retaining a whole book of page rasters.
+    Detailed placements are serialized by page rather than retained in the
+    window object. The PDF composer can therefore load one page's work, render
+    it, and release it without coupling typography to erasure or retaining a
+    whole book of page rasters or a very long paragraph's glyph coordinates.
     """
 
     first_page_index: int
     last_page_index: int
-    paragraphs: tuple[PlannedParagraph, ...]
+    _summaries: tuple[_PlannedParagraphSummary, ...]
+    _page_plan_paths: Mapping[int, Path]
+    _temporary_directory: TemporaryDirectory
+
+    @property
+    def has_page_contributions(self) -> bool:
+        """Whether this window has any page work to compose."""
+        return bool(self._page_plan_paths)
+
+    def page_contributions(self, page_index: int) -> Iterator[_PagePlanContribution]:
+        """Yield the serialized text and erase work for one page only."""
+        try:
+            path = self._page_plan_paths[page_index]
+        except KeyError:
+            return
+        with path.open("rb") as stream:
+            while True:
+                try:
+                    yield pickle.load(stream)
+                except EOFError:
+                    return
+
+    @property
+    def paragraphs(self) -> tuple[PlannedParagraph, ...]:
+        """Materialize all placements for compatibility with plan inspection.
+
+        Production composition deliberately uses :meth:`page_contributions`.
+        Callers that inspect this compatibility view explicitly opt into the
+        corresponding whole-window allocation.
+        """
+        placements = [[] for _ in self._summaries]
+        for page_index in range(self.first_page_index, self.last_page_index + 1):
+            for contribution in self.page_contributions(page_index):
+                placements[contribution.paragraph_index].extend(contribution.placements)
+        return tuple(
+            PlannedParagraph(
+                summary.replacement,
+                FittedParagraph(summary.text, summary.font_size, tuple(placements[index])),
+            )
+            for index, summary in enumerate(self._summaries)
+        )
+
+    def close(self) -> None:
+        """Release serialized placement files once the window has been composed."""
+        self._temporary_directory.cleanup()
 
 
 class HeadlineConstraintError(ValueError):
@@ -422,35 +537,48 @@ class WindowedParagraphPlanner:
     ) -> FillWindowPlan:
         body = [replacement for replacement in replacements if not _is_headline(replacement)]
         headlines = [replacement for replacement in replacements if _is_headline(replacement)]
-        planned: list[PlannedParagraph] = []
+        summaries: list[_PlannedParagraphSummary] = []
         body_font_sizes: dict[int, float] = {}
+        storage = _WindowPlanStorage()
 
-        for replacement in body:
-            paragraph = self._fit_or_skip(replacement)
-            if paragraph is None:
-                continue
-            planned.append(PlannedParagraph(replacement, paragraph))
-            for placement in paragraph.placements:
-                body_font_sizes[placement.page_index] = max(
-                    body_font_sizes.get(placement.page_index, 0.0), paragraph.font_size,
-                )
-
-        for replacement in headlines:
-            minimum = self._headline_minimum(replacement, body_font_sizes)
-            try:
-                paragraph = self._filler.fit(replacement, self._page_sizes, minimum)
-            except ValueError as error:
-                constraint = HeadlineConstraintError(replacement, minimum, error)
-                if self._options.overflow == "skip":
-                    self.skipped.append((replacement, constraint))
+        try:
+            for replacement in body:
+                paragraph = self._fit_or_skip(replacement)
+                if paragraph is None:
                     continue
-                raise constraint from error
-            planned.append(PlannedParagraph(replacement, paragraph))
+                paragraph_index = len(summaries)
+                summaries.append(_PlannedParagraphSummary(
+                    replacement, paragraph.text, paragraph.font_size,
+                ))
+                for placement in paragraph.placements:
+                    body_font_sizes[placement.page_index] = max(
+                        body_font_sizes.get(placement.page_index, 0.0), paragraph.font_size,
+                    )
+                storage.append(paragraph_index, replacement, paragraph)
 
-        if body_font_sizes:
-            latest_page = max(body_font_sizes)
-            self._previous_body_font_size = body_font_sizes[latest_page]
-        return FillWindowPlan(first_page, last_page, tuple(planned))
+            for replacement in headlines:
+                minimum = self._headline_minimum(replacement, body_font_sizes)
+                try:
+                    paragraph = self._filler.fit(replacement, self._page_sizes, minimum)
+                except ValueError as error:
+                    constraint = HeadlineConstraintError(replacement, minimum, error)
+                    if self._options.overflow == "skip":
+                        self.skipped.append((replacement, constraint))
+                        continue
+                    raise constraint from error
+                paragraph_index = len(summaries)
+                summaries.append(_PlannedParagraphSummary(
+                    replacement, paragraph.text, paragraph.font_size,
+                ))
+                storage.append(paragraph_index, replacement, paragraph)
+
+            if body_font_sizes:
+                latest_page = max(body_font_sizes)
+                self._previous_body_font_size = body_font_sizes[latest_page]
+            return storage.into_plan(first_page, last_page, tuple(summaries))
+        except Exception:
+            storage.close()
+            raise
 
     def _fit_or_skip(self, replacement: PDFReplacement) -> FittedParagraph | None:
         try:

--- a/tests/test_pdf_patcher.py
+++ b/tests/test_pdf_patcher.py
@@ -4,7 +4,7 @@ import tempfile
 import unittest
 from pathlib import Path
 from typing import Any, cast
-from unittest.mock import Mock
+from unittest.mock import Mock, patch
 
 import pypdf
 from PIL import Image
@@ -12,7 +12,7 @@ from reportlab.pdfgen import canvas
 
 from pdf_craft.pdf.handler import PDFHandler
 from pdf_craft.pipeline.pdf import (
-    FittedParagraph, PDFPatcher, PDFReplacement, PDFReplacementRegion, PatchTextOptions,
+    FillWindowPlan, FittedParagraph, PDFPatcher, PDFReplacement, PDFReplacementRegion, PatchTextOptions,
     QTextParagraphFiller,
 )
 
@@ -203,7 +203,7 @@ class TestPDFPatcher(unittest.TestCase):
             self.assertIn("cannot fit paragraph source regions", patcher.skipped_replacements[0].reason)
 
     def test_long_cross_page_window_releases_each_source_image_before_the_next(self):
-        """A single ParagraphLayout must not retain every page raster it spans."""
+        """Composition consumes serialized page work without materializing a whole window."""
         class TrackingImage:
             def __init__(self, page_index):
                 self.page_index = page_index
@@ -276,7 +276,11 @@ class TestPDFPatcher(unittest.TestCase):
                 1, regions[0].bbox, "long paragraph", (100, 100), regions=regions,
             )
 
-            patcher.patch(source, target, [replacement])
+            def fail_if_materialized(_plan):
+                raise AssertionError("patcher must stream page contributions")
+
+            with patch.object(FillWindowPlan, "paragraphs", new=property(fail_if_materialized)):
+                patcher.patch(source, target, [replacement])
 
             self.assertEqual([image.page_index for image in handler.document.images], list(range(1, 9)))
             self.assertTrue(all(image.closed for image in handler.document.images))

--- a/tests/test_pdf_windowed_layout.py
+++ b/tests/test_pdf_windowed_layout.py
@@ -1,4 +1,5 @@
 import unittest
+from pathlib import Path
 
 from pdf_craft.pipeline.pdf import (
     HeadlineConstraintError, PDFReplacement, PDFReplacementRegion,
@@ -135,3 +136,43 @@ class TestWindowedParagraphPlanner(unittest.TestCase):
 
         self.assertEqual((first.first_page_index, first.last_page_index), (1, 1))
         self.assertEqual(consumed, [1, 2])
+
+    def test_serializes_long_paragraph_placements_by_page(self):
+        """A long paragraph keeps summaries in memory, not every glyph placement."""
+        page_count = 24
+        regions = [
+            PDFReplacementRegion(page_index, (0, 0, 240, 32), (240, 100))
+            for page_index in range(1, page_count + 1)
+        ]
+        replacement = _replacement(
+            "one two three four five six seven " * 30, regions,
+        )
+        options = PatchTextOptions(max_font_size=8, min_font_size=8)
+        planner = WindowedParagraphPlanner(
+            QTextParagraphFiller(options),
+            {page_index: (240, 100) for page_index in range(1, page_count + 1)},
+            options,
+        )
+
+        window = next(planner.plan([replacement]))
+        temporary_root = Path(window._temporary_directory.name)  # pylint: disable=protected-access
+        try:
+            self.assertEqual(len(window._summaries), 1)  # pylint: disable=protected-access
+            self.assertFalse(hasattr(window._summaries[0], "placements"))  # pylint: disable=protected-access
+            self.assertTrue(temporary_root.is_dir())
+
+            active_pages = []
+            for page_index in range(1, page_count + 1):
+                contributions = tuple(window.page_contributions(page_index))
+                self.assertEqual(len(contributions), 1)
+                self.assertEqual(contributions[0].regions, (regions[page_index - 1],))
+                if contributions[0].placements:
+                    active_pages.append(page_index)
+                    self.assertTrue(all(
+                        placement.page_index == page_index
+                        for placement in contributions[0].placements
+                    ))
+            self.assertGreater(len(active_pages), 1)
+        finally:
+            window.close()
+        self.assertFalse(temporary_root.exists())


### PR DESCRIPTION
## Summary\n- serialize completed paragraph placements per page instead of retaining a cross-page window-wide tuple\n- stream each page's erasure and Qt text contributions during PDF composition\n- cover long ParagraphLayout plan release and prevent patcher from materializing the compatibility view\n\n## Verification\n- poetry run python test.py (342 passed)\n- poetry run pyright pdf_craft tests\n- poetry run pylint pdf_craft tests