### PR TITLE
fix: crop inline formula PDF fragments

### DIFF
--- a/pdf_craft/pipeline/pdf/inline_formula.py
+++ b/pdf_craft/pipeline/pdf/inline_formula.py
@@ -6,10 +6,9 @@ retain the plain-text path below it.
 """
 
 from dataclasses import dataclass
-from pathlib import Path
+from io import BytesIO
 from shutil import which
 import subprocess
-from tempfile import TemporaryDirectory
 
 
 @dataclass(frozen=True)
@@ -41,7 +40,7 @@ class InlineFormulaPDFRenderer:
                 self._available = False
                 return False
             latex = which("latex")
-            if latex is None or not (which("dvipdfmx") or which("dvipdf")):
+            if latex is None:
                 self._available = False
             else:
                 try:
@@ -71,31 +70,38 @@ class InlineFormulaPDFRenderer:
             self._cache[key] = None
             return None
         try:
-            latex_bin = which("latex")
-            converter = which("dvipdfmx") or which("dvipdf")
-            if latex_bin is None or converter is None:
-                raise RuntimeError("local TeX PDF toolchain is unavailable")
-            with TemporaryDirectory(prefix="pdf-craft-inline-tex-") as directory:
-                root = Path(directory)
-                source = root / "formula.tex"
-                source.write_text(
-                    "\\documentclass[preview]{standalone}\n"
-                    "\\begin{document}\n"
-                    f"{{\\fontsize{{{point_size}}}{{{point_size}}}\\selectfont ${latex}$}}\n"
-                    "\\end{document}\n", encoding="utf-8",
+            if which("latex") is None:
+                raise RuntimeError("local TeX executable is unavailable")
+            from matplotlib import rc_context  # type: ignore[reportMissingImports]
+            from matplotlib.backends.backend_pdf import FigureCanvasPdf  # type: ignore[reportMissingImports]
+            from matplotlib.figure import Figure  # type: ignore[reportMissingImports]
+            from matplotlib.texmanager import TexManager  # type: ignore[reportMissingImports]
+
+            expression = f"${latex}$"
+            with rc_context({"text.usetex": True, "font.family": "serif"}):
+                width, height, descent = TexManager().get_text_width_height_descent(
+                    expression, point_size, None,
                 )
-                subprocess.run(
-                    [latex_bin, "-no-shell-escape", "-interaction=nonstopmode", "-halt-on-error", source.name],
-                    cwd=root, check=True, timeout=15, stdout=subprocess.DEVNULL, stderr=subprocess.DEVNULL,
+                # Give Matplotlib a tiny temporary margin, then ask its PDF
+                # backend to crop to the TeX glyph bounds.  The resulting
+                # MediaBox starts at (0, 0) and is exactly the DVI metrics,
+                # unlike a raw dvipdfmx output which retains an A4 page and
+                # places its glyphs at ordinary document coordinates.
+                margin = 1.0
+                figure_width = width + 2 * margin
+                figure_height = height + 2 * margin
+                figure = Figure(figsize=(figure_width / 72, figure_height / 72))
+                FigureCanvasPdf(figure)
+                figure.text(
+                    margin / figure_width,
+                    (margin + descent) / figure_height,
+                    expression,
+                    fontsize=point_size,
+                    va="baseline",
                 )
-                subprocess.run([converter, "formula.dvi"], cwd=root, check=True, timeout=15,
-                               stdout=subprocess.DEVNULL, stderr=subprocess.DEVNULL)
-                output = root / "formula.pdf"
-                pdf = output.read_bytes()
-                from matplotlib import dviread  # type: ignore[reportMissingImports]
-                dvi_page = next(iter(dviread.Dvi(str(root / "formula.dvi"), 72)))
-            self._cache[key] = FormulaFragment(pdf, float(dvi_page.width), float(dvi_page.height),
-                                               float(dvi_page.descent))
+                output = BytesIO()
+                figure.savefig(output, format="pdf", transparent=True, bbox_inches="tight", pad_inches=0)
+            self._cache[key] = FormulaFragment(output.getvalue(), float(width), float(height), float(descent))
         except Exception:  # local TeX packages and individual expressions vary widely.
             self._cache[key] = None
         return self._cache[key]

--- a/pdf_craft/pipeline/pdf/text_layout.py
+++ b/pdf_craft/pipeline/pdf/text_layout.py
@@ -688,7 +688,7 @@ class QTextParagraphFiller:
                 ):
                     break
                 if any(
-                    _x_coordinate(line.cursorToX(span.start - line_start_index))
+                    _x_coordinate(line.cursorToX(span.start))
                     + span.fragment.width > available_width + 1e-6
                     for span in formula_spans
                     if line_start_index <= span.start and span.start + span.length <= line_end_index
@@ -698,10 +698,10 @@ class QTextParagraphFiller:
                     span for span in formula_spans
                     if line_start_index <= span.start and span.start + span.length <= line_end_index
                 )
-                actual_line_width = _x_coordinate(line.cursorToX(line.textLength())) + sum(
+                actual_line_width = _x_coordinate(line.cursorToX(line_end_index)) + sum(
                     span.fragment.width - (
-                        _x_coordinate(line.cursorToX(span.start + span.length - line_start_index))
-                        - _x_coordinate(line.cursorToX(span.start - line_start_index))
+                        _x_coordinate(line.cursorToX(span.start + span.length))
+                        - _x_coordinate(line.cursorToX(span.start))
                     )
                     for span in line_formula_spans
                 )
@@ -712,8 +712,8 @@ class QTextParagraphFiller:
                     *(fragment.height - fragment.descent for fragment in line_fragments),
                 ))
                 line_tops.append(line_baseline - line.ascent())
-                line_start = _x_coordinate(line.cursorToX(0))
-                line_end = _x_coordinate(line.cursorToX(line.textLength()))
+                line_start = _x_coordinate(line.cursorToX(line_start_index))
+                line_end = _x_coordinate(line.cursorToX(line_end_index))
                 line_text_lefts.append(content_left + line_start)
                 line_text_widths.append(line_end - line_start)
                 line_heights.append(line_height)
@@ -721,7 +721,7 @@ class QTextParagraphFiller:
                     if line_start_index <= span.start and span.start + span.length <= line_end_index:
                         formula_draws.append(FormulaDraw(
                             span.fragment.pdf,
-                            content_left + _x_coordinate(line.cursorToX(span.start - line_start_index)),
+                            content_left + _x_coordinate(line.cursorToX(span.start)),
                             line_baseline,
                             span.fragment.descent,
                         ))

--- a/pdf_craft/pipeline/pdf/text_layout.py
+++ b/pdf_craft/pipeline/pdf/text_layout.py
@@ -652,6 +652,19 @@ class QTextParagraphFiller:
         QtCore, QtGui = _qt_modules()
         _ensure_qt_application(QtGui)
         layout = self._create_layout(QtCore, QtGui, text, style, font_size)
+        # Formula spans retain Python indexes so _plan can slice the remaining
+        # text safely.  QTextLine positions, however, are absolute UTF-16
+        # units, so map the spans once for every current remaining-text layout.
+        # This matters for astral characters before a formula.
+        utf16_formula_spans = tuple(
+            _FormulaSpan(
+                _utf16_index_for_python(text, span.start),
+                _utf16_index_for_python(text, span.start + span.length)
+                - _utf16_index_for_python(text, span.start),
+                span.fragment,
+            )
+            for span in formula_spans
+        )
         content_left = rectangle.x + style.horizontal_padding
         line_tops: list[float] = []
         line_text_lefts: list[float] = []
@@ -672,7 +685,7 @@ class QTextParagraphFiller:
                 line_start_index = line.textStart()
                 line_end_index = line_start_index + line.textLength()
                 line_fragments = tuple(
-                    span.fragment for span in formula_spans
+                    span.fragment for span in utf16_formula_spans
                     if line_start_index <= span.start and span.start + span.length <= line_end_index
                 )
                 if line_fragments:
@@ -684,18 +697,18 @@ class QTextParagraphFiller:
                 # atom for the next source rectangle instead.
                 if any(
                     span.start < line_end_index < span.start + span.length
-                    for span in formula_spans
+                    for span in utf16_formula_spans
                 ):
                     break
                 if any(
                     _x_coordinate(line.cursorToX(span.start))
                     + span.fragment.width > available_width + 1e-6
-                    for span in formula_spans
+                    for span in utf16_formula_spans
                     if line_start_index <= span.start and span.start + span.length <= line_end_index
                 ):
                     break
                 line_formula_spans = tuple(
-                    span for span in formula_spans
+                    span for span in utf16_formula_spans
                     if line_start_index <= span.start and span.start + span.length <= line_end_index
                 )
                 actual_line_width = _x_coordinate(line.cursorToX(line_end_index)) + sum(
@@ -717,7 +730,7 @@ class QTextParagraphFiller:
                 line_text_lefts.append(content_left + line_start)
                 line_text_widths.append(line_end - line_start)
                 line_heights.append(line_height)
-                for span in formula_spans:
+                for span in line_formula_spans:
                     if line_start_index <= span.start and span.start + span.length <= line_end_index:
                         formula_draws.append(FormulaDraw(
                             span.fragment.pdf,
@@ -1073,6 +1086,11 @@ def _python_index_for_utf16(text: str, utf16_index: int) -> int:
         if units >= utf16_index:
             return index + 1
     return len(text)
+
+
+def _utf16_index_for_python(text: str, python_index: int) -> int:
+    """Translate a Python character boundary to Qt's UTF-16 text position."""
+    return len(text[:python_index].encode("utf-16-le")) // 2
 
 
 def _x_coordinate(cursor_position) -> float:

