### PR TITLE
feat: freeze PCEX formulas during translation

### DIFF
--- a/pdf_craft/transformer/chapter_formula_interrupter.py
+++ b/pdf_craft/transformer/chapter_formula_interrupter.py
@@ -1,7 +1,7 @@
 """Keep PCEX formulas visible to translation while restoring their source form.
 
 ``Chapter`` XML represents inline formulas as ``inline_expr`` nodes and display
-formulas as the ``content`` of an ``asset ref=\"equation\"``.  Neither shape is
+formulas as an entire ``asset ref=\"equation\"``.  Neither shape is
 MathML, so the EPUB MathML interrupter cannot be used here.  This adapter uses
 the same XMLTranslator interruption protocol with the PCEX schema instead.
 """
@@ -141,27 +141,23 @@ class ChapterFormulaInterrupter:
 
     def _formula_in(self, text_segment: TextSegment) -> tuple[_Formula | None, int | None]:
         """Return the formula owner and its parent-stack index for one segment."""
-        asset_content_index: int | None = None
-        in_equation_asset = False
+        equation_asset_index: int | None = None
         for index, element in enumerate(text_segment.parent_stack):
             if element.tag == "asset" and element.get("ref") == "equation":
-                in_equation_asset = True
-                asset_content_index = None
-                continue
-            if in_equation_asset and element.tag == "content":
-                asset_content_index = index
+                equation_asset_index = index
                 continue
             if element.tag == "inline_expr" and element.get("kind") != "text":
-                if asset_content_index is not None:
-                    # The equation asset content is one opaque display formula,
-                    # even when its OCR representation happens to contain an
-                    # inline_expr child.
+                if equation_asset_index is not None:
+                    # An equation asset is opaque as a whole. Its title and
+                    # caption must not be sent to the translator either: doing
+                    # so lets XML submission reconstruct part of the asset and
+                    # corrupt its source-only fields.
                     continue
                 return self._formula_for_inline(element), index
 
-        if asset_content_index is not None:
-            element = text_segment.parent_stack[asset_content_index]
-            return self._formula_for_asset_content(element), asset_content_index
+        if equation_asset_index is not None:
+            element = text_segment.parent_stack[equation_asset_index]
+            return self._formula_for_asset(element), equation_asset_index
         return None, None
 
     def _formula_for_inline(self, element: Element) -> _Formula:
@@ -176,14 +172,18 @@ class ChapterFormulaInterrupter:
         )
         return formula
 
-    def _formula_for_asset_content(self, element: Element) -> _Formula:
+    def _formula_for_asset(self, element: Element) -> _Formula:
+        """Freeze every serialised field of an equation asset as one unit."""
         existing = self._element_to_formula.get(id(element))
         if existing is not None:
             return existing
+        content = element.find("content")
         formula = self._new_formula(
             element=element,
             display="block",
-            latex=f"$${_serialize_formula_content(element).strip()}$$",
+            latex=(
+                f"$${_serialize_formula_content(content).strip() if content is not None else ''}$$"
+            ),
         )
         return formula
 

