### PR TITLE
feat: normalize PDF patch font sizes per bbox

### DIFF
--- a/pdf_craft/pipeline/pdf/text_layout.py
+++ b/pdf_craft/pipeline/pdf/text_layout.py
@@ -1,7 +1,7 @@
 """Paragraph flow backed by Qt's native ``QTextLayout`` engine."""
 # pylint: disable=no-member,c-extension-no-member
 
-from collections.abc import Iterable, Iterator, Mapping
+from collections.abc import Callable, Iterable, Iterator, Mapping
 from dataclasses import dataclass, field, replace
 import os
 import pickle
@@ -269,6 +269,54 @@ class _WindowPlanStorage:
             self._page_plan_paths,
             self._temporary_directory,
         )
+
+    def rewrite_placements(
+        self,
+        transform: Callable[[int, RegionTextPlacement], RegionTextPlacement],
+    ) -> None:
+        """Replace placements one serialized page at a time.
+
+        A paragraph can stretch across a large document, so second-pass
+        typography must not first materialize all of its glyph coordinates in
+        a window-wide list.  Each page stream is read, transformed, and
+        atomically replaced before moving to the next one.
+        """
+        for path in self._page_plan_paths.values():
+            temporary_path = path.with_suffix(".updated")
+            with path.open("rb") as source, temporary_path.open("wb") as target:
+                while True:
+                    try:
+                        contribution = pickle.load(source)
+                    except EOFError:
+                        break
+                    rewritten = _PagePlanContribution(
+                        contribution.paragraph_index,
+                        contribution.regions,
+                        tuple(
+                            transform(contribution.paragraph_index, placement)
+                            for placement in contribution.placements
+                        ),
+                    )
+                    pickle.dump(rewritten, target, protocol=pickle.HIGHEST_PROTOCOL)
+            temporary_path.replace(path)
+
+    def page_contributions(self, page_index: int) -> Iterator[_PagePlanContribution]:
+        """Read one spooled page while retaining no other page's placements."""
+        try:
+            path = self._page_plan_paths[page_index]
+        except KeyError:
+            return
+        with path.open("rb") as stream:
+            while True:
+                try:
+                    yield pickle.load(stream)
+                except EOFError:
+                    return
+
+    @property
+    def page_indexes(self) -> tuple[int, ...]:
+        """The small index of pages that currently have serialized work."""
+        return tuple(self._page_plan_paths)
 
     def close(self) -> None:
         self._temporary_directory.cleanup()
@@ -1131,38 +1179,43 @@ class WindowedParagraphPlanner:
         storage = _WindowPlanStorage()
 
         try:
-            body_plans: list[tuple[PDFReplacement, FittedParagraph]] = []
+            body_replacements: dict[int, PDFReplacement] = {}
+            body_statistics: dict[tuple[int, str, int], list[float]] = {}
             for replacement in body:
                 paragraph = self._fit_or_skip(replacement)
                 if paragraph is None:
                     continue
-                body_plans.append((replacement, paragraph))
-            body_plans = self._normalize_window_placements(body_plans)
-            for replacement, paragraph in body_plans:
                 paragraph_index = len(summaries)
                 summaries.append(_PlannedParagraphSummary(
                     replacement, paragraph.text, paragraph.font_size,
                 ))
                 for placement in paragraph.placements:
-                    body_font_sizes[placement.page_index] = max(
-                        body_font_sizes.get(placement.page_index, 0.0), paragraph.font_size,
-                    )
+                    self._record_font_size_statistic(body_statistics, replacement, placement)
                 storage.append(paragraph_index, replacement, paragraph)
+                body_replacements[paragraph_index] = replacement
+            body_targets = self._font_size_targets(body_statistics)
+            self._normalize_stored_placements(storage, body_replacements, body_targets)
+            body_font_sizes = self._stored_page_font_sizes(storage, body_replacements)
 
-            headline_plans: list[tuple[PDFReplacement, FittedParagraph]] = []
+            headline_replacements: dict[int, PDFReplacement] = {}
             headline_minimums: dict[int, float] = {}
+            headline_statistics: dict[tuple[int, str, int], list[float]] = {}
             for replacement in headlines:
                 minimum = self._headline_minimum(replacement, body_font_sizes)
                 paragraph = self._filler.fit_headline(replacement, self._page_sizes, minimum)
-                headline_plans.append((replacement, paragraph))
-                headline_minimums[id(replacement)] = minimum
-            headline_plans = self._normalize_window_placements(headline_plans, headline_minimums)
-            for replacement, paragraph in headline_plans:
                 paragraph_index = len(summaries)
                 summaries.append(_PlannedParagraphSummary(
                     replacement, paragraph.text, paragraph.font_size,
                 ))
+                for placement in paragraph.placements:
+                    self._record_font_size_statistic(headline_statistics, replacement, placement)
                 storage.append(paragraph_index, replacement, paragraph)
+                headline_replacements[paragraph_index] = replacement
+                headline_minimums[paragraph_index] = minimum
+            headline_targets = self._font_size_targets(headline_statistics)
+            self._normalize_stored_placements(
+                storage, headline_replacements, headline_targets, headline_minimums,
+            )
 
             if body_font_sizes:
                 latest_page = max(body_font_sizes)
@@ -1172,50 +1225,85 @@ class WindowedParagraphPlanner:
             storage.close()
             raise
 
