### PR TITLE
fix: keep formula spacing within inline atom

### DIFF
--- a/pdf_craft/pipeline/pdf/text_layout.py
+++ b/pdf_craft/pipeline/pdf/text_layout.py
@@ -1126,6 +1126,12 @@ class QTextParagraphFiller:
         The proxy is an atom-sized NBSP run: Qt includes it in ordinary line
         breaking and alignment, while the composer later replaces its visual
         area with the transparent vector fragment at the measured baseline.
+        A literal space immediately after a rendered formula is made
+        non-breaking in this private layout representation.  It retains the
+        original space's visual advance, but belongs to the formula atom so
+        Qt cannot leave the formula at a source-region edge and start the
+        next line with the following text.  This is deliberately formula
+        structure, not a language- or punctuation-specific line-break rule.
         A fragment that cannot be rendered is immediately substituted with
         Unicode text instead, so one bad TeX expression never fails a page.
         """
@@ -1145,10 +1151,13 @@ class QTextParagraphFiller:
         spans: list[_FormulaSpan] = []
         formula_index = 0
         offset = 0
-        for character in text:
+        index = 0
+        while index < len(text):
+            character = text[index]
             if character != "\ufffc":
                 parts.append(character)
                 offset += 1
+                index += 1
                 continue
             formula = replacement.inline_formulas[formula_index]
             formula_index += 1
@@ -1157,11 +1166,20 @@ class QTextParagraphFiller:
                 fallback = latex_to_plain_text(formula.latex)
                 parts.append(fallback)
                 offset += len(fallback)
+                index += 1
                 continue
             length = max(1, round(fragment.width / space_width))
             parts.append("\u00a0" * length)
             spans.append(_FormulaSpan(offset, length, fragment, formula.latex))
             offset += length
+            index += 1
+            # The replacement's logical text remains untouched.  Only the
+            # formula's private Qt proxy absorbs its immediate ASCII spacer,
+            # preserving the width while making the inline atom indivisible.
+            if index < len(text) and text[index] == " ":
+                parts.append("\u00a0")
+                offset += 1
+                index += 1
         return "".join(parts), tuple(spans)
 
 

--- a/tests/test_pdf_inline_formula.py
+++ b/tests/test_pdf_inline_formula.py
@@ -189,6 +189,100 @@ class TestPDFInlineFormulaFallback(unittest.TestCase):
 
         self.assertEqual(len(fitted.placements[0].formula_draws), 1)
 
+    def test_formula_trailing_space_stays_with_the_atom_across_regions(self):
+        """A vector formula must not strand following text at a region edge.
+
+        This is the minimal cross-bbox counterpart of the translated PDF
+        regression: a formula is followed by ordinary source whitespace and
+        then Chinese punctuation.  The test does not teach Qt a punctuation
+        rule; it verifies that the formula's own separator is represented as
+        part of that indivisible inline atom.
+        """
+        class Renderer:
+            available = True
+
+            @staticmethod
+            def render(latex, point_size):
+                del latex, point_size
+                return FormulaFragment(b"%PDF-1.4", 28, 10, 2)
+
+        raw_text = "甲乙\ufffc ，后续文字"
+        broad_region = PDFReplacementRegion(1, (0, 0, 280, 80), (300, 100))
+        replacement = PDFReplacement(
+            1, broad_region.bbox, raw_text, broad_region.page_pixel_size,
+            regions=(broad_region,), inline_formulas=(PDFInlineFormula("q"),),
+        )
+        filler = QTextParagraphFiller(PatchTextOptions(max_font_size=10, min_font_size=10))
+        filler._formula_renderer = cast(Any, Renderer())  # pylint: disable=protected-access
+        style = filler._resolve_font(  # pylint: disable=protected-access
+            filler.options.style_for("text", 0), raw_text,
+        )
+        layout_text, spans = filler._formula_layout_text(  # pylint: disable=protected-access
+            raw_text, replacement, style, 10, 278, 78,
+        )
+        self.assertEqual(len(spans), 1)
+        span = spans[0]
+        self.assertEqual(layout_text[span.start + span.length], "\u00a0")
+        self.assertEqual(replacement.text, raw_text)
+
+        # Find a real Qt width where the old proxy would leave the comma at a
+        # new-line start but the atom-bound separator makes Qt move the whole
+        # formula.  The search avoids hard-coding platform font metrics.
+        unbound = (
+            layout_text[:span.start + span.length]
+            + " "
+            + layout_text[span.start + span.length + 1:]
+        )
+        QtCore, QtGui = _qt_modules()
+        _ensure_qt_application(QtGui)
+
+        def lines_for(text, width):
+            layout = filler._create_layout(  # pylint: disable=protected-access
+                QtCore, QtGui, text, style, 10,
+            )
+            lines = []
+            layout.beginLayout()
+            try:
+                while True:
+                    line = layout.createLine()
+                    if not line.isValid():
+                        break
+                    line.setLineWidth(width)
+                    start = line.textStart()
+                    lines.append(text[start:start + line.textLength()])
+            finally:
+                layout.endLayout()
+            return lines
+
+        width = None
+        for candidate in range(20, 160):
+            unbound_lines = lines_for(unbound, candidate)
+            bound_lines = lines_for(layout_text, candidate)
+            if (
+                len(unbound_lines) >= 2
+                and len(bound_lines) >= 2
+                and unbound_lines[1].startswith("，")
+                and not bound_lines[1].startswith("，")
+                and "\u00a0" * span.length in bound_lines[1]
+            ):
+                width = candidate
+                break
+        self.assertIsNotNone(width)
+        assert width is not None
+        first = PDFReplacementRegion(1, (0, 0, width, 22), (300, 100))
+        second = PDFReplacementRegion(1, (0, 25, 280, 90), (300, 100))
+        flowed = PDFReplacement(
+            1, first.bbox, raw_text, first.page_pixel_size,
+            regions=(first, second), inline_formulas=(PDFInlineFormula("q"),),
+        )
+
+        fitted = filler.fit(flowed, {1: (300, 100)})
+
+        self.assertEqual(len(fitted.placements), 2)
+        self.assertEqual(fitted.placements[0].formula_draws, ())
+        self.assertEqual(len(fitted.placements[1].formula_draws), 1)
+        self.assertFalse(fitted.placements[1].assigned_text.startswith("，"))
+
     def test_formula_draw_uses_the_wrapped_line_cursor_position(self):
         class Renderer:
             available = True


### PR DESCRIPTION
## Summary

- keep the separator after a rendered inline formula inside its private non-breaking Qt proxy
- preserve source replacement text and leave normal language line breaking to QTextLayout
- add a real Qt two-bbox regression for formula-adjacent punctuation

## Verification

- `poetry run python -m unittest tests.test_pdf_inline_formula tests.test_pdf_text_layout tests.test_pdf_windowed_layout`
- `poetry run pyright pdf_craft/pipeline/pdf/text_layout.py tests/test_pdf_inline_formula.py`
- `poetry run pylint pdf_craft/pipeline/pdf/text_layout.py tests/test_pdf_inline_formula.py`
- `poetry run python test.py`
- manual vector-formula PDF visual check using `table&formula.pdf`