--- a/tests/test_pdf_inline_formula.py
+++ b/tests/test_pdf_inline_formula.py
@@ -164,7 +164,7 @@ class TestPDFInlineFormulaFallback(unittest.TestCase):
         fitted = filler.fit(replacement, {1: (80, 100)})
 
         placement = fitted.placements[0]
-        self.assertEqual(len(placement.line_tops), 2)
+        self.assertGreaterEqual(len(placement.line_tops), 2)
         self.assertEqual(len(placement.formula_draws), 1)
         # The formula follows abc on line two; a line-relative cursor lookup
         # would incorrectly reset it to the left edge.

--- a/tests/test_pdf_inline_formula.py
+++ b/tests/test_pdf_inline_formula.py
@@ -1,7 +1,10 @@
 """Regression coverage for safe inline-formula handling in PDF patches."""
 
+from io import BytesIO
 import unittest
 from typing import Any, cast
+
+import pypdf
 
 from pdf_craft.formula import latex_to_plain_text
 from pdf_craft.pipeline.pdf import PDFInlineFormula, PDFReplacement, PDFReplacementRegion
@@ -21,6 +24,9 @@ class TestPDFInlineFormulaFallback(unittest.TestCase):
         self.assertTrue(fragment.pdf.startswith(b"%PDF"))
         self.assertGreater(fragment.width, 0)
         self.assertGreater(fragment.height, fragment.descent)
