### PR TITLE
fix: translate equation metadata separately

### DIFF
--- a/pdf_craft/transformer/chapter_formula_interrupter.py
+++ b/pdf_craft/transformer/chapter_formula_interrupter.py
@@ -1,7 +1,7 @@
 """Keep PCEX formulas visible to translation while restoring their source form.
 
 ``Chapter`` XML represents inline formulas as ``inline_expr`` nodes and display
-formulas as an entire ``asset ref=\"equation\"``.  Neither shape is
+formulas in the ``content`` of an ``asset ref=\"equation\"``.  Neither shape is
 MathML, so the EPUB MathML interrupter cannot be used here.  This adapter uses
 the same XMLTranslator interruption protocol with the PCEX schema instead.
 """
@@ -20,6 +20,8 @@ from pdf_craft.transformer.xml_translator.xml import (
 
 _FORMULA_ID_KEY = "__PDF_CRAFT_CHAPTER_FORMULA_ID"
 _FORMULA_TAG = "expression"
+_FORMULA_CONTEXT_KEY = "__PDF_CRAFT_CHAPTER_FORMULA_CONTEXT"
+_FORMULA_CONTEXT_TAG = "formula_context"
 
 
 @dataclass(frozen=True)
@@ -42,10 +44,10 @@ class ChapterFormulaInterrupter:
     The temporary ``expression`` nodes never reach a decoded Chapter.  The
     source text shown to the language model contains Markdown-style LaTex
     delimiters, while the translated stream is replaced with the original
-    ``inline_expr`` text segments. Equation assets are injected as discarded
-    context tokens into their preceding and following paragraphs, so a token
+    ``inline_expr`` text segments. Equation asset *content* is injected as
+    discarded context into its preceding and following paragraphs, so a token
     budget split cannot hide an equation from either neighboring translation.
-    The original ``asset`` remains in the Chapter XML untouched.
+    The asset's title and caption remain ordinary translatable Chapter text.
     """
 
     def __init__(self) -> None:
@@ -106,6 +108,15 @@ class ChapterFormulaInterrupter:
     ) -> Generator[TextSegment, None, None]:
         """Discard translated formula text and restore original inline segments."""
         for text_segment in text_segments:
+            if any(
+                _FORMULA_CONTEXT_KEY in element.attrib
+                for element in text_segment.parent_stack
+            ):
+                # Context is deliberately visible to the model but has no
+                # counterpart in the source XML.  In particular, discard the
+                # text surrounding its temporary expression as well as the
+                # expression itself; a model may place text in either spot.
+                continue
             parent_element = text_segment.parent_stack[-1]
             token_id = parent_element.attrib.pop(_FORMULA_ID_KEY, None)
             if token_id is None:
@@ -141,23 +152,25 @@ class ChapterFormulaInterrupter:
 
     def _formula_in(self, text_segment: TextSegment) -> tuple[_Formula | None, int | None]:
         """Return the formula owner and its parent-stack index for one segment."""
+        equation_asset: Element | None = None
         equation_asset_index: int | None = None
         for index, element in enumerate(text_segment.parent_stack):
             if element.tag == "asset" and element.get("ref") == "equation":
+                equation_asset = element
                 equation_asset_index = index
-                continue
-            if element.tag == "inline_expr" and element.get("kind") != "text":
-                if equation_asset_index is not None:
-                    # An equation asset is opaque as a whole. Its title and
-                    # caption must not be sent to the translator either: doing
-                    # so lets XML submission reconstruct part of the asset and
-                    # corrupt its source-only fields.
-                    continue
-                return self._formula_for_inline(element), index
+                break
 
-        if equation_asset_index is not None:
-            element = text_segment.parent_stack[equation_asset_index]
-            return self._formula_for_asset(element), equation_asset_index
+        if equation_asset is not None and equation_asset_index is not None:
+            content = equation_asset.find("content")
+            if content is not None and any(
+                element is content
+                for element in text_segment.parent_stack[equation_asset_index + 1:]
+            ):
+                return self._formula_for_asset(equation_asset), equation_asset_index
+
+        for index, element in enumerate(text_segment.parent_stack):
+            if element.tag == "inline_expr" and element.get("kind") != "text":
+                return self._formula_for_inline(element), index
         return None, None
 
     def _formula_for_inline(self, element: Element) -> _Formula:
@@ -173,7 +186,7 @@ class ChapterFormulaInterrupter:
         return formula
 
     def _formula_for_asset(self, element: Element) -> _Formula:
-        """Freeze every serialised field of an equation asset as one unit."""
+        """Freeze one equation asset's formula content as one unit."""
         existing = self._element_to_formula.get(id(element))
         if existing is not None:
             return existing
@@ -269,10 +282,22 @@ class ChapterFormulaInterrupter:
                 DISPLAY_ATTRIBUTE: "inline",
             },
         )
+        context = Element(
+            _FORMULA_CONTEXT_TAG,
+            {
+                _FORMULA_CONTEXT_KEY: token_id,
+                DISPLAY_ATTRIBUTE: "inline",
+            },
+        )
+        context.append(placeholder)
         position = neighbor.position if neighbor is not None else _text_position(parent_stack)
         return TextSegment(
             text=f" {formula.latex} ",
-            parent_stack=[*parent_stack, placeholder],
+            # Keep the context inline with its neighboring paragraph, while
+            # wrapping it in a synthetic marker.  That marker lets the return
+            # path discard every model-produced character, including text the
+            # model puts beside the expression token.
+            parent_stack=[*parent_stack, context, placeholder],
             left_common_depth=0,
             right_common_depth=0,
             block_depth=_block_depth([*parent_stack, placeholder]),
@@ -295,9 +320,17 @@ class ChapterFormulaInterrupter:
                 DISPLAY_ATTRIBUTE: "block",
             },
         )
