### PR TITLE
fix: defer PDF text wrapping to Qt

### DIFF
--- a/pdf_craft/pipeline/pdf/text_layout.py
+++ b/pdf_craft/pipeline/pdf/text_layout.py
@@ -468,7 +468,11 @@ class QTextParagraphFiller:
         side of a bounded binary search so a discontinuity at a wrapping
         threshold cannot produce an overflowing result.
         """
-        text = " ".join(replacement.text.split())
+        # Preserve the translated character stream verbatim.  QTextLayout is
+        # responsible for interpreting its whitespace and native line-break
+        # opportunities; the formula-object proxy built below is the sole
+        # intentional text-level substitution.
+        text = replacement.text
         font_text = self._materialize_formula_fallbacks(replacement)
         if not text:
             raise ValueError("replacement text must not be empty")
@@ -643,7 +647,7 @@ class QTextParagraphFiller:
         minimum_font_size: float,
     ) -> FittedParagraph:
         """Return an unwrapped headline anchored at its first source box."""
-        text = " ".join(self._materialize_formula_fallbacks(replacement).split())
+        text = self._materialize_formula_fallbacks(replacement)
         if not text:
             raise ValueError("replacement text must not be empty")
         style = self.options.style_for(replacement.layout_ref, replacement.layout_level)
@@ -1068,7 +1072,6 @@ class QTextParagraphFiller:
         font.setPointSizeF(font_size)
         font.setWeight(QtGui.QFont.Weight(style.font_weight))
         option = QtGui.QTextOption()
-        option.setWrapMode(QtGui.QTextOption.WrapMode.WrapAtWordBoundaryOrAnywhere)
         option.setAlignment({
             "left": QtCore.Qt.AlignmentFlag.AlignLeft,
             "center": QtCore.Qt.AlignmentFlag.AlignHCenter,

--- a/tests/test_pdf_text_layout.py
+++ b/tests/test_pdf_text_layout.py
@@ -102,6 +102,31 @@ class TestQTextParagraphFiller(unittest.TestCase):
         self.assertTrue(fitted.placements[0].remaining_text.startswith("one two"))
         self.assertNotEqual(fitted.placements[1].remaining_text, fitted.placements[0].remaining_text)
 
+    def test_keeps_ordinary_whitespace_for_qt_to_layout(self):
+        """Do not normalize translated whitespace before handing it to Qt."""
+        region = PDFReplacementRegion(1, (0, 0, 300, 100), (300, 100))
+        text = "alpha  beta\tgamma"
+        filler = QTextParagraphFiller(PatchTextOptions(max_font_size=10, min_font_size=10))
+
+        fitted = filler.fit(_replacement(text, [region]), {1: (300, 100)})
+
+        self.assertEqual(fitted.text, text)
+        self.assertEqual(fitted.placements[0].assigned_text, text)
+
+    def test_does_not_split_an_overwide_english_word_character_by_character(self):
+        """Qt's default WordWrap must not split ordinary words character by character."""
+        regions = [
+            PDFReplacementRegion(1, (0, 0, 12, 30), (200, 100)),
+            PDFReplacementRegion(1, (0, 32, 180, 80), (200, 100)),
+        ]
+        filler = QTextParagraphFiller(PatchTextOptions(max_font_size=10, min_font_size=10))
+
+        fitted = filler.fit(_replacement("apple", regions), {1: (200, 100)})
+
+        self.assertEqual(len(fitted.placements), 1)
+        self.assertEqual(fitted.placements[0].rectangle, PageRectangle(0, 0, 12, 30))
+        self.assertEqual(fitted.placements[0].assigned_text, "apple")
+
     def test_moves_a_whole_line_to_the_next_rectangle(self):
         regions = [
             PDFReplacementRegion(1, (0, 0, 90, 18), (100, 100)),


### PR DESCRIPTION
## Summary\n- restore QTextLayout's default WordWrap instead of forcing character-level fallback wrapping\n- preserve translated whitespace before it reaches Qt\n- retain the formula inline-span exception and add regression coverage\n\n## Verification\n- poetry run python -m unittest tests.test_pdf_text_layout tests.test_pdf_inline_formula tests.test_pdf_windowed_layout\n- poetry run pyright pdf_craft/pipeline/pdf/text_layout.py tests/test_pdf_text_layout.py\n- poetry run pylint pdf_craft/pipeline/pdf/text_layout.py tests/test_pdf_text_layout.py