### PR TITLE
fix: allow headline right overflow at minimum size

### DIFF
--- a/pdf_craft/pipeline/pdf/text_layout.py
+++ b/pdf_craft/pipeline/pdf/text_layout.py
@@ -20,6 +20,7 @@ FontResolutionSource = Literal["automatic", "configured", "qt-fallback"]
 
 _FONT_SIZE_TOLERANCE = 0.05
 _MAX_FONT_SIZE_SEARCH_ITERATIONS = 16
+_HEADLINE_OVERFLOW_LINE_WIDTH = 1_000_000.0
 _CJK_FONT_CANDIDATES = (
     "PingFang SC",
     "Noto Sans CJK SC",
@@ -149,6 +150,7 @@ class RegionTextPlacement:
     line_heights: tuple[float, ...]
     font_size: float
     style: PatchTextStyle
+    allows_horizontal_overflow: bool = False
 
 
 @dataclass(frozen=True)
@@ -431,6 +433,28 @@ class QTextParagraphFiller:
                 lower = middle
         return best
 
+    def fit_headline(
+        self,
+        replacement: PDFReplacement,
+        page_sizes: dict[int, tuple[float, float]],
+        minimum_font_size: float,
+    ) -> FittedParagraph:
+        """Fit a headline normally, or draw it as one natural-width line.
+
+        Headline font minima are a normal part of the document's typography,
+        not a reason to abort an otherwise usable translation.  A narrow
+        source rectangle first receives the ordinary multi-region treatment.
+        If that cannot hold the headline at its required size, the first
+        rectangle supplies only the left/vertical anchor and the unwrapped
+        line is allowed to continue to the right.
+        """
+        try:
+            return self.fit(replacement, page_sizes, minimum_font_size)
+        except ValueError:
+            return self._plan_headline_overflow(
+                replacement, page_sizes, minimum_font_size,
+            )
+
     def _resolve_font(self, style: PatchTextStyle, text: str) -> PatchTextStyle:
         """Resolve an automatic family once, without rejecting explicit names."""
         requested = style.font_name.strip() if style.font_name else None
@@ -512,6 +536,67 @@ class QTextParagraphFiller:
             return None
         return FittedParagraph(text, font_size, tuple(placements))
 
+    def _plan_headline_overflow(
+        self,
+        replacement: PDFReplacement,
+        page_sizes: dict[int, tuple[float, float]],
+        minimum_font_size: float,
+    ) -> FittedParagraph:
+        """Return an unwrapped headline anchored at its first source box."""
+        text = " ".join(replacement.text.split())
+        if not text:
+            raise ValueError("replacement text must not be empty")
+        style = self.options.style_for(replacement.layout_ref, replacement.layout_level)
+        # The body-relative minimum wins even when an explicit headline style
+        # supplied a lower maximum.  The caller selected this as the headline
+        # size required for the current page; width is the only relaxed bound.
+        effective_minimum = max(style.min_font_size, minimum_font_size)
+        style = replace(style, max_font_size=max(style.max_font_size, effective_minimum))
+        style = self._resolve_font(style, text)
+        self._validate_style(style)
+
+        region = replacement.source_regions()[0]
+        page_width, page_height = page_sizes[region.page_index]
+        rectangle = region_in_page_points(region, page_width, page_height)
+        # The overflow rule is intentionally left aligned to the physical box
+        # edge and vertically centered on that edge, independent of the
+        # ordinary paragraph's padding/alignment settings.
+        overflow_style = replace(
+            style,
+            horizontal_padding=0.0,
+            vertical_padding=0.0,
+            alignment="left",
+        )
+        QtCore, QtGui = _qt_modules()
+        _ensure_qt_application(QtGui)
+        layout = self._create_layout(QtCore, QtGui, text, overflow_style, effective_minimum)
+        layout.beginLayout()
+        try:
+            line = layout.createLine()
+            if not line.isValid():
+                raise ValueError("Qt could not create a headline line")
+            line.setLineWidth(_HEADLINE_OVERFLOW_LINE_WIDTH)
+            line_height = line.height()
+            line_start = _x_coordinate(line.cursorToX(0))
+            line_end = _x_coordinate(line.cursorToX(line.textLength()))
+        finally:
+            layout.endLayout()
+        if line.textLength() <= 0:
+            raise ValueError("Qt could not lay out headline text")
+        placement = RegionTextPlacement(
+            region.page_index,
+            rectangle,
+            text,
+            (rectangle.x + line_start,),
+            (line_end - line_start,),
+            (rectangle.top + (rectangle.height - line_height) / 2,),
+            (line_height,),
+            effective_minimum,
+            overflow_style,
+            allows_horizontal_overflow=True,
+        )
+        return FittedParagraph(text, effective_minimum, (placement,))
+
     def _fit_region(
         self,
         page_index: int,
@@ -585,8 +670,12 @@ class QTextParagraphFiller:
         layout = self._create_layout(
             QtCore, QtGui, placement.remaining_text, placement.style, placement.font_size,
         )
-        available_width = placement.rectangle.width - 2 * placement.style.horizontal_padding
-        x = placement.rectangle.x + placement.style.horizontal_padding
+        if placement.allows_horizontal_overflow:
+            available_width = _HEADLINE_OVERFLOW_LINE_WIDTH
+            x = placement.rectangle.x
+        else:
+            available_width = placement.rectangle.width - 2 * placement.style.horizontal_padding
+            x = placement.rectangle.x + placement.style.horizontal_padding
         layout.beginLayout()
         try:
             for top in placement.line_tops:
@@ -711,14 +800,7 @@ class WindowedParagraphPlanner:
 
             for replacement in headlines:
                 minimum = self._headline_minimum(replacement, body_font_sizes)
-                try:
-                    paragraph = self._filler.fit(replacement, self._page_sizes, minimum)
-                except ValueError as error:
-                    constraint = HeadlineConstraintError(replacement, minimum, error)
-                    if self._options.overflow == "skip":
-                        self.skipped.append((replacement, constraint))
-                        continue
-                    raise constraint from error
+                paragraph = self._filler.fit_headline(replacement, self._page_sizes, minimum)
                 paragraph_index = len(summaries)
                 summaries.append(_PlannedParagraphSummary(
                     replacement, paragraph.text, paragraph.font_size,

--- a/tests/test_pdf_patcher.py
+++ b/tests/test_pdf_patcher.py
@@ -15,7 +15,7 @@ from reportlab.pdfgen import canvas
 from pdf_craft.pdf.handler import PDFHandler
 from pdf_craft.pipeline.pdf import (
     FillWindowPlan, FittedParagraph, GhostscriptVisualBaseCompiler, PDFPatcher, PDFReplacement,
-    PDFReplacementRegion, PatchTextOptions,
+    PDFReplacementRegion, PatchTextOptions, PatchTextStyle,
     QTextParagraphFiller,
 )
 from pdf_craft.pipeline.pdf.text_layout import _CJK_FONT_CANDIDATES, _ensure_qt_application
@@ -121,6 +121,35 @@ class TestPDFPatcher(unittest.TestCase):
             self.assertIn("Translated", page.extract_text())
             self.assertNotIn("Original", page.extract_text())
             self.assertEqual(len(list(page.images)), 0)
+
+    def test_writes_a_narrow_headline_as_a_natural_right_overflow_line(self):
+        """A headline lower bound never prevents a patched PDF from being written."""
+        options = PatchTextOptions(
+            styles={
+                "text": PatchTextStyle(max_font_size=10, min_font_size=10),
+                "sub_title": PatchTextStyle(max_font_size=11, min_font_size=4),
+            },
+            headline_min_body_ratio=1.2,
+        )
+        body = PDFReplacement(1, (0, 50, 200, 100), "Body", (200, 100))
+        title = PDFReplacement(
+            1, (0, 10, 36, 40), "A deliberately long heading", (200, 100),
+            layout_ref="sub_title",
+        )
+        with tempfile.TemporaryDirectory() as temp_dir:
+            root = Path(temp_dir)
+            source = root / "source.pdf"
+            target = root / "target.pdf"
+            doc = canvas.Canvas(str(source), pagesize=(200, 100))
+            doc.drawString(0, 90, "Original title")
+            doc.save()
+
+            self.patcher(options=options).patch(source, target, [body, title])
+
+            extracted = " ".join(
+                pypdf.PdfReader(str(target)).pages[0].extract_text().split()
+            )
+            self.assertIn("A deliberately long heading", extracted)
 
     def test_rejects_invalid_bbox(self):
         with self.assertRaises(ValueError):

--- a/tests/test_pdf_windowed_layout.py
+++ b/tests/test_pdf_windowed_layout.py
@@ -2,7 +2,7 @@ import unittest
 from pathlib import Path
 
 from pdf_craft.pipeline.pdf import (
-    HeadlineConstraintError, PDFReplacement, PDFReplacementRegion,
+    PDFReplacement, PDFReplacementRegion,
     PatchTextOptions, PatchTextStyle, QTextParagraphFiller, WindowedParagraphPlanner,
 )
 
@@ -151,7 +151,7 @@ class TestWindowedParagraphPlanner(unittest.TestCase):
 
         self.assertGreaterEqual(window.paragraphs[0].paragraph.font_size, 14)
 
-    def test_fails_explicitly_when_headline_cannot_meet_body_constraint(self):
+    def test_narrow_headline_keeps_body_relative_minimum_and_flows_right(self):
         options = PatchTextOptions(
             styles={
                 "text": PatchTextStyle(max_font_size=10, min_font_size=10),
@@ -163,13 +163,28 @@ class TestWindowedParagraphPlanner(unittest.TestCase):
             QTextParagraphFiller(options), {1: (200, 100)}, options,
         )
 
-        with self.assertRaises(HeadlineConstraintError):
-            list(planner.plan([
-                _replacement("Body", [_region(1)]),
-                _replacement("Heading", [_region(1)], layout_ref="sub_title"),
-            ]))
+        narrow_title = PDFReplacementRegion(1, (0, 20, 36, 50), (200, 100))
+        window = next(planner.plan([
+            _replacement("Body", [_region(1)]),
+            _replacement(
+                "A deliberately long heading", [narrow_title], layout_ref="sub_title",
+            ),
+        ]))
 
-    def test_explicit_headline_level_style_remains_a_hard_limit_when_skipped(self):
+        _, headline_plan = (item.paragraph for item in window.paragraphs)
+        placement = headline_plan.placements[0]
+        self.assertEqual(headline_plan.font_size, 12)
+        self.assertTrue(placement.allows_horizontal_overflow)
+        self.assertEqual(len(placement.line_tops), 1)
+        self.assertAlmostEqual(placement.line_text_lefts[0], placement.rectangle.x)
+        self.assertGreater(placement.line_text_widths[0], placement.rectangle.width)
+        self.assertAlmostEqual(
+            placement.line_tops[0] + placement.line_heights[0] / 2,
+            placement.rectangle.top + placement.rectangle.height / 2,
+        )
+        window.close()
+
+    def test_headline_never_uses_generic_skip_overflow_policy(self):
         options = PatchTextOptions(
             styles={
                 "text": PatchTextStyle(max_font_size=10, min_font_size=10),
@@ -188,9 +203,10 @@ class TestWindowedParagraphPlanner(unittest.TestCase):
 
         window = next(planner.plan([body, headline]))
 
-        self.assertEqual([item.replacement for item in window.paragraphs], [body])
-        self.assertEqual(planner.skipped[0][0], headline)
-        self.assertIsInstance(planner.skipped[0][1], HeadlineConstraintError)
+        self.assertEqual([item.replacement for item in window.paragraphs], [body, headline])
+        self.assertTrue(window.paragraphs[1].paragraph.placements[0].allows_horizontal_overflow)
+        self.assertEqual(planner.skipped, [])
+        window.close()
 
     def test_emits_a_closed_window_before_consuming_later_pages(self):
         options = PatchTextOptions(max_font_size=10, min_font_size=10)


### PR DESCRIPTION
## Summary

- keep the body-relative headline minimum when a title does not fit its source bbox
- render that headline as a vertically centered, left-anchored, natural-width single line that may continue right
- keep ordinary paragraph bbox flow and failure semantics unchanged

## Verification

- `poetry run python -m unittest tests.test_pdf_windowed_layout tests.test_pdf_text_layout tests.test_pdf_patcher`
- `poetry run pyright pdf_craft tests`
- `poetry run pylint pdf_craft tests`
- `poetry run python test.py`
- real `table&formula.pdf` PCEX patch smoke and rendered page inspection