+        context = Element(
+            _FORMULA_CONTEXT_TAG,
+            {
+                _FORMULA_CONTEXT_KEY: token_id,
+                DISPLAY_ATTRIBUTE: "inline",
+            },
+        )
+        context.append(placeholder)
         return TextSegment(
             text=f" {formula.latex} ",
-            parent_stack=[*parent_stack, placeholder],
+            parent_stack=[*parent_stack, context, placeholder],
             left_common_depth=0,
             right_common_depth=0,
             block_depth=_block_depth([*parent_stack, placeholder]),

--- a/tests/test_chapter_formula_translation.py
+++ b/tests/test_chapter_formula_translation.py
@@ -188,14 +188,14 @@ class TestChapterFormulaTranslation(unittest.TestCase):
         self.assertIn(r'<inline_expr kind="\(">\beta</inline_expr>', encoded)
         self.assertIn("<em>", encoded)
 
-    def test_equation_asset_is_context_and_is_never_rewritten(self):
+    def test_equation_content_is_context_and_is_never_rewritten(self):
         equation = AssetLayout(
             page_index=1,
             ref="equation",
             det=(10, 40, 90, 60),
-            title=["Equation title"],
+            title=[],
             content=[r"\int_0^1 x^2 dx"],
-            caption=["Equation caption"],
+            caption=[],
             hash="equation-image",
         )
         chapter = Chapter(None, 0, [
@@ -220,7 +220,7 @@ class TestChapterFormulaTranslation(unittest.TestCase):
         assert isinstance(restored, AssetLayout)
         self.assertEqual(restored, equation)
 
-    def test_equation_asset_with_title_or_caption_is_frozen_as_a_whole(self):
+    def test_equation_title_and_caption_are_translated_while_content_is_frozen(self):
         for title, caption in [(["Title"], []), ([], ["Caption"]), (["Title"], ["Caption"])]:
             with self.subTest(title=title, caption=caption):
                 equation = AssetLayout(
@@ -242,9 +242,52 @@ class TestChapterFormulaTranslation(unittest.TestCase):
                     )]),
                 ])
 
-                translated = ChapterXMLTransformer(_FormulaAwareTranslator()).transform(chapter)
+                translator = _FormulaAwareTranslator()
+                translated = ChapterXMLTransformer(translator).transform(chapter)
 
-                self.assertEqual(translated.layouts[1], equation)
+                restored = translated.layouts[1]
+                self.assertIsInstance(restored, AssetLayout)
+                assert isinstance(restored, AssetLayout)
+                self.assertEqual(restored.content, equation.content)
+                self.assertEqual(
+                    restored.title,
+                    [f"译:{item}" for item in equation.title],
+                )
+                self.assertEqual(
+                    restored.caption,
+                    [f"译:{item}" for item in equation.caption],
+                )
+                self.assertTrue(any(r"$$x^2$$" in source for source in translator.model_sources))
+
+    def test_equation_metadata_inline_formulas_are_protected_independently(self):
+        title_formula = InlineExpression(ExpressionKind.INLINE_DOLLAR, "n")
+        caption_formula = InlineExpression(ExpressionKind.INLINE_PAREN, r"\chi")
+        equation = AssetLayout(
+            page_index=1,
+            ref="equation",
+            det=(10, 40, 90, 60),
+            title=["Title ", title_formula],
+            content=["f", InlineExpression(ExpressionKind.INLINE_DOLLAR, "x"), " = 0"],
+            caption=["Caption ", caption_formula],
+            hash="equation-metadata-inline-formulas",
+        )
+        translator = _FormulaAwareTranslator()
+
+        translated = ChapterXMLTransformer(translator).transform(Chapter(None, 0, [equation]))
+
+        restored = translated.layouts[0]
+        self.assertIsInstance(restored, AssetLayout)
+        assert isinstance(restored, AssetLayout)
+        self.assertEqual(restored.content, equation.content)
+        title_formulas = [item for item in restored.title if isinstance(item, InlineExpression)]
+        caption_formulas = [item for item in restored.caption if isinstance(item, InlineExpression)]
+        self.assertEqual(title_formulas, [title_formula])
+        self.assertEqual(caption_formulas, [caption_formula])
+        source = "\n".join(translator.model_sources)
+        self.assertIn("$n$", source)
+        self.assertIn(r"\(\chi\)", source)
+        self.assertIn("$$f$x$ = 0$$", source)
+        self.assertNotIn("MODEL_CHANGED_FORMULA", tostring(encode(translated), encoding="unicode"))
 
     def test_equation_only_chapter_keeps_the_asset_and_does_not_skip_translation(self):
         equation = AssetLayout(


### PR DESCRIPTION
## Summary
- freeze only equation Asset `content` during PCEX translation
- translate equation titles and captions normally while protecting inline formulas in them
- make display-formula context tokens fully output-discarded

## Verification
- poetry run python -m unittest tests.test_chapter_formula_translation
- poetry run pyright pdf_craft tests
- poetry run pylint pdf_craft tests
- poetry run python test.py