### PR TITLE
fix: load AMS fonts for inline PDF formulas

### DIFF
--- a/pdf_craft/pipeline/pdf/inline_formula.py
+++ b/pdf_craft/pipeline/pdf/inline_formula.py
@@ -11,6 +11,9 @@ from shutil import which
 import subprocess
 
 
+_TEX_PREAMBLE = r"\usepackage{amsfonts}"
+
+
 @dataclass(frozen=True)
 class FormulaFragment:
     """A cropped, transparent vector-PDF formula and its point metrics."""
@@ -78,7 +81,16 @@ class InlineFormulaPDFRenderer:
             from matplotlib.texmanager import TexManager  # type: ignore[reportMissingImports]
 
             expression = f"${latex}$"
-            with rc_context({"text.usetex": True, "font.family": "serif"}):
+            # PCEX formulas originate from mathematical source documents, where
+            # ``\mathbb`` is conventionally provided by amsfonts.  Matplotlib's
+            # default usetex preamble is intentionally minimal, so make this
+            # small, explicit baseline available to both measuring and drawing.
+            # A machine without it still follows the normal safe fallback.
+            with rc_context({
+                "text.usetex": True,
+                "font.family": "serif",
+                "text.latex.preamble": _TEX_PREAMBLE,
+            }):
                 width, height, descent = TexManager().get_text_width_height_descent(
                     expression, point_size, None,
                 )

--- a/tests/test_pdf_inline_formula.py
+++ b/tests/test_pdf_inline_formula.py
@@ -31,6 +31,17 @@ class TestPDFInlineFormulaFallback(unittest.TestCase):
         self.assertAlmostEqual(float(page.mediabox.width), fragment.width, places=3)  # pylint: disable=no-member
         self.assertAlmostEqual(float(page.mediabox.height), fragment.height, places=3)  # pylint: disable=no-member
 
+    def test_real_tex_renderer_supports_mathbb_when_available(self):
+        renderer = InlineFormulaPDFRenderer()
+        if not renderer.available:
+            self.skipTest("requires a complete local Matplotlib/TeX PDF backend")
+        fragment = renderer.render(r"(\mathbb{Z} / q\mathbb{Z})^{*}", 10)
+        self.assertIsNotNone(fragment)
+        assert fragment is not None
+        self.assertTrue(fragment.pdf.startswith(b"%PDF"))
+        self.assertGreater(fragment.width, 0)
+        self.assertGreater(fragment.height, fragment.descent)
+
     def test_plain_text_converter_is_shared_with_epub(self):
         self.assertEqual(latex_to_plain_text(r"\mathbb{Z}\to\mathbb{C}"), "ℤ→ℂ")
 


### PR DESCRIPTION
## Summary
- load the minimal AMS fonts preamble for Matplotlib inline TeX rendering
- render `\mathbb` formulas as vector PDF fragments instead of plain-text fallback
- cover `(\mathbb{Z} / q\mathbb{Z})^{*}` with a real TeX regression

## Verification
- `PYTHONWARNINGS=error::ResourceWarning poetry run python -m unittest tests.test_pdf_inline_formula`
- `poetry run pyright pdf_craft tests`
- `poetry run pylint pdf_craft tests`
- `poetry run python test.py` (382 passed)
- local `table&formula.pdf` PDF patch smoke, visually checked §2.2 mathbb formula