-    def _normalize_window_placements(
+    @staticmethod
+    def _record_font_size_statistic(
+        statistics: dict[tuple[int, str, int], list[float]],
+        replacement: PDFReplacement,
+        placement: RegionTextPlacement,
+    ) -> None:
+        """Accumulate compact size statistics for a frozen placement."""
+        text = placement.assigned_text or placement.remaining_text
+        weight = len(text.strip())
+        if not weight:
+            return
+        statistic = statistics.setdefault(
+            (placement.page_index, replacement.layout_ref, replacement.layout_level),
+            [0.0, 0.0, 0.0],
+        )
+        statistic[0] += placement.font_size * weight
+        statistic[1] += weight
+        statistic[2] += 1
+
+    @staticmethod
+    def _font_size_targets(
+        statistics: Mapping[tuple[int, str, int], list[float]],
+    ) -> dict[tuple[int, str, int], float]:
+        """Return only averages supported by multiple bbox placements."""
+        return {
+            key: weighted_sizes / weights
+            for key, (weighted_sizes, weights, placement_count) in statistics.items()
+            if placement_count > 1 and weights > 0
+        }
+
+    def _normalize_stored_placements(
         self,
-        paragraphs: list[tuple[PDFReplacement, FittedParagraph]],
+        storage: _WindowPlanStorage,
+        replacements: Mapping[int, PDFReplacement],
+        targets: Mapping[tuple[int, str, int], float],
         minimum_font_sizes: Mapping[int, float] | None = None,
-    ) -> list[tuple[PDFReplacement, FittedParagraph]]:
-        """Make frozen region placements approach their page/style average.
+    ) -> None:
+        """Normalize serialized placements while keeping only one page live.
 
         First-pass paragraphs own inter-region flow.  This deliberately runs
         afterwards, grouping only placements that physically share a page and
         semantic level, then fitting each placement's already-consumed text
-        independently.  No second-pass decision can move text across regions.
+        independently.  No second-pass decision can move text across regions,
+        and the page streams avoid retaining a long paragraph's full geometry.
         """
-        samples: dict[tuple[int, str, int], list[tuple[int, RegionTextPlacement]]] = {}
-        for paragraph_index, (replacement, paragraph) in enumerate(paragraphs):
-            for placement in paragraph.placements:
-                text = placement.assigned_text or placement.remaining_text
-                weight = len(text.strip())
-                if weight:
-                    samples.setdefault(
-                        (placement.page_index, replacement.layout_ref, replacement.layout_level), []
-                    ).append((paragraph_index, placement))
-        targets = {
-            key: sum(placement.font_size * len((placement.assigned_text or placement.remaining_text).strip())
-                     for _, placement in group)
-            / sum(len((placement.assigned_text or placement.remaining_text).strip()) for _, placement in group)
-            for key, group in samples.items()
-            if len(group) > 1
-        }
         if not targets:
-            return paragraphs
-        optimized: list[tuple[PDFReplacement, FittedParagraph]] = []
-        for replacement, paragraph in paragraphs:
-            placements = []
-            minimum = (minimum_font_sizes or {}).get(id(replacement))
-            for placement in paragraph.placements:
-                target = targets.get((
-                    placement.page_index, replacement.layout_ref, replacement.layout_level,
-                ))
-                placements.append(
-                    self._filler.fit_frozen_region(placement, target, minimum)
-                    if target is not None else placement
-                )
-            optimized.append((replacement, replace(paragraph, placements=tuple(placements))))
-        return optimized
+            return
+
+        def normalize(paragraph_index: int, placement: RegionTextPlacement) -> RegionTextPlacement:
+            replacement = replacements.get(paragraph_index)
+            if replacement is None:
+                return placement
+            target = targets.get((
+                placement.page_index, replacement.layout_ref, replacement.layout_level,
+            ))
+            if target is None:
+                return placement
+            return self._filler.fit_frozen_region(
+                placement, target, (minimum_font_sizes or {}).get(paragraph_index),
+            )
+
+        storage.rewrite_placements(normalize)
+
+    @staticmethod
+    def _stored_page_font_sizes(
+        storage: _WindowPlanStorage,
+        replacements: Mapping[int, PDFReplacement],
+    ) -> dict[int, float]:
+        """Read the normalized body stream back as compact per-page maxima."""
+        font_sizes: dict[int, float] = {}
+        for page_index in storage.page_indexes:
+            for contribution in storage.page_contributions(page_index):
+                if contribution.paragraph_index not in replacements:
+                    continue
+                for placement in contribution.placements:
+                    font_sizes[placement.page_index] = max(
+                        font_sizes.get(placement.page_index, 0.0), placement.font_size,
+                    )
+        return font_sizes
 
     def _fit_or_skip(self, replacement: PDFReplacement) -> FittedParagraph | None:
         try:

--- a/pdf_craft/pipeline/pdf/text_layout.py
+++ b/pdf_craft/pipeline/pdf/text_layout.py
@@ -694,6 +694,7 @@ class QTextParagraphFiller:
             effective_minimum,
             overflow_style,
             allows_horizontal_overflow=True,
+            assigned_text=text,
         )
         return FittedParagraph(text, effective_minimum, (placement,))
 
@@ -881,8 +882,6 @@ class QTextParagraphFiller:
         not constrain vertical glyph bounds: their height is often just the
         tight ink box rather than a typographic line box.
         """
-        if placement.allows_horizontal_overflow:
-            return placement
         text = placement.assigned_text or placement.remaining_text
         if not text:
             return placement
@@ -895,6 +894,8 @@ class QTextParagraphFiller:
         minimum = max(style.min_font_size, minimum_font_size or style.min_font_size)
         maximum = max(style.max_font_size, minimum)
         target = min(max(target_font_size, minimum), maximum)
+        if placement.allows_horizontal_overflow:
+            return self._fit_frozen_overflow_region(placement, text, target)
 
         def candidate(size: float) -> RegionTextPlacement | None:
             local_text, formula_spans = self._formula_spans_for_frozen_region(
@@ -946,6 +947,57 @@ class QTextParagraphFiller:
                     best = fitted
                     high = middle
         return best
+
+    def _fit_frozen_overflow_region(
+        self,
+        placement: RegionTextPlacement,
+        text: str,
+        font_size: float,
+    ) -> RegionTextPlacement:
+        """Re-layout one headline as its required natural-width overflow line.
+
+        Overflow is a headline-specific constraint relaxation: it keeps the
+        physical bbox's left edge and vertical centre, but never wraps or
+        clips at its right edge.  That remains true during local
+        normalization, so a same-level page target can update the font size
+        without turning an intentionally overflowing headline into a normal
+        constrained paragraph.
+        """
+        if placement.formula_draws:
+            # Overflow headlines currently materialize inline formulas as
+            # text before this path.  Retaining an unexpected vector atom is
+            # safer than drawing it with coordinates measured at another size.
+            return placement
+        QtCore, QtGui = _qt_modules()
+        _ensure_qt_application(QtGui)
+        layout = self._create_layout(QtCore, QtGui, text, placement.style, font_size)
+        layout.beginLayout()
+        try:
+            line = layout.createLine()
+            if not line.isValid():
+                return placement
+            line.setLineWidth(_HEADLINE_OVERFLOW_LINE_WIDTH)
+            if line.textLength() != _utf16_index_for_python(text, len(text)):
+                return placement
+            line_height = line.height()
+            line_start = _x_coordinate(line.cursorToX(0))
+            line_end = _x_coordinate(line.cursorToX(line.textLength()))
+        finally:
+            layout.endLayout()
+        rectangle = placement.rectangle
+        return RegionTextPlacement(
+            placement.page_index,
+            rectangle,
+            text,
+            (rectangle.x + line_start,),
+            (line_end - line_start,),
+            (rectangle.top + (rectangle.height - line_height) / 2,),
+            (line_height,),
+            font_size,
+            placement.style,
+            allows_horizontal_overflow=True,
+            assigned_text=text,
+        )
 
     def _formula_spans_for_frozen_region(
         self, placement: RegionTextPlacement, font_size: float,

--- a/pdf_craft/pipeline/pdf/text_layout.py
+++ b/pdf_craft/pipeline/pdf/text_layout.py
@@ -155,6 +155,10 @@ class RegionTextPlacement:
     style: PatchTextStyle
     allows_horizontal_overflow: bool = False
     formula_draws: tuple["FormulaDraw", ...] = ()
+    # The exact text consumed by this region during the paragraph-wide first
+    # pass.  ``remaining_text`` is retained for compatibility, but a later
+    # local optimisation must never reflow text into a neighbouring region.
+    assigned_text: str = ""
 
 
 @dataclass(frozen=True)
@@ -165,6 +169,12 @@ class FormulaDraw:
     x: float
     baseline: float
     descent: float
+    # Keep enough source information to re-measure the atom during the local
+    # second pass.  The proxy location is expressed in Python string indexes
+    # of this placement's assigned text.
+    latex: str = ""
+    proxy_start: int = 0
+    proxy_length: int = 0
 
 
 @dataclass(frozen=True)
@@ -172,11 +182,16 @@ class _FormulaSpan:
     start: int
     length: int
     fragment: FormulaFragment
+    latex: str
 
 
 @dataclass(frozen=True)
 class FittedParagraph:
-    """A complete paragraph layout proven to fit its ordered source regions."""
+    """A paragraph flow plan proven to fit its ordered source regions.
+
+    ``font_size`` is the uniform first-pass size.  Its frozen placements may
+    subsequently carry independently normalized local sizes.
+    """
 
     text: str
     font_size: float
@@ -566,7 +581,7 @@ class QTextParagraphFiller:
             placements.append(placement)
             remaining = remaining[consumed:]
             remaining_spans = tuple(
-                _FormulaSpan(span.start - consumed, span.length, span.fragment)
+                _FormulaSpan(span.start - consumed, span.length, span.fragment, span.latex)
                 for span in remaining_spans if span.start >= consumed
             )
         if remaining:
@@ -642,6 +657,7 @@ class QTextParagraphFiller:
         style: PatchTextStyle,
         font_size: float,
         formula_spans: tuple[_FormulaSpan, ...] = (),
+        ignore_height: bool = False,
     ) -> tuple[RegionTextPlacement | None, int]:
         available_width = rectangle.width - 2 * style.horizontal_padding
         available_top = rectangle.top + style.vertical_padding
@@ -662,6 +678,7 @@ class QTextParagraphFiller:
                 _utf16_index_for_python(text, span.start + span.length)
                 - _utf16_index_for_python(text, span.start),
                 span.fragment,
+                span.latex,
             )
             for span in formula_spans
         )