--- a/pdf_craft/transformer/chapter_formula_interrupter.py
+++ b/pdf_craft/transformer/chapter_formula_interrupter.py
@@ -1,0 +1,349 @@
+"""Keep PCEX formulas visible to translation while restoring their source form.
+
+``Chapter`` XML represents inline formulas as ``inline_expr`` nodes and display
+formulas as the ``content`` of an ``asset ref=\"equation\"``.  Neither shape is
+MathML, so the EPUB MathML interrupter cannot be used here.  This adapter uses
+the same XMLTranslator interruption protocol with the PCEX schema instead.
+"""
+
+from collections.abc import Generator, Iterable
+from dataclasses import dataclass
+from xml.etree.ElementTree import Element
+
+from pdf_craft.expression import decode_expression_kind, to_markdown_string
+from pdf_craft.transformer.xml_translator.segment import TextPosition, TextSegment
+from pdf_craft.transformer.xml_translator.xml import (
+    DISPLAY_ATTRIBUTE,
+    plain_text,
+)
+
+
+_FORMULA_ID_KEY = "__PDF_CRAFT_CHAPTER_FORMULA_ID"
+_FORMULA_TAG = "expression"
+
+
+@dataclass(frozen=True)
+class _Formula:
+    """One source formula represented by a temporary translation token."""
+
+    token_id: str
+    element: Element
+    display: str
+    latex: str
+
+    @property
+    def is_block(self) -> bool:
+        return self.display == "block"
+
+
+class ChapterFormulaInterrupter:
+    """Expose PCEX formulas as frozen, readable XMLTranslator tokens.
+
+    The temporary ``expression`` nodes never reach a decoded Chapter.  The
+    source text shown to the language model contains Markdown-style LaTex
+    delimiters, while the translated stream is replaced with the original
+    ``inline_expr`` text segments. Equation assets are injected as discarded
+    context tokens into their preceding and following paragraphs, so a token
+    budget split cannot hide an equation from either neighboring translation.
+    The original ``asset`` remains in the Chapter XML untouched.
+    """
+
+    def __init__(self) -> None:
+        self._next_id = 1
+        self._element_to_formula: dict[int, _Formula] = {}
+        self._formula_by_id: dict[str, _Formula] = {}
+        self._raw_text_segments: dict[str, list[TextSegment]] = {}
+        self._last_formula_id: str | None = None
+        self._last_paragraph_stack: list[Element] | None = None
+        self._pending_block_formulas: list[_Formula] = []
+        self._block_formula_parent_stacks: dict[str, list[Element]] = {}
+        self._block_formula_positions: dict[str, TextPosition] = {}
+        self._block_formula_context_counts: dict[str, int] = {}
+
+    def interrupt_source_text_segments(
+        self, text_segments: Iterable[TextSegment],
+    ) -> Generator[TextSegment, None, None]:
+        """Replace source formulas with readable temporary formula tokens."""
+        for text_segment in text_segments:
+            formula, formula_index = self._formula_in(text_segment)
+            formula_id = formula.token_id if formula is not None else None
+            if formula is not None and not formula.is_block:
+                self._raw_text_segments.setdefault(formula.token_id, []).append(text_segment)
+            elif formula is not None:
+                if formula_index is None:  # Defensive: formula ownership includes its stack index.
+                    raise RuntimeError("formula source segment has no formula stack index")
+                self._block_formula_parent_stacks.setdefault(
+                    formula.token_id, text_segment.parent_stack[:formula_index],
+                )
+                self._block_formula_positions.setdefault(formula.token_id, text_segment.position)
+
+            if self._last_formula_id is not None and formula_id != self._last_formula_id:
+                yield from self._finish_formula(self._last_formula_id)
+
+            self._last_formula_id = formula_id
+            if formula is None:
+                paragraph_stack = _paragraph_block_stack(text_segment)
+                if paragraph_stack is not None:
+                    for pending in self._pending_block_formulas:
+                        yield self._context_token(pending, paragraph_stack, text_segment)
+                    self._pending_block_formulas.clear()
+                yield text_segment
+                if paragraph_stack is not None:
+                    self._last_paragraph_stack = paragraph_stack
+
+        if self._last_formula_id is not None:
+            yield from self._finish_formula(self._last_formula_id)
+            self._last_formula_id = None
+        for formula in self._pending_block_formulas:
+            if self._block_formula_context_counts.get(formula.token_id, 0) == 0:
+                standalone = self._standalone_block_token(formula)
+                if standalone is not None:
+                    yield standalone
+        self._pending_block_formulas.clear()
+
+    def interrupt_translated_text_segments(
+        self, text_segments: Iterable[TextSegment],
+    ) -> Generator[TextSegment, None, None]:
+        """Discard translated formula text and restore original inline segments."""
+        for text_segment in text_segments:
+            parent_element = text_segment.parent_stack[-1]
+            token_id = parent_element.attrib.pop(_FORMULA_ID_KEY, None)
+            if token_id is None:
+                yield text_segment
+                continue
+
+            formula = self._formula_by_id.get(token_id)
+            if formula is None:
+                # A foreign temporary node must never become a formula result.
+                continue
+            if formula.is_block:
+                # Equation asset content remains in the source XML.  Returning
+                # no segment prevents XML submission from replacing it.
+                continue
+
+            raw_text_segments = self._raw_text_segments.pop(token_id, None)
+            if not raw_text_segments:
+                # Do not fall back to model-produced formula text if a token was
+                # malformed or lost. Formula fidelity is stricter than text fill.
+                continue
+
+            text_basic_parent_stack = text_segment.parent_stack[:-1]
+            for raw_text_segment in raw_text_segments:
+                raw_text_segment.parent_stack = (
+                    text_basic_parent_stack + raw_text_segment.parent_stack
+                )
+                yield raw_text_segment
+
+    def interrupt_block_element(self, element: Element) -> Element:
+        """Remove transient metadata before the XML submitter sees a token."""
+        element.attrib.pop(_FORMULA_ID_KEY, None)
+        return element
+
+    def _formula_in(self, text_segment: TextSegment) -> tuple[_Formula | None, int | None]:
+        """Return the formula owner and its parent-stack index for one segment."""
+        asset_content_index: int | None = None
+        in_equation_asset = False
+        for index, element in enumerate(text_segment.parent_stack):
+            if element.tag == "asset" and element.get("ref") == "equation":
+                in_equation_asset = True
+                asset_content_index = None
+                continue
+            if in_equation_asset and element.tag == "content":
+                asset_content_index = index
+                continue
+            if element.tag == "inline_expr" and element.get("kind") != "text":
+                if asset_content_index is not None:
+                    # The equation asset content is one opaque display formula,
+                    # even when its OCR representation happens to contain an
+                    # inline_expr child.
+                    continue
+                return self._formula_for_inline(element), index
+
+        if asset_content_index is not None:
+            element = text_segment.parent_stack[asset_content_index]
+            return self._formula_for_asset_content(element), asset_content_index
+        return None, None
+
+    def _formula_for_inline(self, element: Element) -> _Formula:
+        existing = self._element_to_formula.get(id(element))
+        if existing is not None:
+            return existing
+        kind = decode_expression_kind(element.get("kind", "text"))
+        formula = self._new_formula(
+            element=element,
+            display="inline",
+            latex=to_markdown_string(kind, plain_text(element)),
+        )
+        return formula
+
+    def _formula_for_asset_content(self, element: Element) -> _Formula:
+        existing = self._element_to_formula.get(id(element))
+        if existing is not None:
+            return existing
+        formula = self._new_formula(
+            element=element,
+            display="block",
+            latex=f"$${_serialize_formula_content(element).strip()}$$",
+        )
+        return formula
+
+    def _new_formula(self, element: Element, display: str, latex: str) -> _Formula:
+        token_id = str(self._next_id)
+        self._next_id += 1
+        formula = _Formula(token_id, element, display, latex)
+        self._element_to_formula[id(element)] = formula
+        self._formula_by_id[token_id] = formula
+        return formula
+
+    def _finish_formula(self, token_id: str) -> Generator[TextSegment, None, None]:
+        formula = self._formula_by_id.get(token_id)
+        if formula is None:
+            return
+        if formula.is_block:
+            # A display equation is made visible to both adjoining paragraphs.
+            # This keeps its semantic context deterministic when XMLTranslator
+            # has to cut the chapter into independent token-budget groups.
+            if self._last_paragraph_stack is not None:
+                yield self._context_token(formula, self._last_paragraph_stack, None)
+            self._pending_block_formulas.append(formula)
+            return
+        replacement = self._pop_formula(token_id)
+        if replacement is not None:
+            yield replacement
+
+    def _pop_formula(self, token_id: str) -> TextSegment | None:
+        formula = self._formula_by_id.get(token_id)
+        text_segments = self._raw_text_segments.get(token_id)
+        if formula is None or not text_segments:
+            return None
+
+        first = text_segments[0]
+        _, formula_index = self._formula_in(first)
+        if formula_index is None:  # Defensive: token ownership must be stable.
+            return None
+
+        placeholder = Element(
+            _FORMULA_TAG,
+            {
+                _FORMULA_ID_KEY: token_id,
+                DISPLAY_ATTRIBUTE: formula.display,
+            },
+        )
+        parent_stack = first.parent_stack[:formula_index] + [placeholder]
+        left_common_depth = first.left_common_depth
+        right_common_depth = text_segments[-1].right_common_depth
+        for text_segment in text_segments:
+            # Preserve just the original formula-relative stack. It is grafted
+            # back below the translated text location during restoration.
+            text_segment.left_common_depth = max(0, text_segment.left_common_depth - formula_index)
+            text_segment.right_common_depth = max(0, text_segment.right_common_depth - formula_index)
+            text_segment.parent_stack = text_segment.parent_stack[formula_index:]
+            text_segment.block_depth = _block_depth(text_segment.parent_stack)
+
+        return TextSegment(
+            text=f" {formula.latex} ",
+            parent_stack=parent_stack,
+            left_common_depth=left_common_depth,
+            right_common_depth=right_common_depth,
+            block_depth=_block_depth(parent_stack),
+            position=first.position,
+        )
+
+    def _context_token(
+        self,
+        formula: _Formula,
+        parent_stack: list[Element],
+        neighbor: TextSegment | None,
+    ) -> TextSegment:
+        """Create one output-discarded display-formula context token."""
+        token_id = f"{formula.token_id}:context:{self._next_id}"
+        self._next_id += 1
+        self._formula_by_id[token_id] = formula
+        self._block_formula_context_counts[formula.token_id] = (
+            self._block_formula_context_counts.get(formula.token_id, 0) + 1
+        )
+        placeholder = Element(
+            _FORMULA_TAG,
+            {
+                _FORMULA_ID_KEY: token_id,
+                DISPLAY_ATTRIBUTE: "inline",
+            },
+        )
+        position = neighbor.position if neighbor is not None else _text_position(parent_stack)
+        return TextSegment(
+            text=f" {formula.latex} ",
+            parent_stack=[*parent_stack, placeholder],
+            left_common_depth=0,
+            right_common_depth=0,
+            block_depth=_block_depth([*parent_stack, placeholder]),
+            position=position,
+        )
+
+    def _standalone_block_token(self, formula: _Formula) -> TextSegment | None:
+        """Keep an equation-only Chapter translatable without changing the asset."""
+        parent_stack = self._block_formula_parent_stacks.get(formula.token_id)
+        position = self._block_formula_positions.get(formula.token_id)
+        if parent_stack is None or position is None:
+            return None
+        token_id = f"{formula.token_id}:standalone:{self._next_id}"
+        self._next_id += 1
+        self._formula_by_id[token_id] = formula
+        placeholder = Element(
+            _FORMULA_TAG,
+            {
+                _FORMULA_ID_KEY: token_id,
+                DISPLAY_ATTRIBUTE: "block",
+            },
+        )
+        return TextSegment(
+            text=f" {formula.latex} ",
+            parent_stack=[*parent_stack, placeholder],
+            left_common_depth=0,
+            right_common_depth=0,
+            block_depth=_block_depth([*parent_stack, placeholder]),
+            position=position,
+        )
+
+
+def _serialize_formula_content(element: Element) -> str:
+    """Serialize an equation asset's content without translating nested formulas."""
+    parts: list[str] = []
+    if element.text:
+        parts.append(element.text)
+    for child in element:
+        if child.tag == "inline_expr" and child.get("kind") != "text":
+            kind = decode_expression_kind(child.get("kind", "text"))
+            parts.append(to_markdown_string(kind, plain_text(child)))
+        else:
+            parts.append(_serialize_formula_content(child))
+        if child.tail:
+            parts.append(child.tail)
+    return "".join(parts)
+
+
+def _block_depth(parent_stack: list[Element]) -> int:
+    """Avoid importing a private XMLTranslator implementation detail."""
+    from pdf_craft.transformer.xml_translator.segment import find_block_depth
+
+    return find_block_depth(parent_stack)
+
+
+def _paragraph_block_stack(text_segment: TextSegment) -> list[Element] | None:
+    """Return the actual ParagraphLayout block owning a text segment, if any."""
+    paragraph_index: int | None = None
+    block_index: int | None = None
+    for index, element in enumerate(text_segment.parent_stack):
+        if element.tag == "paragraph":
+            paragraph_index = index
+        elif paragraph_index is not None and element.tag == "block":
+            block_index = index
+            break
+    if block_index is None:
+        return None
+    return text_segment.parent_stack[:block_index + 1]
+
+
+def _text_position(parent_stack: list[Element]) -> TextPosition:
+    """Use a neighboring text position when available; otherwise TEXT."""
+    del parent_stack
+    return TextPosition.TEXT