+        page = cast(Any, pypdf.PdfReader(BytesIO(fragment.pdf)).pages[0])
+        self.assertAlmostEqual(float(page.mediabox.width), fragment.width, places=3)  # pylint: disable=no-member
+        self.assertAlmostEqual(float(page.mediabox.height), fragment.height, places=3)  # pylint: disable=no-member
 
     def test_plain_text_converter_is_shared_with_epub(self):
         self.assertEqual(latex_to_plain_text(r"\mathbb{Z}\to\mathbb{C}"), "ℤ→ℂ")
@@ -135,6 +141,31 @@ class TestPDFInlineFormulaFallback(unittest.TestCase):
         fitted = filler.fit(replacement, {1: (100, 100)})
 
         self.assertEqual(len(fitted.placements[0].formula_draws), 1)
+
+    def test_formula_draw_uses_the_wrapped_line_cursor_position(self):
+        class Renderer:
+            available = True
+
+            @staticmethod
+            def render(latex, point_size):
+                del latex, point_size
+                return FormulaFragment(b"%PDF-1.4", 10, 10, 2)
+
+        region = PDFReplacementRegion(1, (0, 0, 80, 100), (80, 100))
+        replacement = PDFReplacement(
+            1, region.bbox, "abcdefghij abc \ufffc", region.page_pixel_size,
+            regions=(region,), inline_formulas=(PDFInlineFormula("x"),),
+        )
+        filler = QTextParagraphFiller(PatchTextOptions(max_font_size=10, min_font_size=10))
+        filler._formula_renderer = cast(Any, Renderer())  # pylint: disable=protected-access
+        fitted = filler.fit(replacement, {1: (80, 100)})
+
+        placement = fitted.placements[0]
+        self.assertEqual(len(placement.line_tops), 2)
+        self.assertEqual(len(placement.formula_draws), 1)
+        # The formula follows abc on line two; a line-relative cursor lookup
+        # would incorrectly reset it to the left edge.
+        self.assertGreater(placement.formula_draws[0].x, 20)
 
     def test_tall_fragment_falls_back_before_it_can_escape_a_bbox(self):
         class Renderer:

--- a/tests/test_pdf_inline_formula.py
+++ b/tests/test_pdf_inline_formula.py
@@ -189,7 +189,7 @@ class TestPDFInlineFormulaFallback(unittest.TestCase):
         fitted = filler.fit(replacement, {1: (80, 100)})
 
         placement = fitted.placements[0]
