### PR TITLE
fix: derive implicit headline limits from body layout

### DIFF
--- a/docs/en/PDF_TRANSLATION.md
+++ b/docs/en/PDF_TRANSLATION.md
@@ -166,7 +166,7 @@ PDF patching treats each `ParagraphLayout` as one text flow, even when it has so
 
 Within a releasable page window, `text` paragraphs are fitted before `sub_title` paragraphs. The largest fitted body size on every page touched by a headline becomes the headline's lower bound, multiplied by `headline_min_body_ratio` (default `1.2`). A semantic style can override that ratio with `minimum_body_font_ratio`; the normal fitting search may still choose a larger title size when its boxes permit it.
 
-When no `sub_title` style is configured, its default maximum reserves this body-relative headroom automatically. An explicitly configured `sub_title` or `sub_title:<level>` maximum remains a hard limit; set it high enough for the selected ratio or use `overflow="skip"` for titles that cannot fit.
+When no `sub_title` style is configured, its effective maximum expands to meet the actual body-relative lower bound, including one introduced by a `text` or `text:<level>` style. An explicitly configured `sub_title` or `sub_title:<level>` maximum remains a hard limit; set it high enough for the selected ratio or use `overflow="skip"` for titles that cannot fit.
 
 ```python
 options = PatchTextOptions(

--- a/docs/zh-CN/PDF_TRANSLATION.md
+++ b/docs/zh-CN/PDF_TRANSLATION.md
@@ -241,7 +241,7 @@ PDF 写回把一个 `ParagraphLayout` 视为一段连续文本流，即使它的
 在一个可释放的页面窗口中，`text` 正文会先于 `sub_title` 标题完成排版。标题涉及的每一页中，
 已排版正文的最大字号乘以 `headline_min_body_ratio`（默认 `1.2`）后，构成标题字号的下限。
 
-未配置 `sub_title` 样式时，默认标题字号上限会自动预留这部分相对正文的余量。显式配置的 `sub_title` 或 `sub_title:<level>` 上限仍是硬约束；应将其设为足以容纳所选比例的值，或对无法容纳的标题使用 `overflow="skip"`。
+未配置 `sub_title` 样式时，标题的有效上限会自动扩展到实际正文相对下限，即使该下限来自 `text` 或 `text:<level>` 样式。显式配置的 `sub_title` 或 `sub_title:<level>` 上限仍是硬约束；应将其设为足以容纳所选比例的值，或对无法容纳的标题使用 `overflow="skip"`。
 某个语义样式可以通过 `minimum_body_font_ratio` 覆盖此比例；如果标题 bbox 仍有空间，常规的
 字号搜索仍会选择大于该下限的字号。
 

--- a/pdf_craft/pipeline/pdf/text_layout.py
+++ b/pdf_craft/pipeline/pdf/text_layout.py
@@ -2,8 +2,8 @@
 # pylint: disable=no-member,c-extension-no-member
 
 from collections.abc import Iterable, Iterator, Mapping
-from dataclasses import dataclass, field
-from math import ceil
+from dataclasses import dataclass, field, replace
+from math import ceil, floor
 import os
 import pickle
 from pathlib import Path
@@ -85,7 +85,9 @@ class PatchTextOptions:
             vertical_alignment=self.vertical_alignment,
         )
         if layout_ref == "sub_title":
-            minimum_maximum = ceil(self.max_font_size * self.headline_min_body_ratio * 4) / 4
+            minimum_maximum = _ceil_quarter(
+                self.max_font_size * self.headline_min_body_ratio,
+            )
             return PatchTextStyle(
                 font_name=default.font_name,
                 fallback_fonts=default.fallback_fonts,
@@ -109,7 +111,6 @@ class PatchTextOptions:
         if ratio <= 0:
             raise ValueError("headline minimum body font ratio must be positive")
         return ratio
-
 
 @dataclass(frozen=True)
 class RegionTextPlacement:
@@ -309,6 +310,18 @@ class QTextParagraphFiller:
         if not text:
             raise ValueError("replacement text must not be empty")
         style = self.options.style_for(replacement.layout_ref, replacement.layout_level)
+        if (
+            replacement.layout_ref == "sub_title"
+            and not _has_explicit_style(
+                self.options,
+                replacement.layout_ref, replacement.layout_level,
+            )
+            and minimum_font_size is not None
+        ):
+            style = replace(
+                style,
+                max_font_size=max(style.max_font_size, _ceil_quarter(minimum_font_size)),
+            )
         self._validate_style(style)
 
         effective_minimum = max(style.min_font_size, minimum_font_size or style.min_font_size)
@@ -317,8 +330,8 @@ class QTextParagraphFiller:
                 f"requested minimum font size {effective_minimum:.2f} exceeds style maximum "
                 f"{style.max_font_size:.2f}"
             )
-        low = int(round(effective_minimum * 4))
-        high = int(round(style.max_font_size * 4))
+        low = ceil(effective_minimum * 4)
+        high = floor(style.max_font_size * 4)
         best: FittedParagraph | None = None
         while low <= high:
             middle = (low + high) // 2
@@ -657,6 +670,23 @@ class WindowedParagraphPlanner:
 def _is_headline(replacement: PDFReplacement) -> bool:
     """Use semantic chapter metadata, never image appearance, for title roles."""
     return replacement.layout_ref == "sub_title"
+
+
+def _ceil_quarter(font_size: float) -> float:
+    """Return the smallest supported font increment meeting a hard lower bound."""
+    return ceil(font_size * 4) / 4
+
+
+def _has_explicit_style(
+    options: PatchTextOptions,
+    layout_ref: str,
+    layout_level: int,
+) -> bool:
+    """Whether a semantic style supplies a deliberate user font ceiling."""
+    return (
+        f"{layout_ref}:{layout_level}" in options.styles
+        or layout_ref in options.styles
+    )
 
 
 def _replacement_pages(replacement: PDFReplacement) -> tuple[int, ...]:

--- a/tests/test_pdf_windowed_layout.py
+++ b/tests/test_pdf_windowed_layout.py
@@ -44,6 +44,42 @@ class TestWindowedParagraphPlanner(unittest.TestCase):
         self.assertEqual(body_plan.font_size, 12)
         self.assertGreaterEqual(headline_plan.font_size, body_plan.font_size * 1.2)
 
+    def test_implicit_headline_uses_the_actual_generic_body_style_ceiling(self):
+        options = PatchTextOptions(
+            styles={"text": PatchTextStyle(max_font_size=20, min_font_size=20)},
+        )
+        planner = WindowedParagraphPlanner(
+            QTextParagraphFiller(options), {1: (200, 100)}, options,
+        )
+        body = _replacement("Body", [_region(1)])
+        headline = _replacement("Heading", [_region(1)], layout_ref="sub_title")
+
+        window = next(planner.plan([body, headline]))
+        try:
+            body_plan, headline_plan = (item.paragraph for item in window.paragraphs)
+            self.assertEqual(body_plan.font_size, 20)
+            self.assertGreaterEqual(headline_plan.font_size, 24)
+        finally:
+            window.close()
+
+    def test_implicit_headline_uses_the_actual_levelled_body_style_ceiling(self):
+        options = PatchTextOptions(
+            styles={"text:1": PatchTextStyle(max_font_size=20, min_font_size=20)},
+        )
+        planner = WindowedParagraphPlanner(
+            QTextParagraphFiller(options), {1: (200, 100)}, options,
+        )
+        body = _replacement("Body", [_region(1)], layout_level=1)
+        headline = _replacement("Heading", [_region(1)], layout_ref="sub_title")
+
+        window = next(planner.plan([body, headline]))
+        try:
+            body_plan, headline_plan = (item.paragraph for item in window.paragraphs)
+            self.assertEqual(body_plan.font_size, 20)
+            self.assertGreaterEqual(headline_plan.font_size, 24)
+        finally:
+            window.close()
+
     def test_plans_body_before_headline_and_applies_page_body_minimum(self):
         options = PatchTextOptions(
             styles={


### PR DESCRIPTION
Summary: expand an implicit headline ceiling from the body-relative minimum selected by the planner; preserve explicit subtitle semantic ceilings as hard limits; cover generic and level-specific body styles and update the PDF translation docs. Validation: poetry run python test.py (346 passed), poetry run pyright pdf_craft tests, poetry run pylint pdf_craft tests.