@@ -690,7 +707,7 @@ class QTextParagraphFiller:
                 )
                 if line_fragments:
                     line_height = max(line_height, *(fragment.height for fragment in line_fragments))
-                if y + line_height > available_bottom + 1e-6:
+                if not ignore_height and y + line_height > available_bottom + 1e-6:
                     break
                 # QTextLayout may wrap anywhere.  Never accept a line that
                 # cuts through one formula's width proxy: leave the complete
@@ -737,6 +754,10 @@ class QTextParagraphFiller:
                             content_left + _x_coordinate(line.cursorToX(span.start)),
                             line_baseline,
                             span.fragment.descent,
+                            span.latex,
+                            _python_index_for_utf16(text, span.start),
+                            _python_index_for_utf16(text, span.start + span.length)
+                            - _python_index_for_utf16(text, span.start),
                         ))
                 consumed_utf16 = line.textStart() + line.textLength()
                 last_line_height = line_height
@@ -754,6 +775,7 @@ class QTextParagraphFiller:
             shift = spare
         else:
             shift = 0.0
+        consumed = _python_index_for_utf16(text, consumed_utf16)
         return RegionTextPlacement(
             page_index,
             rectangle,
@@ -765,14 +787,19 @@ class QTextParagraphFiller:
             font_size,
             style,
             formula_draws=tuple(
-                FormulaDraw(draw.pdf, draw.x, draw.baseline + shift, draw.descent)
+                FormulaDraw(
+                    draw.pdf, draw.x, draw.baseline + shift, draw.descent,
+                    draw.latex, draw.proxy_start, draw.proxy_length,
+                )
                 for draw in formula_draws
             ),
-        ), _python_index_for_utf16(text, consumed_utf16)
+            assigned_text=text[:consumed],
+        ), consumed
 
     def _draw_placement(self, QtCore, QtGui, painter, placement: RegionTextPlacement) -> None:
         layout = self._create_layout(
-            QtCore, QtGui, placement.remaining_text, placement.style, placement.font_size,
+            QtCore, QtGui, placement.assigned_text or placement.remaining_text,
+            placement.style, placement.font_size,
         )
         if placement.allows_horizontal_overflow:
             available_width = _HEADLINE_OVERFLOW_LINE_WIDTH