--- a/pdf_craft/transformer/chapter_xml.py
+++ b/pdf_craft/transformer/chapter_xml.py
@@ -5,6 +5,7 @@ from xml.etree.ElementTree import Element
 from pdf_craft.extractor.chapter.chapter import Chapter, decode, encode
 from pdf_craft.transformer.xml_translator.segment import search_text_segments
 from pdf_craft.transformer.events import TranslationEvent, TranslationItemKind
+from .chapter_formula_interrupter import ChapterFormulaInterrupter
 from .xml_translator.xml_translator import SubmitKind, TranslationTask
 
 
@@ -44,6 +45,7 @@ class ChapterXMLTransformer:
         # an empty stream, which otherwise raises "Translation failed unexpectedly".
         if not any(segment.text.strip() for segment in search_text_segments(element)):
             return chapter
+        formula_interrupter = ChapterFormulaInterrupter()
         translated, _ = self._translator.translate_element(
             TranslationTask(
                 element=element,
@@ -58,5 +60,8 @@ class ChapterXMLTransformer:
             total_characters=total_characters,
             emit_scope_events=emit_scope_events,
             emit_item_events=emit_item_events,
+            interrupt_source_text_segments=formula_interrupter.interrupt_source_text_segments,
+            interrupt_translated_text_segments=formula_interrupter.interrupt_translated_text_segments,
+            interrupt_block_element=formula_interrupter.interrupt_block_element,
         )
         return decode(translated)

--- a/tests/test_chapter_formula_translation.py
+++ b/tests/test_chapter_formula_translation.py
@@ -1,0 +1,255 @@
+"""PCEX formula interruption tests without network-backed language models."""
+
+from __future__ import annotations
+
+import unittest
+from typing import cast
+from xml.etree.ElementTree import Element, tostring
+
+from tiktoken import get_encoding
+
+from pdf_craft.expression import ExpressionKind
+from pdf_craft.extractor.chapter.chapter import (
+    AssetLayout,
+    BlockLayout,
+    BlockMember,
+    Chapter,
+    InlineExpression,
+    ParagraphLayout,
+    encode,
+)
+from pdf_craft.markdown.paragraph import HTMLTag, tag_definition
+from pdf_craft.transformer.chapter_xml import ChapterXMLTransformer
+from pdf_craft.transformer.xml_translator.segment import search_text_segments
+from pdf_craft.transformer.xml_translator.xml_translator.callbacks import warp_callbacks
+from pdf_craft.transformer.xml_translator.xml_translator.stream_mapper import XMLStreamMapper
+from pdf_craft.transformer.xml_translator.xml_translator.submitter import submit
+
+
+class _FormulaAwareTranslator:
+    """A deterministic XMLTranslator stand-in that deliberately corrupts formulas."""
+
+    def __init__(self, max_group_score: int = 10_000) -> None:
+        self.model_sources: list[str] = []
+        self._max_group_score = max_group_score
+
+    def translate_element(self, task, **kwargs):
+        source_hook = kwargs["interrupt_source_text_segments"]
+
+        def record_source(segments):
+            interrupted = list(source_hook(segments))
+            return iter(interrupted)
+
+        callbacks = warp_callbacks(
+            interrupt_source_text_segments=record_source,
+            interrupt_translated_text_segments=kwargs["interrupt_translated_text_segments"],
+            interrupt_block_element=kwargs["interrupt_block_element"],
+            on_fill_failed=None,
+        )
+        mapper = XMLStreamMapper(get_encoding("cl100k_base"), max_group_score=self._max_group_score)
+
+        def translate_group(inline_segments):
+            self.model_sources.append(
+                "\n\n".join("".join(segment.text for segment in inline) for inline in inline_segments)
+            )
+            mappings = []
+            for inline in inline_segments:
+                template = inline.create_element()
+                self._corrupt_formula_text_and_move_it(template)
+                assigned = inline.assign_attributes(template)
+                mappings.append((inline.parent, list(search_text_segments(assigned))))
+            return mappings
+
+        translated = task.element
+        for element, mappings in mapper.map_stream(
+            elements=iter((task.element,)), callbacks=callbacks, map=translate_group, concurrency=1,
+        ):
+            translated = submit(element, task.action, mappings)
+        return translated, task.payload
+
+    def _corrupt_formula_text_and_move_it(self, element: Element) -> None:
+        formulas = [child for child in element if child.tag == "expression"]
+        if formulas:
+            # The expression content is deliberately changed. The interrupter
+            # must recover the source formula rather than accepting this text.
+            formula = formulas[0]
+            formula.text = "MODEL_CHANGED_FORMULA"
+            formula.tail = "译文"
+            return
+        for node in element.iter():
+            if node.text:
+                node.text = "译:" + node.text
+            if node.tail:
+                node.tail = "译:" + node.tail
+
+
+class _ReorderingFormulaTranslator(_FormulaAwareTranslator):
+    """Simulate a fill model that moves one frozen token before natural text."""
+
+    def _corrupt_formula_text_and_move_it(self, element: Element) -> None:
+        formulas = [child for child in element if child.tag == "expression"]
+        if len(formulas) == 1:
+            formula = formulas[0]
+            element.text = None
+            formula.text = "MODEL_CHANGED_FORMULA"
+            formula.tail = "译文后"
+            return
+        super()._corrupt_formula_text_and_move_it(element)
+
+
+class TestChapterFormulaTranslation(unittest.TestCase):
+    def test_inline_formulas_are_visible_to_translation_and_restored_after_reordering(self):
+        chapter = Chapter(None, 0, [
+            ParagraphLayout("text", 0, [BlockLayout(
+                1, 1, (1, 1, 100, 30), [
+                    "Before ",
+                    InlineExpression(ExpressionKind.INLINE_DOLLAR, "x^2"),
+                    " and ",
+                    InlineExpression(ExpressionKind.INLINE_PAREN, r"\chi"),
+                    ".",
+                ],
+            )]),
+        ])
+        translator = _FormulaAwareTranslator()
+
+        translated = ChapterXMLTransformer(translator).transform(chapter)
+
+        source = "\n".join(translator.model_sources)
+        self.assertIn("$x^2$", source)
+        self.assertIn(r"\(\chi\)", source)
+        layout = translated.layouts[0]
+        self.assertIsInstance(layout, ParagraphLayout)
+        assert isinstance(layout, ParagraphLayout)
+        content = layout.blocks[0].content
+        formulas: list[InlineExpression] = [
+            item for item in content if isinstance(item, InlineExpression)
+        ]
+        self.assertEqual(
+            [(formula.kind, formula.content) for formula in formulas],
+            [
+                (ExpressionKind.INLINE_DOLLAR, "x^2"),
+                (ExpressionKind.INLINE_PAREN, r"\chi"),
+            ],
+        )
+        self.assertNotIn("MODEL_CHANGED_FORMULA", tostring(encode(translated), encoding="unicode"))
+        self.assertNotIn("__PDF_CRAFT_CHAPTER_FORMULA_ID", tostring(encode(translated), encoding="unicode"))
+
+    def test_inline_formula_is_restored_when_the_model_moves_its_token(self):
+        chapter = Chapter(None, 0, [
+            ParagraphLayout("text", 0, [BlockLayout(
+                1, 1, (1, 1, 100, 30), [
+                    "Before ",
+                    InlineExpression(ExpressionKind.INLINE_PAREN, r"\alpha"),
+                    " after.",
+                ],
+            )]),
+        ])
+
+        translated = ChapterXMLTransformer(_ReorderingFormulaTranslator()).transform(chapter)
+
+        layout = translated.layouts[0]
+        self.assertIsInstance(layout, ParagraphLayout)
+        assert isinstance(layout, ParagraphLayout)
+        content = layout.blocks[0].content
+        self.assertIsInstance(content[0], InlineExpression)
+        assert isinstance(content[0], InlineExpression)
+        self.assertEqual((content[0].kind, content[0].content), (ExpressionKind.INLINE_PAREN, r"\alpha"))
+        self.assertIn("译文后", "".join(item for item in content if isinstance(item, str)))
+
+    def test_inline_formulas_survive_html_and_cross_page_paragraph_blocks(self):
+        emphasis = tag_definition("em")
+        assert emphasis is not None
+        chapter = Chapter(None, 0, [
+            ParagraphLayout("text", 0, [
+                BlockLayout(1, 1, (1, 1, 100, 30), [
+                    "First ", HTMLTag(
+                        definition=emphasis,
+                        attributes=[],
+                        children=cast(
+                            list[str | BlockMember | HTMLTag[BlockMember]],
+                            ["wrapped ", InlineExpression(ExpressionKind.INLINE_DOLLAR, "x")],
+                        ),
+                    ),
+                ]),
+                BlockLayout(2, 2, (1, 1, 100, 30), [
+                    "Second ", InlineExpression(ExpressionKind.INLINE_PAREN, r"\beta"), ".",
+                ]),
+            ]),
+        ])
+
+        translated = ChapterXMLTransformer(_FormulaAwareTranslator()).transform(chapter)
+
+        layout = translated.layouts[0]
+        self.assertIsInstance(layout, ParagraphLayout)
+        assert isinstance(layout, ParagraphLayout)
+        self.assertEqual([block.page_index for block in layout.blocks], [1, 2])
+        encoded = tostring(encode(translated), encoding="unicode")
+        self.assertIn('<inline_expr kind="$">x</inline_expr>', encoded)
+        self.assertIn(r'<inline_expr kind="\(">\beta</inline_expr>', encoded)
+        self.assertIn("<em>", encoded)
+
+    def test_equation_asset_is_context_and_is_never_rewritten(self):
+        equation = AssetLayout(
+            page_index=1,
+            ref="equation",
+            det=(10, 40, 90, 60),
+            title=[],
+            content=[r"\int_0^1 x^2 dx"],
+            caption=[],
+            hash="equation-image",
+        )
+        chapter = Chapter(None, 0, [
+            ParagraphLayout("text", 0, [BlockLayout(1, 1, (1, 1, 100, 30), ["Before equation."])]),
+            equation,
+            ParagraphLayout("text", 0, [BlockLayout(1, 2, (1, 70, 100, 100), ["After equation."])]),
+        ])
+        translator = _FormulaAwareTranslator(max_group_score=1)
+
+        translated = ChapterXMLTransformer(translator).transform(chapter)
+
+        self.assertTrue(any(
+            "Before equation." in source and r"$$\int_0^1 x^2 dx$$" in source
+            for source in translator.model_sources
+        ))
+        self.assertTrue(any(
+            r"$$\int_0^1 x^2 dx$$" in source and "After equation." in source
+            for source in translator.model_sources
+        ))
+        restored = translated.layouts[1]
+        self.assertIsInstance(restored, AssetLayout)
+        assert isinstance(restored, AssetLayout)
+        self.assertEqual(restored, equation)
+
+    def test_equation_only_chapter_keeps_the_asset_and_does_not_skip_translation(self):
+        equation = AssetLayout(
+            page_index=1,
+            ref="equation",
+            det=(10, 40, 90, 60),
+            title=[],
+            content=[r"x^2 + y^2 = z^2"],
+            caption=[],
+            hash="equation-only",
+        )
+        translator = _FormulaAwareTranslator(max_group_score=1)
+
+        translated = ChapterXMLTransformer(translator).transform(Chapter(None, 0, [equation]))
+
+        self.assertTrue(any(r"$$x^2 + y^2 = z^2$$" in source for source in translator.model_sources))
+        self.assertEqual(translated.layouts, [equation])
+
+    def test_chapter_without_formula_keeps_normal_xml_translation(self):
+        chapter = Chapter(None, 0, [
+            ParagraphLayout("text", 0, [BlockLayout(1, 1, (1, 1, 100, 30), ["plain text"])]),
+        ])
+
+        translated = ChapterXMLTransformer(_FormulaAwareTranslator()).transform(chapter)
+
+        layout = translated.layouts[0]
+        self.assertIsInstance(layout, ParagraphLayout)
+        assert isinstance(layout, ParagraphLayout)
+        content = layout.blocks[0].content
+        self.assertEqual(content, ["译:plain text"])
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_chapter_formula_translation.py
+++ b/tests/test_chapter_formula_translation.py
@@ -193,9 +193,9 @@ class TestChapterFormulaTranslation(unittest.TestCase):
             page_index=1,
             ref="equation",
             det=(10, 40, 90, 60),
-            title=[],
+            title=["Equation title"],
             content=[r"\int_0^1 x^2 dx"],
-            caption=[],
+            caption=["Equation caption"],
             hash="equation-image",
         )
         chapter = Chapter(None, 0, [
@@ -219,6 +219,32 @@ class TestChapterFormulaTranslation(unittest.TestCase):
         self.assertIsInstance(restored, AssetLayout)
         assert isinstance(restored, AssetLayout)
         self.assertEqual(restored, equation)
+
+    def test_equation_asset_with_title_or_caption_is_frozen_as_a_whole(self):
+        for title, caption in [(["Title"], []), ([], ["Caption"]), (["Title"], ["Caption"])]:
+            with self.subTest(title=title, caption=caption):
+                equation = AssetLayout(
+                    page_index=1,
+                    ref="equation",
+                    det=(10, 40, 90, 60),
+                    title=title,
+                    content=[r"x^2"],
+                    caption=caption,
+                    hash="equation-metadata",
+                )
+                chapter = Chapter(None, 0, [
+                    ParagraphLayout("text", 0, [BlockLayout(
+                        1, 1, (1, 1, 100, 30), ["Before."],
+                    )]),
+                    equation,
+                    ParagraphLayout("text", 0, [BlockLayout(
+                        1, 2, (1, 70, 100, 100), ["After."],
+                    )]),
+                ])
+
+                translated = ChapterXMLTransformer(_FormulaAwareTranslator()).transform(chapter)
+
+                self.assertEqual(translated.layouts[1], equation)
 
     def test_equation_only_chapter_keeps_the_asset_and_does_not_skip_translation(self):
         equation = AssetLayout(


### PR DESCRIPTION
## Summary\n- expose PCEX inline formulas to translation while restoring their original structure\n- pass display equations into adjacent paragraph context without accepting model rewrites\n- freeze equation asset metadata as well as formula content\n\n## Validation\n- poetry run python test.py\n- poetry run pyright pdf_craft tests\n- poetry run pylint pdf_craft tests