-        self.assertEqual(len(placement.line_tops), 2)
+        self.assertGreaterEqual(len(placement.line_tops), 2)
         self.assertEqual(len(placement.formula_draws), 1)
         QtCore, QtGui = _qt_modules()
         _ensure_qt_application(QtGui)

--- a/tests/test_pdf_inline_formula.py
+++ b/tests/test_pdf_inline_formula.py
@@ -8,7 +8,10 @@ import pypdf
 
 from pdf_craft.formula import latex_to_plain_text
 from pdf_craft.pipeline.pdf import PDFInlineFormula, PDFReplacement, PDFReplacementRegion
-from pdf_craft.pipeline.pdf.text_layout import PatchTextOptions, QTextParagraphFiller
+from pdf_craft.pipeline.pdf.text_layout import (
+    PatchTextOptions, QTextParagraphFiller, _ensure_qt_application,
+    _qt_modules, _utf16_index_for_python, _x_coordinate,
+)
 from pdf_craft.pipeline.pdf.inline_formula import FormulaFragment
 from pdf_craft.pipeline.pdf.inline_formula import InlineFormulaPDFRenderer
 
@@ -166,6 +169,54 @@ class TestPDFInlineFormulaFallback(unittest.TestCase):
         # The formula follows abc on line two; a line-relative cursor lookup
         # would incorrectly reset it to the left edge.
         self.assertGreater(placement.formula_draws[0].x, 20)
+
+    def test_formula_draw_uses_utf16_cursor_position_after_astral_character(self):
+        class Renderer:
+            available = True
+
+            @staticmethod
+            def render(latex, point_size):
+                del latex, point_size
+                return FormulaFragment(b"%PDF-1.4", 10, 10, 2)
+
+        region = PDFReplacementRegion(1, (0, 0, 80, 100), (80, 100))
+        replacement = PDFReplacement(
+            1, region.bbox, "😀abcdefghij abc \ufffc", region.page_pixel_size,
+            regions=(region,), inline_formulas=(PDFInlineFormula("x"),),
+        )
+        filler = QTextParagraphFiller(PatchTextOptions(max_font_size=10, min_font_size=10))
+        filler._formula_renderer = cast(Any, Renderer())  # pylint: disable=protected-access
+        fitted = filler.fit(replacement, {1: (80, 100)})
+
+        placement = fitted.placements[0]
+        self.assertEqual(len(placement.line_tops), 2)
+        self.assertEqual(len(placement.formula_draws), 1)
+        QtCore, QtGui = _qt_modules()
+        _ensure_qt_application(QtGui)
+        layout = filler._create_layout(  # pylint: disable=protected-access
+            QtCore, QtGui, placement.remaining_text, placement.style, placement.font_size,
+        )
+        marker_index = placement.remaining_text.index("\u00a0")
+        marker_utf16_index = _utf16_index_for_python(placement.remaining_text, marker_index)
+        expected_x = None
+        layout.beginLayout()
+        try:
+            while True:
+                line = layout.createLine()
+                if not line.isValid():
+                    break
+                line.setLineWidth(placement.rectangle.width - 2 * placement.style.horizontal_padding)
+                if line.textStart() <= marker_utf16_index <= line.textStart() + line.textLength():
+                    expected_x = (
+                        placement.rectangle.x + placement.style.horizontal_padding
+                        + _x_coordinate(line.cursorToX(marker_utf16_index))
+                    )
+                    break
+        finally:
+            layout.endLayout()
+        self.assertIsNotNone(expected_x)
+        assert expected_x is not None
+        self.assertAlmostEqual(placement.formula_draws[0].x, expected_x)
 
     def test_tall_fragment_falls_back_before_it_can_escape_a_bbox(self):
         class Renderer:


### PR DESCRIPTION
## Summary
- generate tight vector PDF formula fragments through Matplotlib's PDF backend
- position formula runs with Qt UTF-16 cursor offsets, including astral Unicode text
- add fragment-boundary and wrapped formula regressions

## Verification
- poetry run pyright pdf_craft tests
- poetry run pylint pdf_craft/pipeline/pdf/inline_formula.py pdf_craft/pipeline/pdf/text_layout.py tests/test_pdf_inline_formula.py
- poetry run python test.py (381 passed)
- real patch smoke using table&formula.pdf plus the existing translated .pcex, visually reviewed page 1