@@ -791,6 +818,144 @@ class QTextParagraphFiller:
         finally:
             layout.endLayout()
         layout.draw(painter, QtCore.QPointF(0, 0))
+
+    def fit_frozen_region(
+        self,
+        placement: RegionTextPlacement,
+        target_font_size: float,
+        minimum_font_size: float | None = None,
+    ) -> RegionTextPlacement:
+        """Project one already-assigned region towards a local target size.
+
+        The first paragraph pass owns text flow between source rectangles.  A
+        second pass may only reflow the text it consumed itself, and only while
+        preserving its exact line count.  One-line OCR boxes intentionally do
+        not constrain vertical glyph bounds: their height is often just the
+        tight ink box rather than a typographic line box.
+        """
+        if placement.allows_horizontal_overflow:
+            return placement
+        text = placement.assigned_text or placement.remaining_text
+        if not text:
+            return placement
+        expected_lines = len(placement.line_tops)
+        if not expected_lines:
+            return placement
+
+        style = placement.style
+        original = placement.font_size
+        minimum = max(style.min_font_size, minimum_font_size or style.min_font_size)
+        maximum = max(style.max_font_size, minimum)
+        target = min(max(target_font_size, minimum), maximum)
+
+        def candidate(size: float) -> RegionTextPlacement | None:
+            local_text, formula_spans = self._formula_spans_for_frozen_region(
+                placement, size,
+            )
+            if local_text is None:
+                return None
+            fitted, consumed = self._fit_region(
+                placement.page_index,
+                placement.rectangle,
+                local_text,
+                style,
+                size,
+                formula_spans,
+                ignore_height=expected_lines == 1,
+            )
+            if (
+                fitted is None
+                or consumed != len(local_text)
+                or len(fitted.line_tops) != expected_lines
+            ):
+                return None
+            return fitted
+
+        exact = candidate(target)
+        if exact is not None:
+            return exact
+        # Font-size changes are monotone for a fixed local string in normal Qt
+        # wrapping.  Keep the first-pass size as the known feasible endpoint
+        # and approach the page-level target without crossing a line-count or
+        # bbox boundary.  The 0.05pt tolerance is shared with first-pass fit.
+        low, high = sorted((original, target))
+        best = candidate(original) or placement
+        for _ in range(_MAX_FONT_SIZE_SEARCH_ITERATIONS):
+            if high - low <= _FONT_SIZE_TOLERANCE:
+                break
+            middle = (low + high) / 2
+            fitted = candidate(middle)
+            if target > original:
+                if fitted is None:
+                    high = middle
+                else:
+                    best = fitted
+                    low = middle
+            else:
+                if fitted is None:
+                    low = middle
+                else:
+                    best = fitted
+                    high = middle
+        return best
+
+    def _formula_spans_for_frozen_region(
+        self, placement: RegionTextPlacement, font_size: float,
+    ) -> tuple[str | None, tuple[_FormulaSpan, ...]]:
+        """Rebuild vector formula proxies for one already-owned text run.
+
+        Formula fragments depend on point size.  Keeping their old PDFs while
+        changing nearby text size would make Qt reserve one width and the
+        composer draw another.  We therefore re-render every atom from the
+        source retained in ``FormulaDraw``.  If that cannot be done, retaining
+        the first-pass placement is safer than degrading the formula or
+        splitting it across a region boundary.
+        """
+        text = placement.assigned_text or placement.remaining_text
+        if not placement.formula_draws:
+            return text, ()
+        if not self.options.render_inline_formulas or not self._formula_renderer.available:
+            return None, ()
+        draws = tuple(sorted(placement.formula_draws, key=lambda draw: draw.proxy_start))
+        if any(not draw.latex or draw.proxy_length <= 0 for draw in draws):
+            return None, ()
+
+        QtCore, QtGui = _qt_modules()
+        del QtCore
+        _ensure_qt_application(QtGui)
+        font = QtGui.QFont(placement.style.font_name or "")
+        font.setPointSizeF(font_size)
+        space_width = float(QtGui.QFontMetricsF(font).horizontalAdvance("\u00a0"))
+        if space_width <= 0:
+            return None, ()
+        maximum_width = placement.rectangle.width - 2 * placement.style.horizontal_padding
+        maximum_height = placement.rectangle.height - 2 * placement.style.vertical_padding
+        parts: list[str] = []
+        spans: list[_FormulaSpan] = []
+        cursor = 0
+        offset = 0
+        for draw in draws:
+            start = draw.proxy_start
+            end = start + draw.proxy_length
+            if start < cursor or end > len(text) or text[start:end] != "\u00a0" * draw.proxy_length:
+                return None, ()
+            fragment = self._formula_renderer.render(draw.latex, font_size)
+            if (
+                fragment is None
+                or fragment.width > maximum_width
+                or (len(placement.line_tops) != 1 and fragment.height > maximum_height)
+            ):
+                return None, ()
+            prefix = text[cursor:start]
+            parts.append(prefix)
+            offset += len(prefix)
+            length = max(1, round(fragment.width / space_width))
+            parts.append("\u00a0" * length)
+            spans.append(_FormulaSpan(offset, length, fragment, draw.latex))
+            offset += length
+            cursor = end
+        parts.append(text[cursor:])
+        return "".join(parts), tuple(spans)
 
     @staticmethod
     def _create_layout(QtCore, QtGui, text: str, style: PatchTextStyle, font_size: float):
@@ -892,7 +1057,7 @@ class QTextParagraphFiller:
                 continue
             length = max(1, round(fragment.width / space_width))
             parts.append("\u00a0" * length)
-            spans.append(_FormulaSpan(offset, length, fragment))
+            spans.append(_FormulaSpan(offset, length, fragment, formula.latex))
             offset += length
         return "".join(parts), tuple(spans)
 
@@ -966,10 +1131,14 @@ class WindowedParagraphPlanner:
         storage = _WindowPlanStorage()
 
         try:
+            body_plans: list[tuple[PDFReplacement, FittedParagraph]] = []
             for replacement in body:
                 paragraph = self._fit_or_skip(replacement)
                 if paragraph is None:
                     continue
+                body_plans.append((replacement, paragraph))
+            body_plans = self._normalize_window_placements(body_plans)
+            for replacement, paragraph in body_plans:
                 paragraph_index = len(summaries)
                 summaries.append(_PlannedParagraphSummary(
                     replacement, paragraph.text, paragraph.font_size,
@@ -980,9 +1149,15 @@ class WindowedParagraphPlanner:
                     )
                 storage.append(paragraph_index, replacement, paragraph)
 
+            headline_plans: list[tuple[PDFReplacement, FittedParagraph]] = []
+            headline_minimums: dict[int, float] = {}
             for replacement in headlines:
                 minimum = self._headline_minimum(replacement, body_font_sizes)
                 paragraph = self._filler.fit_headline(replacement, self._page_sizes, minimum)
+                headline_plans.append((replacement, paragraph))
+                headline_minimums[id(replacement)] = minimum
+            headline_plans = self._normalize_window_placements(headline_plans, headline_minimums)
+            for replacement, paragraph in headline_plans:
                 paragraph_index = len(summaries)
                 summaries.append(_PlannedParagraphSummary(
                     replacement, paragraph.text, paragraph.font_size,
@@ -996,6 +1171,51 @@ class WindowedParagraphPlanner:
         except Exception:
             storage.close()
             raise
+
+    def _normalize_window_placements(
+        self,
+        paragraphs: list[tuple[PDFReplacement, FittedParagraph]],
+        minimum_font_sizes: Mapping[int, float] | None = None,
+    ) -> list[tuple[PDFReplacement, FittedParagraph]]:
+        """Make frozen region placements approach their page/style average.
+
+        First-pass paragraphs own inter-region flow.  This deliberately runs
+        afterwards, grouping only placements that physically share a page and
+        semantic level, then fitting each placement's already-consumed text
+        independently.  No second-pass decision can move text across regions.
+        """
+        samples: dict[tuple[int, str, int], list[tuple[int, RegionTextPlacement]]] = {}
+        for paragraph_index, (replacement, paragraph) in enumerate(paragraphs):
+            for placement in paragraph.placements:
+                text = placement.assigned_text or placement.remaining_text
+                weight = len(text.strip())
+                if weight:
+                    samples.setdefault(
+                        (placement.page_index, replacement.layout_ref, replacement.layout_level), []
+                    ).append((paragraph_index, placement))
+        targets = {
+            key: sum(placement.font_size * len((placement.assigned_text or placement.remaining_text).strip())
+                     for _, placement in group)
+            / sum(len((placement.assigned_text or placement.remaining_text).strip()) for _, placement in group)
+            for key, group in samples.items()
+            if len(group) > 1
+        }
+        if not targets:
+            return paragraphs
+        optimized: list[tuple[PDFReplacement, FittedParagraph]] = []
+        for replacement, paragraph in paragraphs:
+            placements = []
+            minimum = (minimum_font_sizes or {}).get(id(replacement))
+            for placement in paragraph.placements:
+                target = targets.get((
+                    placement.page_index, replacement.layout_ref, replacement.layout_level,
+                ))
+                placements.append(
+                    self._filler.fit_frozen_region(placement, target, minimum)
+                    if target is not None else placement
+                )
+            optimized.append((replacement, replace(paragraph, placements=tuple(placements))))
+        return optimized
 
     def _fit_or_skip(self, replacement: PDFReplacement) -> FittedParagraph | None:
         try:

--- a/tests/test_pdf_inline_formula.py
+++ b/tests/test_pdf_inline_formula.py
@@ -108,6 +108,32 @@ class TestPDFInlineFormulaFallback(unittest.TestCase):
         self.assertEqual(len(draws), 1)
         self.assertEqual(draws[0].pdf, b"%PDF-1.4")
 
+    def test_second_pass_rerenders_formula_atom_at_its_local_font_size(self):
+        class Renderer:
+            available = True
+
+            @staticmethod
+            def render(latex, point_size):
+                return FormulaFragment(
+                    f"%PDF-{latex}-{point_size}".encode(), point_size * 2, point_size, 2,
+                )
+
+        region = PDFReplacementRegion(1, (0, 0, 200, 100), (200, 100))
+        replacement = PDFReplacement(
+            1, region.bbox, "before \ufffc after", region.page_pixel_size,
+            regions=(region,), inline_formulas=(PDFInlineFormula("x^2"),),
+        )
+        filler = QTextParagraphFiller(PatchTextOptions(max_font_size=20, min_font_size=4))
+        filler._formula_renderer = cast(Any, Renderer())  # pylint: disable=protected-access
+        initial = filler.fit(replacement, {1: (200, 100)}).placements[0]
+
+        reflowed = filler.fit_frozen_region(initial, 12)
+
+        self.assertEqual(reflowed.font_size, 12)
+        self.assertEqual(len(reflowed.formula_draws), 1)
+        self.assertEqual(reflowed.formula_draws[0].latex, "x^2")
+        self.assertEqual(reflowed.formula_draws[0].pdf, b"%PDF-x^2-12")
+
     def test_one_formula_failure_does_not_hide_a_later_formula(self):
         class Renderer:
             available = True

--- a/tests/test_pdf_inline_formula.py
+++ b/tests/test_pdf_inline_formula.py
@@ -129,10 +129,17 @@ class TestPDFInlineFormulaFallback(unittest.TestCase):
 
         reflowed = filler.fit_frozen_region(initial, 12)
 
-        self.assertEqual(reflowed.font_size, 12)
+        # The proxy uses the active platform font's space metrics, so a line
+        # boundary can make 12pt infeasible on one platform but not another.
+        # The invariant is that the surviving local candidate re-renders the
+        # atom at its own final point size rather than retaining the old PDF.
+        self.assertLessEqual(reflowed.font_size, initial.font_size)
         self.assertEqual(len(reflowed.formula_draws), 1)
         self.assertEqual(reflowed.formula_draws[0].latex, "x^2")
-        self.assertEqual(reflowed.formula_draws[0].pdf, b"%PDF-x^2-12")
+        self.assertEqual(
+            reflowed.formula_draws[0].pdf,
+            f"%PDF-x^2-{reflowed.font_size}".encode(),
+        )
 
     def test_one_formula_failure_does_not_hide_a_later_formula(self):
         class Renderer:

--- a/tests/test_pdf_text_layout.py
+++ b/tests/test_pdf_text_layout.py
@@ -4,8 +4,9 @@ import unittest
 
 from pdf_craft.pipeline.pdf import (
     FittedParagraph, PDFReplacement, PDFReplacementRegion, PatchTextOptions, PatchTextStyle,
-    QTextParagraphFiller,
+    QTextParagraphFiller, RegionTextPlacement,
 )
+from pdf_craft.pipeline.pdf.geometry import PageRectangle
 from pdf_craft.pipeline.pdf.text_layout import _choose_automatic_font
 
 
@@ -113,6 +114,62 @@ class TestQTextParagraphFiller(unittest.TestCase):
         self.assertEqual(len(fitted.placements[0].line_tops), 1)
         self.assertGreaterEqual(len(fitted.placements[1].line_tops), 1)
         self.assertTrue(fitted.placements[1].remaining_text.startswith("second"))
+
+    def test_second_pass_keeps_frozen_multi_bbox_text_and_line_ownership(self):
+        regions = [
+            PDFReplacementRegion(1, (0, 0, 90, 18), (100, 100)),
+            PDFReplacementRegion(1, (0, 20, 90, 80), (100, 100)),
+        ]
+        filler = QTextParagraphFiller(PatchTextOptions(max_font_size=10, min_font_size=4))
+        fitted = filler.fit(
+            _replacement("first line second line third line", regions), {1: (100, 100)},
+        )
+        self.assertGreaterEqual(len(fitted.placements), 2)
+
+        reflowed = tuple(
+            filler.fit_frozen_region(placement, placement.font_size * 0.8)
+            for placement in fitted.placements
+        )
+
+        self.assertEqual(
+            [placement.assigned_text for placement in reflowed],
+            [placement.assigned_text for placement in fitted.placements],
+        )
+        self.assertEqual(
+            [len(placement.line_tops) for placement in reflowed],
+            [len(placement.line_tops) for placement in fitted.placements],
+        )
+
+    def test_second_pass_stops_at_a_deterministic_infeasible_boundary(self):
+        class ThresholdFiller(QTextParagraphFiller):
+            def _fit_region(
+                self, page_index, rectangle, text, style, font_size,
+                formula_spans=(), ignore_height=False,
+            ):
+                del formula_spans, ignore_height
+                if font_size > 10:
+                    return None, 0
+                return RegionTextPlacement(
+                    page_index, rectangle, text,
+                    (rectangle.x,), (rectangle.width,), (rectangle.top, rectangle.top + 12),
+                    (12, 12), font_size, style, assigned_text=text,
+                ), len(text)
+
+        style = PatchTextStyle(max_font_size=20, min_font_size=4)
+        original = RegionTextPlacement(
+            1, PageRectangle(0, 0, 100, 30), "fixed text",
+            (0, 0), (50, 50), (0, 12), (12, 12), 8, style,
+            assigned_text="fixed text",
+        )
+
+        reflowed = ThresholdFiller(PatchTextOptions(styles={"text": style})).fit_frozen_region(
+            original, 14,
+        )
+
+        self.assertEqual(reflowed.assigned_text, "fixed text")
+        self.assertEqual(len(reflowed.line_tops), 2)
+        self.assertLessEqual(reflowed.font_size, 10)
+        self.assertLess(10 - reflowed.font_size, 0.05)
 
     def test_selects_largest_uniform_font_size_for_the_paragraph(self):
         regions = [PDFReplacementRegion(1, (0, 0, 100, 0 + 100), (100, 100))]

--- a/tests/test_pdf_windowed_layout.py
+++ b/tests/test_pdf_windowed_layout.py
@@ -1,10 +1,13 @@
 import unittest
+from dataclasses import replace
 from pathlib import Path
 
 from pdf_craft.pipeline.pdf import (
     PDFReplacement, PDFReplacementRegion,
-    PatchTextOptions, PatchTextStyle, QTextParagraphFiller, WindowedParagraphPlanner,
+    FittedParagraph, PatchTextOptions, PatchTextStyle, QTextParagraphFiller,
+    RegionTextPlacement, WindowedParagraphPlanner,
 )
+from pdf_craft.pipeline.pdf.geometry import PageRectangle
 
 
 def _replacement(
@@ -29,7 +32,78 @@ def _line_region(page_index: int) -> PDFReplacementRegion:
     return PDFReplacementRegion(page_index, (0, 0, 240, 32), (240, 100))
 
 
+def _placement(text: str, font_size: float, *, lines: int = 1) -> RegionTextPlacement:
+    style = PatchTextStyle(max_font_size=24, min_font_size=4)
+    return RegionTextPlacement(
+        1, PageRectangle(0, 0, 200, 80), text,
+        (0.0,) * lines, (20.0,) * lines,
+        tuple(float(index * 12) for index in range(lines)), (12.0,) * lines,
+        font_size, style, assigned_text=text,
+    )
+
+
 class TestWindowedParagraphPlanner(unittest.TestCase):
+    def test_second_pass_uses_page_level_weighted_target_without_moving_text(self):
+        options = PatchTextOptions()
+        filler = QTextParagraphFiller(options)
+        planner = WindowedParagraphPlanner(filler, {1: (200, 80)}, options)
+        short = _replacement("aa", [_region(1)])
+        long = _replacement("bbbbbbbb", [_region(1)])
+        short_placement = _placement("aa", 8)
+        long_placement = _placement("bbbbbbbb", 12)
+        observed: list[tuple[str, float]] = []
+
+        def record(placement, target, minimum=None):
+            del minimum
+            observed.append((placement.assigned_text, target))
+            return replace(placement, font_size=target)
+
+        filler.fit_frozen_region = record  # type: ignore[method-assign]
+        normalized = planner._normalize_window_placements([  # pylint: disable=protected-access
+            (short, FittedParagraph(short.text, 8, (short_placement,))),
+            (long, FittedParagraph(long.text, 12, (long_placement,))),
+        ])
+
+        # (2 * 8 + 8 * 12) / 10: the actual run assigned to each bbox is the
+        # weight, not the complete paragraph's still-remaining text.
+        self.assertEqual(observed, [("aa", 11.2), ("bbbbbbbb", 11.2)])
+        self.assertEqual(normalized[0][1].placements[0].assigned_text, "aa")
+        self.assertEqual(normalized[1][1].placements[0].assigned_text, "bbbbbbbb")
+
+    def test_second_pass_is_local_and_allows_one_line_to_escape_tight_ocr_height(self):
+        region = PDFReplacementRegion(1, (0, 0, 160, 14), (160, 14))
+        filler = QTextParagraphFiller(PatchTextOptions(max_font_size=20, min_font_size=4))
+        fitted = filler.fit(_replacement("one short line", [region]), {1: (160, 14)})
+        original = fitted.placements[0]
+        self.assertEqual(len(original.line_tops), 1)
+
+        reflowed = filler.fit_frozen_region(original, 14)
+
+        self.assertEqual(reflowed.assigned_text, original.assigned_text)
+        self.assertEqual(len(reflowed.line_tops), 1)
+        self.assertEqual(reflowed.font_size, 14)
+        self.assertGreater(
+            reflowed.line_tops[0] + reflowed.line_heights[0], reflowed.rectangle.bottom,
+        )
+
+    def test_second_pass_keeps_multi_line_runs_inside_their_bbox(self):
+        region = PDFReplacementRegion(1, (0, 0, 80, 30), (80, 30))
+        filler = QTextParagraphFiller(PatchTextOptions(max_font_size=20, min_font_size=4))
+        fitted = filler.fit(
+            _replacement("one two three four five six", [region]), {1: (80, 30)},
+        )
+        original = fitted.placements[0]
+        self.assertGreaterEqual(len(original.line_tops), 2)
+
+        reflowed = filler.fit_frozen_region(original, 20)
+
+        self.assertEqual(reflowed.assigned_text, original.assigned_text)
+        self.assertEqual(len(reflowed.line_tops), len(original.line_tops))
+        self.assertLessEqual(
+            reflowed.line_tops[-1] + reflowed.line_heights[-1],
+            reflowed.rectangle.bottom + 1e-6,
+        )
+
     def test_default_style_reserves_headline_font_size_headroom(self):
         options = PatchTextOptions()
         planner = WindowedParagraphPlanner(

--- a/tests/test_pdf_windowed_layout.py
+++ b/tests/test_pdf_windowed_layout.py
@@ -43,7 +43,7 @@ def _placement(text: str, font_size: float, *, lines: int = 1) -> RegionTextPlac
 
 
 class TestWindowedParagraphPlanner(unittest.TestCase):
-    def test_second_pass_uses_page_level_weighted_target_without_moving_text(self):
+    def test_second_pass_uses_page_level_weighted_target(self):
         options = PatchTextOptions()
         filler = QTextParagraphFiller(options)
         planner = WindowedParagraphPlanner(filler, {1: (200, 80)}, options)
@@ -51,24 +51,57 @@ class TestWindowedParagraphPlanner(unittest.TestCase):
         long = _replacement("bbbbbbbb", [_region(1)])
         short_placement = _placement("aa", 8)
         long_placement = _placement("bbbbbbbb", 12)
-        observed: list[tuple[str, float]] = []
-
-        def record(placement, target, minimum=None):
-            del minimum
-            observed.append((placement.assigned_text, target))
-            return replace(placement, font_size=target)
-
-        filler.fit_frozen_region = record  # type: ignore[method-assign]
-        normalized = planner._normalize_window_placements([  # pylint: disable=protected-access
-            (short, FittedParagraph(short.text, 8, (short_placement,))),
-            (long, FittedParagraph(long.text, 12, (long_placement,))),
-        ])
+        statistics = {}
+        planner._record_font_size_statistic(statistics, short, short_placement)  # pylint: disable=protected-access
+        planner._record_font_size_statistic(statistics, long, long_placement)  # pylint: disable=protected-access
+        targets = planner._font_size_targets(statistics)  # pylint: disable=protected-access
 
         # (2 * 8 + 8 * 12) / 10: the actual run assigned to each bbox is the
         # weight, not the complete paragraph's still-remaining text.
-        self.assertEqual(observed, [("aa", 11.2), ("bbbbbbbb", 11.2)])
-        self.assertEqual(normalized[0][1].placements[0].assigned_text, "aa")
-        self.assertEqual(normalized[1][1].placements[0].assigned_text, "bbbbbbbb")
+        self.assertEqual(targets, {(1, "text", 0): 11.2})
+
+    def test_headline_minimum_uses_normalized_body_placement_size(self):
+        class Filler(QTextParagraphFiller):
+            def __init__(self):
+                super().__init__(PatchTextOptions(headline_min_body_ratio=1.2))
+                self.headline_minimum: float | None = None
+
+            def fit(self, replacement, page_sizes, minimum_font_size=None):
+                del page_sizes, minimum_font_size
+                font_size = 8 if replacement.text == "aa" else 12
+                placement = _placement(replacement.text, font_size)
+                return FittedParagraph(replacement.text, font_size, (placement,))
+
+            def fit_frozen_region(self, placement, target_font_size, minimum_font_size=None):
+                del minimum_font_size
+                return replace(placement, font_size=target_font_size)
+
+            def fit_headline(self, replacement, page_sizes, minimum_font_size):
+                del page_sizes
+                self.headline_minimum = minimum_font_size
+                placement = _placement(replacement.text, minimum_font_size)
+                return FittedParagraph(replacement.text, minimum_font_size, (placement,))
+
+        filler = Filler()
+        planner = WindowedParagraphPlanner(filler, {1: (200, 80)}, filler.options)
+        body_short = _replacement("aa", [_region(1)])
+        body_long = _replacement("bbbbbbbb", [_region(1)])
+        headline = _replacement("heading", [_region(1)], layout_ref="sub_title")
+
+        window = next(planner.plan([body_short, body_long, headline]))
+        try:
+            # The body target is 11.2pt, so the headline lower bound is based
+            # on that normalized on-page result, not the 8pt first pass.
+            self.assertIsNotNone(filler.headline_minimum)
+            assert filler.headline_minimum is not None
+            self.assertAlmostEqual(filler.headline_minimum, 13.44)
+            body_sizes = [
+                item.paragraph.placements[0].font_size
+                for item in window.paragraphs[:2]
+            ]
+            self.assertEqual(body_sizes, [11.2, 11.2])
+        finally:
+            window.close()
 
     def test_second_pass_is_local_and_allows_one_line_to_escape_tight_ocr_height(self):
         region = PDFReplacementRegion(1, (0, 0, 160, 14), (160, 14))
@@ -300,15 +333,18 @@ class TestWindowedParagraphPlanner(unittest.TestCase):
         self.assertEqual((first.first_page_index, first.last_page_index), (1, 1))
         self.assertEqual(consumed, [1, 2])
 
-    def test_serializes_long_paragraph_placements_by_page(self):
-        """A long paragraph keeps summaries in memory, not every glyph placement."""
+    def test_second_pass_rewrites_long_window_from_serialized_pages(self):
+        """A long window normalizes per page without retaining all placements."""
         page_count = 24
         regions = [
             PDFReplacementRegion(page_index, (0, 0, 240, 32), (240, 100))
             for page_index in range(1, page_count + 1)
         ]
-        replacement = _replacement(
+        first = _replacement(
             "one two three four five six seven " * 30, regions,
+        )
+        second = _replacement(
+            "eight nine ten eleven twelve thirteen " * 30, regions,
         )
         options = PatchTextOptions(max_font_size=8, min_font_size=8)
         planner = WindowedParagraphPlanner(
@@ -317,23 +353,30 @@ class TestWindowedParagraphPlanner(unittest.TestCase):
             options,
         )
 
-        window = next(planner.plan([replacement]))
+        window = next(planner.plan([first, second]))
         temporary_root = Path(window._temporary_directory.name)  # pylint: disable=protected-access
         try:
-            self.assertEqual(len(window._summaries), 1)  # pylint: disable=protected-access
-            self.assertFalse(hasattr(window._summaries[0], "placements"))  # pylint: disable=protected-access
+            self.assertEqual(len(window._summaries), 2)  # pylint: disable=protected-access
+            self.assertTrue(all(
+                not hasattr(summary, "placements")
+                for summary in window._summaries  # pylint: disable=protected-access
+            ))
             self.assertTrue(temporary_root.is_dir())
 
             active_pages = []
             for page_index in range(1, page_count + 1):
                 contributions = tuple(window.page_contributions(page_index))
-                self.assertEqual(len(contributions), 1)
-                self.assertEqual(contributions[0].regions, (regions[page_index - 1],))
-                if contributions[0].placements:
+                self.assertEqual(len(contributions), 2)
+                self.assertTrue(all(
+                    contribution.regions == (regions[page_index - 1],)
+                    for contribution in contributions
+                ))
+                if any(contribution.placements for contribution in contributions):
                     active_pages.append(page_index)
                     self.assertTrue(all(
                         placement.page_index == page_index
-                        for placement in contributions[0].placements
+                        for contribution in contributions
+                        for placement in contribution.placements
                     ))
             self.assertGreater(len(active_pages), 1)
         finally:

--- a/tests/test_pdf_windowed_layout.py
+++ b/tests/test_pdf_windowed_layout.py
@@ -60,6 +60,42 @@ class TestWindowedParagraphPlanner(unittest.TestCase):
         # weight, not the complete paragraph's still-remaining text.
         self.assertEqual(targets, {(1, "text", 0): 11.2})
 
+    def test_second_pass_normalizes_natural_overflow_headlines(self):
+        options = PatchTextOptions(styles={
+            "sub_title": PatchTextStyle(max_font_size=20, min_font_size=4),
+        })
+
+        class Filler(QTextParagraphFiller):
+            def __init__(self):
+                super().__init__(options)
+                self._headline_count = 0
+
+            def fit_headline(self, replacement, page_sizes, minimum_font_size):
+                del minimum_font_size
+                self._headline_count += 1
+                return self._plan_headline_overflow(  # pylint: disable=protected-access
+                    replacement, page_sizes, 8 if self._headline_count == 1 else 12,
+                )
+
+        filler = Filler()
+        planner = WindowedParagraphPlanner(filler, {1: (200, 100)}, options)
+        narrow = PDFReplacementRegion(1, (0, 20, 36, 50), (200, 100))
+        first = _replacement("A deliberately long heading", [narrow], layout_ref="sub_title")
+        second = _replacement("A deliberately long heading", [narrow], layout_ref="sub_title")
+        window = next(planner.plan([first, second]))
+        try:
+            normalized = [item.paragraph.placements[0] for item in window.paragraphs]
+            self.assertEqual([placement.font_size for placement in normalized], [10, 10])
+            self.assertTrue(all(placement.allows_horizontal_overflow for placement in normalized))
+            self.assertTrue(all(len(placement.line_tops) == 1 for placement in normalized))
+            self.assertTrue(all(
+                placement.line_text_lefts[0] == placement.rectangle.x
+                and placement.line_text_widths[0] > placement.rectangle.width
+                for placement in normalized
+            ))
+        finally:
+            window.close()
+
     def test_headline_minimum_uses_normalized_body_placement_size(self):
         class Filler(QTextParagraphFiller):
             def __init__(self):


### PR DESCRIPTION
## Summary
- add a second, bbox-local font-size normalization pass after paragraph flow
- spool normalization page by page to preserve bounded memory and use normalized body sizes for headline minima
- preserve natural right-overflow headline behavior while allowing it to normalize

## Validation
- poetry run python -m unittest discover -s tests
- poetry run ruff check pdf_craft/pipeline/pdf/text_layout.py tests/test_pdf_text_layout.py tests/test_pdf_windowed_layout.py
- poetry run pyright pdf_craft/pipeline/pdf/text_layout.py tests/test_pdf_text_layout.py tests/test_pdf_windowed_layout.py
- poetry run pylint pdf_craft/pipeline/pdf/text_layout.py tests/test_pdf_text_layout.py tests/test_pdf_windowed_layout.py