### PR TITLE
改进 PDF 回填的目标线/禁止线拟合与高精度 Qt 度量

### DIFF
--- a/pdf_craft/pipeline/pdf/models.py
+++ b/pdf_craft/pipeline/pdf/models.py
@@ -46,6 +46,11 @@ class PDFReplacement:
     layout_ref: str = "text"
     layout_level: int = 0
     inline_formulas: tuple[PDFInlineFormula, ...] = ()
+    # Non-text source geometry (figures, tables, display formulas, …) which
+    # must remain clear when the text fitter uses the gap below a text bbox.
+    # Text regions are collected globally by the window planner, so callers
+    # only need to attach obstacles that are not themselves replacements.
+    obstacle_regions: tuple[PDFReplacementRegion, ...] = ()
 
     def source_regions(self) -> tuple[PDFReplacementRegion, ...]:
         """Return explicit paragraph regions or the legacy single region."""

--- a/pdf_craft/pipeline/pdf/patcher.py
+++ b/pdf_craft/pipeline/pdf/patcher.py
@@ -225,7 +225,9 @@ class PDFPatcher:
                             fragment = pypdf.PdfReader(BytesIO(formula.pdf)).pages[0]
                             page.merge_transformed_page(
                                 fragment,
-                                pypdf.Transformation().translate(
+                                pypdf.Transformation().scale(
+                                    1 / formula.scale, 1 / formula.scale,
+                                ).translate(
                                     formula.x, page_height - formula.baseline - formula.descent,
                                 ),
                             )

--- a/pdf_craft/pipeline/pdf/pipeline.py
+++ b/pdf_craft/pipeline/pdf/pipeline.py
@@ -7,7 +7,7 @@ from typing import cast
 from pdf_craft.extractor.chapter.chapter import AssetLayout, Chapter, ParagraphLayout, encode
 from pdf_craft.extractor.chapter.chapter import InlineExpression, Reference
 from pdf_craft.extractor.chapter.reader import create_chapters_reader
-from pdf_craft.markdown.paragraph import HTMLTag
+from pdf_craft.markdown.paragraph import HTMLTag, flatten
 from pdf_craft.formula import latex_to_plain_text
 from pdf_craft.document import PDFCraftExtraction
 from pdf_craft.transformer.events import TranslationEvent, TranslationEventKind, TranslationItemKind
@@ -155,13 +155,7 @@ class PDFTranslationPipeline:
         self, chapter: Chapter, transformer, pages,
         render_dpi: int, structured: bool = False,
     ) -> Iterator[PDFReplacement]:
-        obstacle_regions = tuple(
-            PDFReplacementRegion(
-                layout.page_index, layout.det, pages[layout.page_index], render_dpi,
-            )
-            for layout in chapter.layouts
-            if isinstance(layout, AssetLayout) and layout.page_index in pages
-        )
+        obstacle_regions = _chapter_obstacle_regions(chapter, pages, render_dpi)
         for layout in chapter.layouts:
             if not isinstance(layout, ParagraphLayout) or layout.ref not in {"text", "sub_title"}:
                 continue
@@ -256,6 +250,64 @@ def _to_pdf_patch_content(items) -> tuple[str, tuple[PDFInlineFormula, ...]]:
         else:
             raise TypeError(f"unsupported chapter content for PDF patching: {type(item).__name__}")
     return "".join(parts), tuple(formulas)
+
+
+def _chapter_obstacle_regions(chapter: Chapter, pages, render_dpi: int) -> tuple[PDFReplacementRegion, ...]:
+    """Collect non-flow geometry that may stop text from extending downward.
+
+    Top-level paragraph blocks are already represented by the replacement
+    regions passed to the window planner.  Assets and reference layouts are
+    not: references (notably footnotes) live beneath ``Reference.layouts``
+    rather than in ``Chapter.layouts``.  Their block and asset rectangles are
+    therefore explicit obstacles even when the reference itself is not being
+    translated.
+    """
+    regions: list[PDFReplacementRegion] = []
+    seen_regions: set[tuple[int, tuple[int, int, int, int]]] = set()
+    seen_references: set[tuple[int, int]] = set()
+
+    def add_region(page_index: int, det: tuple[int, int, int, int]) -> None:
+        if page_index not in pages:
+            raise ValueError(f"PDFCraftExtraction pages.xml is missing page {page_index}")
+        key = (page_index, det)
+        if key not in seen_regions:
+            seen_regions.add(key)
+            regions.append(PDFReplacementRegion(page_index, det, pages[page_index], render_dpi))
+
+    def visit_reference(reference: Reference) -> None:
+        if reference.id in seen_references:
+            return
+        seen_references.add(reference.id)
+        for layout in reference.layouts:
+            visit_reference_layout(layout)
+
+    def visit_reference_layout(layout: AssetLayout | ParagraphLayout) -> None:
+        if isinstance(layout, AssetLayout):
+            add_region(layout.page_index, layout.det)
+            visit_references(layout.title)
+            visit_references(layout.content)
+            visit_references(layout.caption)
+            return
+        for block in layout.blocks:
+            add_region(block.page_index, block.det)
+            visit_references(block.content)
+
+    def visit_references(items) -> None:
+        for item in flatten(items):
+            if isinstance(item, Reference):
+                visit_reference(item)
+
+    for layout in chapter.layouts:
+        if isinstance(layout, AssetLayout):
+            add_region(layout.page_index, layout.det)
+            visit_references(layout.title)
+            visit_references(layout.content)
+            visit_references(layout.caption)
+        else:
+            for block in layout.blocks:
+                visit_references(block.content)
+
+    return tuple(regions)
 
 
 def _ensure_extraction(value: PDFCraftExtraction | Path) -> PDFCraftExtraction:

--- a/pdf_craft/pipeline/pdf/pipeline.py
+++ b/pdf_craft/pipeline/pdf/pipeline.py
@@ -4,7 +4,7 @@ from collections.abc import Callable, Iterator
 from pathlib import Path
 from typing import cast
 
-from pdf_craft.extractor.chapter.chapter import Chapter, ParagraphLayout, encode
+from pdf_craft.extractor.chapter.chapter import AssetLayout, Chapter, ParagraphLayout, encode
 from pdf_craft.extractor.chapter.chapter import InlineExpression, Reference
 from pdf_craft.extractor.chapter.reader import create_chapters_reader
 from pdf_craft.markdown.paragraph import HTMLTag
@@ -155,6 +155,13 @@ class PDFTranslationPipeline:
         self, chapter: Chapter, transformer, pages,
         render_dpi: int, structured: bool = False,
     ) -> Iterator[PDFReplacement]:
+        obstacle_regions = tuple(
+            PDFReplacementRegion(
+                layout.page_index, layout.det, pages[layout.page_index], render_dpi,
+            )
+            for layout in chapter.layouts
+            if isinstance(layout, AssetLayout) and layout.page_index in pages
+        )
         for layout in chapter.layouts:
             if not isinstance(layout, ParagraphLayout) or layout.ref not in {"text", "sub_title"}:
                 continue
@@ -195,6 +202,7 @@ class PDFTranslationPipeline:
                 reading_order=first.reading_order, regions=tuple(regions),
                 layout_ref=layout.ref, layout_level=layout.level,
                 inline_formulas=inline_formulas,
+                obstacle_regions=obstacle_regions,
             )
 
 

--- a/pdf_craft/pipeline/pdf/text_layout.py
+++ b/pdf_craft/pipeline/pdf/text_layout.py
@@ -25,6 +25,12 @@ _MAX_FONT_SIZE_SEARCH_ITERATIONS = 16
 _AUTOMATIC_FONT_SIZE_INITIAL = 12.0
 _MAX_AUTOMATIC_FONT_SIZE_BRACKETING_ITERATIONS = 16
 _HEADLINE_OVERFLOW_LINE_WIDTH = 1_000_000.0
+# QTextLayout otherwise measures against the GUI screen's low-DPI font grid.
+# Keep all layout geometry in a larger private coordinate system, then scale
+# it back at PDF draw time.  This preserves Qt's shaping and break decisions
+# while making a 0.05pt search a real typographic search rather than a screen
+# pixel search.
+_LAYOUT_SCALE = 8.0
 _CJK_FONT_CANDIDATES = (
     "PingFang SC",
     "Noto Sans CJK SC",
@@ -154,6 +160,10 @@ class RegionTextPlacement:
     # pass.  ``remaining_text`` is retained for compatibility, but a later
     # local optimisation must never reflow text into a neighbouring region.
     assigned_text: str = ""
+    # ``rectangle.bottom`` is a visual target, not the hard edge.  This is the
+    # first lower overlapping source region (or the page bottom) that text
+    # must not enter.
+    forbidden_bottom: float | None = None
 
 
 @dataclass(frozen=True)
@@ -170,6 +180,9 @@ class FormulaDraw:
     latex: str = ""
     proxy_start: int = 0
     proxy_length: int = 0
+    # Formula PDFs remain in ordinary PDF points; ``scale`` keeps the merger
+    # compatible with any future non-unit fragment coordinate system.
+    scale: float = 1.0
 
 
 @dataclass(frozen=True)
@@ -418,6 +431,9 @@ class QTextParagraphFiller:
         self._auto_font_resolution: FontResolution | None = None
         self._font_resolutions: dict[str | None, FontResolution] = {}
         self._formula_renderer = InlineFormulaPDFRenderer()
+        self._layout_obstacles: Mapping[int, tuple[PageRectangle, ...]] = {}
+        self._uses_window_obstacles = False
+        self._active_forbidden_bottom: float | None = None
 
     @property
     def font_resolutions(self) -> tuple[FontResolution, ...]:
@@ -428,6 +444,13 @@ class QTextParagraphFiller:
         """Start a new patch run without retaining its previous font choice."""
         self._auto_font_resolution = None
         self._font_resolutions.clear()
+
+    def set_layout_obstacles(
+        self, obstacles: Mapping[int, tuple[PageRectangle, ...]],
+    ) -> None:
+        """Set the current window's immutable source-geometry obstacle map."""
+        self._layout_obstacles = obstacles
+        self._uses_window_obstacles = True
 
     def prepare_automatic_font(self, contains_cjk: bool) -> None:
         """Fix this run's automatic family before its first paragraph is fitted.
@@ -457,11 +480,12 @@ class QTextParagraphFiller:
         page_sizes: dict[int, tuple[float, float]],
         minimum_font_size: float | None = None,
     ) -> FittedParagraph:
-        """Return the largest verified paragraph size fitting every region.
+        """Return a verified paragraph whose terminal line approaches its aim.
 
-        QTextLayout accepts floating-point point sizes.  Keep the successful
-        side of a bounded binary search so a discontinuity at a wrapping
-        threshold cannot produce an overflowing result.
+        A source bbox bottom is an aim line.  A lower overlapping layout box
+        (or the page bottom) is the actual forbidden line.  Qt continues to
+        own text shaping and line breaking; this method only searches sizes
+        that fully fit before the forbidden line.
         """
         # Preserve the translated character stream verbatim.  QTextLayout is
         # responsible for interpreting its whitespace and native line-break
@@ -482,34 +506,73 @@ class QTextParagraphFiller:
                 f"requested minimum font size {effective_minimum:.2f} exceeds style maximum "
                 f"{configured_maximum:.2f}"
             )
-        lower = effective_minimum
-        best = self._plan(text, replacement, page_sizes, style, lower)
-        if best is None:
-            raise ValueError(
-                "replacement text cannot fit paragraph source regions at minimum font size "
-                f"{effective_minimum}"
-            )
+        previous_obstacles = self._layout_obstacles
+        if not self._uses_window_obstacles:
+            self._layout_obstacles = _replacement_obstacles(replacement, page_sizes)
+        try:
+            lower = effective_minimum
+            minimum_plan = self._plan(text, replacement, page_sizes, style, lower)
+            if minimum_plan is None:
+                raise ValueError(
+                    "replacement text cannot fit paragraph source regions at minimum font size "
+                    f"{effective_minimum}"
+                )
 
-        upper = configured_maximum
-        if upper is None:
-            upper = self._find_automatic_font_size_upper_bound(
-                text, replacement, page_sizes, style, lower,
-            )
-        fitted_at_upper = self._plan(text, replacement, page_sizes, style, upper)
-        if fitted_at_upper is not None:
-            return fitted_at_upper
-
-        for _ in range(_MAX_FONT_SIZE_SEARCH_ITERATIONS):
-            if upper - lower <= _FONT_SIZE_TOLERANCE:
-                break
-            middle = (lower + upper) / 2
-            fitted = self._plan(text, replacement, page_sizes, style, middle)
-            if fitted is None:
-                upper = middle
+            upper = configured_maximum
+            if upper is None:
+                upper = self._find_automatic_font_size_upper_bound(
+                    text, replacement, page_sizes, style, lower,
+                )
+            maximum_plan = self._plan(text, replacement, page_sizes, style, upper)
+            if maximum_plan is not None:
+                best = maximum_plan
+                feasible_lower = upper
             else:
-                best = fitted
-                lower = middle
-        return best
+                best = minimum_plan
+                feasible_lower = lower
+                infeasible_upper = upper
+                for _ in range(_MAX_FONT_SIZE_SEARCH_ITERATIONS):
+                    if infeasible_upper - feasible_lower <= _FONT_SIZE_TOLERANCE:
+                        break
+                    middle = (feasible_lower + infeasible_upper) / 2
+                    fitted = self._plan(text, replacement, page_sizes, style, middle)
+                    if fitted is None:
+                        infeasible_upper = middle
+                    else:
+                        best = fitted
+                        feasible_lower = middle
+
+            # Test doubles and external subclasses may report a successful
+            # paragraph without physical placements.  They have no aim line,
+            # so retain the historical successful-side binary-search result.
+            if not minimum_plan.placements or not best.placements:
+                return best
+
+            # The largest feasible size is not necessarily closest to a bbox
+            # bottom: crossing the aim line can happen before the forbidden
+            # line.  Search the terminal-line crossing and compare its two
+            # sides instead of treating the feasibility boundary as the goal.
+            if _terminal_aim_delta(minimum_plan) <= 0 <= _terminal_aim_delta(best):
+                aim_lower, aim_upper = lower, feasible_lower
+                before, after = minimum_plan, best
+                for _ in range(_MAX_FONT_SIZE_SEARCH_ITERATIONS):
+                    if aim_upper - aim_lower <= _FONT_SIZE_TOLERANCE:
+                        break
+                    middle = (aim_lower + aim_upper) / 2
+                    fitted = self._plan(text, replacement, page_sizes, style, middle)
+                    if fitted is None:
+                        aim_upper = middle
+                        continue
+                    if _terminal_aim_delta(fitted) <= 0:
+                        before = fitted
+                        aim_lower = middle
+                    else:
+                        after = fitted
+                        aim_upper = middle
+                return _closest_to_aim((before, after, best))
+            return _closest_to_aim((minimum_plan, best))
+        finally:
+            self._layout_obstacles = previous_obstacles
 
     def _find_automatic_font_size_upper_bound(
         self,
@@ -634,9 +697,19 @@ class QTextParagraphFiller:
                 break
             page_width, page_height = page_sizes[region.page_index]
             rectangle = region_in_page_points(region, page_width, page_height)
-            placement, consumed = self._fit_region(
-                region.page_index, rectangle, remaining, style, font_size, remaining_spans,
+            forbidden_bottom = _forbidden_bottom(
+                rectangle,
+                self._layout_obstacles.get(region.page_index, ()),
+                page_height,
             )
+            previous_forbidden_bottom = self._active_forbidden_bottom
+            self._active_forbidden_bottom = forbidden_bottom
+            try:
+                placement, consumed = self._fit_region(
+                    region.page_index, rectangle, remaining, style, font_size, remaining_spans,
+                )
+            finally:
+                self._active_forbidden_bottom = previous_forbidden_bottom
             if placement is None:
                 continue
             placements.append(placement)
@@ -683,13 +756,15 @@ class QTextParagraphFiller:
         )
         QtCore, QtGui = _qt_modules()
         _ensure_qt_application(QtGui)
-        layout = self._create_layout(QtCore, QtGui, text, overflow_style, effective_minimum)
+        layout = self._create_layout(
+            QtCore, QtGui, text, overflow_style, effective_minimum, _LAYOUT_SCALE,
+        )
         layout.beginLayout()
         try:
             line = layout.createLine()
             if not line.isValid():
                 raise ValueError("Qt could not create a headline line")
-            line.setLineWidth(_HEADLINE_OVERFLOW_LINE_WIDTH)
+            line.setLineWidth(_HEADLINE_OVERFLOW_LINE_WIDTH * _LAYOUT_SCALE)
             line_height = line.height()
             line_start = _x_coordinate(line.cursorToX(0))
             line_end = _x_coordinate(line.cursorToX(line.textLength()))
@@ -701,10 +776,10 @@ class QTextParagraphFiller:
             region.page_index,
             rectangle,
             text,
-            (rectangle.x + line_start,),
-            (line_end - line_start,),
-            (rectangle.top + (rectangle.height - line_height) / 2,),
-            (line_height,),
+            (rectangle.x + line_start / _LAYOUT_SCALE,),
+            ((line_end - line_start) / _LAYOUT_SCALE,),
+            (rectangle.top + (rectangle.height - line_height / _LAYOUT_SCALE) / 2,),
+            (line_height / _LAYOUT_SCALE,),
             effective_minimum,
             overflow_style,
             allows_horizontal_overflow=True,
@@ -722,15 +797,18 @@ class QTextParagraphFiller:
         formula_spans: tuple[_FormulaSpan, ...] = (),
         ignore_height: bool = False,
     ) -> tuple[RegionTextPlacement | None, int]:
-        available_width = rectangle.width - 2 * style.horizontal_padding
-        available_top = rectangle.top + style.vertical_padding
-        available_bottom = rectangle.bottom - style.vertical_padding
+        scaled_rectangle = _scale_rectangle(rectangle)
+        available_width = scaled_rectangle.width - 2 * style.horizontal_padding * _LAYOUT_SCALE
+        available_top = scaled_rectangle.top + style.vertical_padding * _LAYOUT_SCALE
+        forbidden_bottom = self._active_forbidden_bottom
+        hard_bottom = forbidden_bottom if forbidden_bottom is not None else rectangle.bottom
+        available_bottom = hard_bottom * _LAYOUT_SCALE - style.vertical_padding * _LAYOUT_SCALE
         if available_width <= 0 or available_bottom <= available_top:
             return None, 0
 
         QtCore, QtGui = _qt_modules()
         _ensure_qt_application(QtGui)
-        layout = self._create_layout(QtCore, QtGui, text, style, font_size)
+        layout = self._create_layout(QtCore, QtGui, text, style, font_size, _LAYOUT_SCALE)
         # Formula spans retain Python indexes so _plan can slice the remaining
         # text safely.  QTextLine positions, however, are absolute UTF-16
         # units, so map the spans once for every current remaining-text layout.
@@ -745,7 +823,7 @@ class QTextParagraphFiller:
             )
             for span in formula_spans
         )
-        content_left = rectangle.x + style.horizontal_padding
+        content_left = scaled_rectangle.x + style.horizontal_padding * _LAYOUT_SCALE
         line_tops: list[float] = []
         line_text_lefts: list[float] = []
         line_text_widths: list[float] = []
@@ -843,33 +921,38 @@ class QTextParagraphFiller:
             page_index,
             rectangle,
             text,
-            tuple(line_text_lefts),
-            tuple(line_text_widths),
-            tuple(top + shift for top in line_tops),
-            tuple(line_heights),
+            tuple(value / _LAYOUT_SCALE for value in line_text_lefts),
+            tuple(value / _LAYOUT_SCALE for value in line_text_widths),
+            tuple((top + shift) / _LAYOUT_SCALE for top in line_tops),
+            tuple(value / _LAYOUT_SCALE for value in line_heights),
             font_size,
             style,
             formula_draws=tuple(
                 FormulaDraw(
-                    draw.pdf, draw.x, draw.baseline + shift, draw.descent,
+                    draw.pdf, draw.x / _LAYOUT_SCALE,
+                    (draw.baseline + shift) / _LAYOUT_SCALE,
+                    draw.descent / _LAYOUT_SCALE,
                     draw.latex, draw.proxy_start, draw.proxy_length,
                 )
                 for draw in formula_draws
             ),
             assigned_text=text[:consumed],
+            forbidden_bottom=forbidden_bottom,
         ), consumed
 
     def _draw_placement(self, QtCore, QtGui, painter, placement: RegionTextPlacement) -> None:
         layout = self._create_layout(
             QtCore, QtGui, placement.assigned_text or placement.remaining_text,
-            placement.style, placement.font_size,
+            placement.style, placement.font_size, _LAYOUT_SCALE,
         )
         if placement.allows_horizontal_overflow:
-            available_width = _HEADLINE_OVERFLOW_LINE_WIDTH
-            x = placement.rectangle.x
+            available_width = _HEADLINE_OVERFLOW_LINE_WIDTH * _LAYOUT_SCALE
+            x = placement.rectangle.x * _LAYOUT_SCALE
         else:
-            available_width = placement.rectangle.width - 2 * placement.style.horizontal_padding
-            x = placement.rectangle.x + placement.style.horizontal_padding
+            available_width = (
+                placement.rectangle.width - 2 * placement.style.horizontal_padding
+            ) * _LAYOUT_SCALE
+            x = (placement.rectangle.x + placement.style.horizontal_padding) * _LAYOUT_SCALE
         layout.beginLayout()
         try:
             for top in placement.line_tops:
@@ -877,10 +960,15 @@ class QTextParagraphFiller:
                 if not line.isValid():
                     raise RuntimeError("Qt layout changed while drawing a planned paragraph")
                 line.setLineWidth(available_width)
-                line.setPosition(QtCore.QPointF(x, top))
+                line.setPosition(QtCore.QPointF(x, top * _LAYOUT_SCALE))
         finally:
             layout.endLayout()
-        layout.draw(painter, QtCore.QPointF(0, 0))
+        painter.save()
+        painter.scale(1 / _LAYOUT_SCALE, 1 / _LAYOUT_SCALE)
+        try:
+            layout.draw(painter, QtCore.QPointF(0, 0))
+        finally:
+            painter.restore()
 
     def fit_frozen_region(
         self,
@@ -918,15 +1006,15 @@ class QTextParagraphFiller:
             )
             if local_text is None:
                 return None
-            fitted, consumed = self._fit_region(
-                placement.page_index,
-                placement.rectangle,
-                local_text,
-                style,
-                size,
-                formula_spans,
-                ignore_height=expected_lines == 1,
-            )
+            previous_forbidden_bottom = self._active_forbidden_bottom
+            self._active_forbidden_bottom = placement.forbidden_bottom
+            try:
+                fitted, consumed = self._fit_region(
+                    placement.page_index, placement.rectangle, local_text, style, size, formula_spans,
+                    ignore_height=expected_lines == 1,
+                )
+            finally:
+                self._active_forbidden_bottom = previous_forbidden_bottom
             if (
                 fitted is None
                 or consumed != len(local_text)
@@ -985,13 +1073,15 @@ class QTextParagraphFiller:
             return placement
         QtCore, QtGui = _qt_modules()
         _ensure_qt_application(QtGui)
-        layout = self._create_layout(QtCore, QtGui, text, placement.style, font_size)
+        layout = self._create_layout(
+            QtCore, QtGui, text, placement.style, font_size, _LAYOUT_SCALE,
+        )
         layout.beginLayout()
         try:
             line = layout.createLine()
             if not line.isValid():
                 return placement
-            line.setLineWidth(_HEADLINE_OVERFLOW_LINE_WIDTH)
+            line.setLineWidth(_HEADLINE_OVERFLOW_LINE_WIDTH * _LAYOUT_SCALE)
             if line.textLength() != _utf16_index_for_python(text, len(text)):
                 return placement
             line_height = line.height()
@@ -1004,14 +1094,15 @@ class QTextParagraphFiller:
             placement.page_index,
             rectangle,
             text,
-            (rectangle.x + line_start,),
-            (line_end - line_start,),
-            (rectangle.top + (rectangle.height - line_height) / 2,),
-            (line_height,),
+            (rectangle.x + line_start / _LAYOUT_SCALE,),
+            ((line_end - line_start) / _LAYOUT_SCALE,),
+            (rectangle.top + (rectangle.height - line_height / _LAYOUT_SCALE) / 2,),
+            (line_height / _LAYOUT_SCALE,),
             font_size,
             placement.style,
             allows_horizontal_overflow=True,
             assigned_text=text,
+            forbidden_bottom=placement.forbidden_bottom,
         )
 
     def _formula_spans_for_frozen_region(
@@ -1039,12 +1130,16 @@ class QTextParagraphFiller:
         del QtCore
         _ensure_qt_application(QtGui)
         font = QtGui.QFont(placement.style.font_name or "")
-        font.setPointSizeF(font_size)
+        font.setPointSizeF(font_size * _LAYOUT_SCALE)
         space_width = float(QtGui.QFontMetricsF(font).horizontalAdvance("\u00a0"))
         if space_width <= 0:
             return None, ()
-        maximum_width = placement.rectangle.width - 2 * placement.style.horizontal_padding
-        maximum_height = placement.rectangle.height - 2 * placement.style.vertical_padding
+        maximum_width = (
+            placement.rectangle.width - 2 * placement.style.horizontal_padding
+        ) * _LAYOUT_SCALE
+        maximum_height = (
+            placement.rectangle.height - 2 * placement.style.vertical_padding
+        ) * _LAYOUT_SCALE
         parts: list[str] = []
         spans: list[_FormulaSpan] = []
         cursor = 0
@@ -1054,7 +1149,8 @@ class QTextParagraphFiller:
             end = start + draw.proxy_length
             if start < cursor or end > len(text) or text[start:end] != "\u00a0" * draw.proxy_length:
                 return None, ()
-            fragment = self._formula_renderer.render(draw.latex, font_size)
+            raw_fragment = self._formula_renderer.render(draw.latex, font_size)
+            fragment = _scale_formula_fragment(raw_fragment) if raw_fragment is not None else None
             if (
                 fragment is None
                 or fragment.width > maximum_width
@@ -1073,14 +1169,16 @@ class QTextParagraphFiller:
         return "".join(parts), tuple(spans)
 
     @staticmethod
-    def _create_layout(QtCore, QtGui, text: str, style: PatchTextStyle, font_size: float):
+    def _create_layout(
+        QtCore, QtGui, text: str, style: PatchTextStyle, font_size: float, scale: float = 1.0,
+    ):
         families = tuple(
             family for family in (style.font_name, *style.fallback_fonts) if family
         )
         font = QtGui.QFont(families[0]) if families else QtGui.QFont()
         if len(families) > 1:
             font.setFamilies(list(families))
-        font.setPointSizeF(font_size)
+        font.setPointSizeF(font_size * scale)
         font.setWeight(QtGui.QFont.Weight(style.font_weight))
         option = QtGui.QTextOption()
         option.setAlignment({
@@ -1148,6 +1246,8 @@ class QTextParagraphFiller:
         A fragment that cannot be rendered is immediately substituted with
         Unicode text instead, so one bad TeX expression never fails a page.
         """
+        maximum_width *= _LAYOUT_SCALE
+        maximum_height *= _LAYOUT_SCALE
         if not replacement.inline_formulas:
             return text, ()
         if text.count("\ufffc") != len(replacement.inline_formulas):
@@ -1158,7 +1258,7 @@ class QTextParagraphFiller:
         del QtCore
         _ensure_qt_application(QtGui)
         font = QtGui.QFont(style.font_name or "")
-        font.setPointSizeF(font_size)
+        font.setPointSizeF(font_size * _LAYOUT_SCALE)
         space_width = float(QtGui.QFontMetricsF(font).horizontalAdvance("\u00a0"))
         parts: list[str] = []
         spans: list[_FormulaSpan] = []
@@ -1174,7 +1274,8 @@ class QTextParagraphFiller:
                 continue
             formula = replacement.inline_formulas[formula_index]
             formula_index += 1
-            fragment = self._formula_renderer.render(formula.latex, font_size)
+            raw_fragment = self._formula_renderer.render(formula.latex, font_size)
+            fragment = _scale_formula_fragment(raw_fragment) if raw_fragment is not None else None
             if fragment is None or fragment.width > maximum_width or fragment.height > maximum_height:
                 fallback = latex_to_plain_text(formula.latex)
                 parts.append(fallback)
@@ -1203,6 +1304,98 @@ def _replace_formula_markers(text: str, formulas) -> str:
         latex_to_plain_text(next(iterator).latex) if character == "\ufffc" else character
         for character in text
     )
+
+
+def _scale_rectangle(rectangle: PageRectangle) -> PageRectangle:
+    """Map public PDF-point geometry into Qt's private high-DPI space."""
+    return PageRectangle(
+        rectangle.x * _LAYOUT_SCALE,
+        rectangle.top * _LAYOUT_SCALE,
+        rectangle.width * _LAYOUT_SCALE,
+        rectangle.height * _LAYOUT_SCALE,
+    )
+
+
+def _scale_formula_fragment(fragment: FormulaFragment) -> FormulaFragment:
+    """Use an ordinary point-sized formula PDF in scaled Qt measurements."""
+    return FormulaFragment(
+        fragment.pdf,
+        fragment.width * _LAYOUT_SCALE,
+        fragment.height * _LAYOUT_SCALE,
+        fragment.descent * _LAYOUT_SCALE,
+    )
+
+
+def _forbidden_bottom(
+    rectangle: PageRectangle,
+    obstacles: Iterable[PageRectangle],
+    page_height: float,
+) -> float:
+    """Return the first lower obstacle sharing horizontal space with ``rectangle``.
+
+    The source bbox bottom remains an aim only.  An obstacle must start at or
+    below that aim and overlap the bbox's horizontal projection; boxes above
+    or merely touching an edge cannot restrict the downward flow.  The page
+    edge is always the final forbidden line.
+    """
+    right = rectangle.x + rectangle.width
+    candidates = [page_height]
+    for obstacle in obstacles:
+        obstacle_right = obstacle.x + obstacle.width
+        if obstacle.top + 1e-6 < rectangle.bottom:
+            continue
+        if obstacle.x >= right - 1e-6 or obstacle_right <= rectangle.x + 1e-6:
+            continue
+        candidates.append(obstacle.top)
+    return min(candidates)
+
+
+def _replacement_obstacles(
+    replacement: PDFReplacement,
+    page_sizes: Mapping[int, tuple[float, float]],
+) -> Mapping[int, tuple[PageRectangle, ...]]:
+    """Build the direct-fit fallback obstacle map from known source geometry."""
+    grouped: dict[int, list[PageRectangle]] = {}
+    for region in (*replacement.source_regions(), *replacement.obstacle_regions):
+        page_width, page_height = page_sizes[region.page_index]
+        grouped.setdefault(region.page_index, []).append(
+            region_in_page_points(region, page_width, page_height),
+        )
+    return {page_index: tuple(rectangles) for page_index, rectangles in grouped.items()}
+
+
+def _window_obstacles(
+    replacements: Iterable[PDFReplacement],
+    page_sizes: Mapping[int, tuple[float, float]],
+) -> Mapping[int, tuple[PageRectangle, ...]]:
+    """Collect text, asset and formula geometry for one live layout window."""
+    grouped: dict[int, list[PageRectangle]] = {}
+    for replacement in replacements:
+        for region in (*replacement.source_regions(), *replacement.obstacle_regions):
+            page_width, page_height = page_sizes[region.page_index]
+            grouped.setdefault(region.page_index, []).append(
+                region_in_page_points(region, page_width, page_height),
+            )
+    return {page_index: tuple(rectangles) for page_index, rectangles in grouped.items()}
+
+
+def _terminal_aim_delta(paragraph: FittedParagraph) -> float:
+    """Signed terminal line distance from its source bbox aim line."""
+    placement = paragraph.placements[-1]
+    return placement.line_tops[-1] + placement.line_heights[-1] - placement.rectangle.bottom
+
+
+def _aim_score(paragraph: FittedParagraph) -> tuple[int, float, float, float]:
+    """Prefer using all source regions, then terminal aim proximity."""
+    distances = tuple(
+        abs(placement.line_tops[-1] + placement.line_heights[-1] - placement.rectangle.bottom)
+        for placement in paragraph.placements
+    )
+    return -len(paragraph.placements), distances[-1], sum(distances), -paragraph.font_size
+
+
+def _closest_to_aim(paragraphs: Iterable[FittedParagraph]) -> FittedParagraph:
+    return min(paragraphs, key=_aim_score)
 
 
 class WindowedParagraphPlanner:
@@ -1260,6 +1453,10 @@ class WindowedParagraphPlanner:
     ) -> FillWindowPlan:
         body = [replacement for replacement in replacements if not _is_headline(replacement)]
         headlines = [replacement for replacement in replacements if _is_headline(replacement)]
+        obstacles = _window_obstacles(replacements, self._page_sizes)
+        set_layout_obstacles = getattr(self._filler, "set_layout_obstacles", None)
+        if callable(set_layout_obstacles):
+            set_layout_obstacles(obstacles)
         summaries: list[_PlannedParagraphSummary] = []
         body_font_sizes: dict[int, float] = {}
         storage = _WindowPlanStorage()
@@ -1268,7 +1465,7 @@ class WindowedParagraphPlanner:
             body_replacements: dict[int, PDFReplacement] = {}
             body_statistics: dict[tuple[int, str, int], list[float]] = {}
             for replacement in body:
-                paragraph = self._fit_or_skip(replacement)
+                paragraph = self._fit_or_skip(replacement, obstacles)
                 if paragraph is None:
                     continue
                 paragraph_index = len(summaries)
@@ -1391,8 +1588,13 @@ class WindowedParagraphPlanner:
                     )
         return font_sizes
 
-    def _fit_or_skip(self, replacement: PDFReplacement) -> FittedParagraph | None:
+    def _fit_or_skip(
+        self,
+        replacement: PDFReplacement,
+        obstacles: Mapping[int, tuple[PageRectangle, ...]],
+    ) -> FittedParagraph | None:
         try:
+            del obstacles
             return self._filler.fit(replacement, self._page_sizes)
         except ValueError as error:
             if self._options.overflow == "skip":

--- a/pdf_craft/pipeline/pdf/text_layout.py
+++ b/pdf_craft/pipeline/pdf/text_layout.py
@@ -548,6 +548,21 @@ class QTextParagraphFiller:
             if not minimum_plan.placements or not best.placements:
                 return best
 
+            if len(replacement.source_regions()) > 1:
+                # Qt can switch the terminal text run to another bbox at a
+                # wrapping threshold.  That changes the applicable aim line
+                # discontinuously, so endpoint-only binary search cannot see
+                # every candidate (nor assume a signed aim delta is monotone).
+                # Search the already-bounded feasible interval at the public
+                # 0.05pt precision and score each real Qt plan by its actual
+                # terminal bbox.  This is intentionally limited to the rare
+                # multi-bbox paragraph path; normal one-bbox fitting retains
+                # its inexpensive aim-crossing binary search below.
+                candidates = self._multi_bbox_aim_candidates(
+                    text, replacement, page_sizes, style, lower, feasible_lower,
+                )
+                return _closest_to_aim((*candidates, best))
+
             # The largest feasible size is not necessarily closest to a bbox
             # bottom: crossing the aim line can happen before the forbidden
             # line.  Search the terminal-line crossing and compare its two
@@ -573,6 +588,41 @@ class QTextParagraphFiller:
             return _closest_to_aim((minimum_plan, best))
         finally:
             self._layout_obstacles = previous_obstacles
+
+    def _multi_bbox_aim_candidates(
+        self,
+        text: str,
+        replacement: PDFReplacement,
+        page_sizes: dict[int, tuple[float, float]],
+        style: PatchTextStyle,
+        lower: float,
+        upper: float,
+    ) -> tuple[FittedParagraph, ...]:
+        """Sample all 0.05pt multi-bbox candidates inside a feasible interval.
+
+        Text flow can jump from one source rectangle to the next when Qt
+        changes a wrap decision.  The terminal aim line then changes too, so
+        a binary search over only endpoint deltas is unsound.  ``upper`` is
+        already the largest feasible side of the normal bracketing search;
+        every returned plan remains subject to its forbidden line.
+        """
+        step_count = int((upper - lower) / _FONT_SIZE_TOLERANCE)
+        sizes = [lower + step * _FONT_SIZE_TOLERANCE for step in range(step_count + 1)]
+        if not sizes or upper - sizes[-1] > 1e-9:
+            sizes.append(upper)
+        candidates = tuple(
+            plan
+            for size in sizes
+            if (plan := self._plan(text, replacement, page_sizes, style, size)) is not None
+            and plan.placements
+        )
+        # ``lower`` was already proven feasible; retain a defensive fallback
+        # for unusual floating-point intervals.
+        if candidates:
+            return candidates
+        fallback = self._plan(text, replacement, page_sizes, style, lower)
+        assert fallback is not None
+        return (fallback,)
 
     def _find_automatic_font_size_upper_bound(
         self,

--- a/pdf_craft/pipeline/pdf/text_layout.py
+++ b/pdf_craft/pipeline/pdf/text_layout.py
@@ -612,10 +612,18 @@ class QTextParagraphFiller:
         """
         try:
             return self.fit(replacement, page_sizes, minimum_font_size)
-        except ValueError:
-            return self._plan_headline_overflow(
-                replacement, page_sizes, minimum_font_size,
-            )
+        except ValueError as fit_error:
+            previous_obstacles = self._layout_obstacles
+            if not self._uses_window_obstacles:
+                self._layout_obstacles = _replacement_obstacles(replacement, page_sizes)
+            try:
+                return self._plan_headline_overflow(
+                    replacement, page_sizes, minimum_font_size,
+                )
+            except ValueError as overflow_error:
+                raise overflow_error from fit_error
+            finally:
+                self._layout_obstacles = previous_obstacles
 
     def _resolve_font(self, style: PatchTextStyle, text: str) -> PatchTextStyle:
         """Resolve an automatic family once, without rejecting explicit names."""
@@ -745,6 +753,11 @@ class QTextParagraphFiller:
         region = replacement.source_regions()[0]
         page_width, page_height = page_sizes[region.page_index]
         rectangle = region_in_page_points(region, page_width, page_height)
+        forbidden_bottom = _forbidden_bottom(
+            rectangle,
+            self._layout_obstacles.get(region.page_index, ()),
+            page_height,
+        )
         # The overflow rule is intentionally left aligned to the physical box
         # edge and vertically centered on that edge, independent of the
         # ordinary paragraph's padding/alignment settings.
@@ -772,18 +785,24 @@ class QTextParagraphFiller:
             layout.endLayout()
         if line.textLength() <= 0:
             raise ValueError("Qt could not lay out headline text")
+        line_top = rectangle.top + (rectangle.height - line_height / _LAYOUT_SCALE) / 2
+        if line_top + line_height / _LAYOUT_SCALE > forbidden_bottom + 1e-6:
+            raise ValueError(
+                "headline overflow cannot fit before the lower obstacle or page boundary"
+            )
         placement = RegionTextPlacement(
             region.page_index,
             rectangle,
             text,
             (rectangle.x + line_start / _LAYOUT_SCALE,),
             ((line_end - line_start) / _LAYOUT_SCALE,),
-            (rectangle.top + (rectangle.height - line_height / _LAYOUT_SCALE) / 2,),
+            (line_top,),
             (line_height / _LAYOUT_SCALE,),
             effective_minimum,
             overflow_style,
             allows_horizontal_overflow=True,
             assigned_text=text,
+            forbidden_bottom=forbidden_bottom,
         )
         return FittedParagraph(text, effective_minimum, (placement,))
 
@@ -1099,13 +1118,24 @@ class QTextParagraphFiller:
         finally:
             layout.endLayout()
         rectangle = placement.rectangle
+        line_top = rectangle.top + (rectangle.height - line_height / _LAYOUT_SCALE) / 2
+        if (
+            placement.forbidden_bottom is not None
+            and line_top + line_height / _LAYOUT_SCALE > placement.forbidden_bottom + 1e-6
+        ):
+            if (
+                placement.line_tops[-1] + placement.line_heights[-1]
+                > placement.forbidden_bottom + 1e-6
+            ):
+                raise ValueError("frozen headline overflow already exceeds its forbidden line")
+            return placement
         return RegionTextPlacement(
             placement.page_index,
             rectangle,
             text,
             (rectangle.x + line_start / _LAYOUT_SCALE,),
             ((line_end - line_start) / _LAYOUT_SCALE,),
-            (rectangle.top + (rectangle.height - line_height / _LAYOUT_SCALE) / 2,),
+            (line_top,),
             (line_height / _LAYOUT_SCALE,),
             font_size,
             placement.style,
@@ -1394,13 +1424,13 @@ def _terminal_aim_delta(paragraph: FittedParagraph) -> float:
     return placement.line_tops[-1] + placement.line_heights[-1] - placement.rectangle.bottom
 
 
-def _aim_score(paragraph: FittedParagraph) -> tuple[int, float, float, float]:
-    """Prefer using all source regions, then terminal aim proximity."""
+def _aim_score(paragraph: FittedParagraph) -> tuple[float, float, int, float]:
+    """Prefer the actual terminal region's aim before secondary tie-breakers."""
     distances = tuple(
         abs(placement.line_tops[-1] + placement.line_heights[-1] - placement.rectangle.bottom)
         for placement in paragraph.placements
     )
-    return -len(paragraph.placements), distances[-1], sum(distances), -paragraph.font_size
+    return distances[-1], sum(distances), -len(paragraph.placements), -paragraph.font_size
 
 
 def _closest_to_aim(paragraphs: Iterable[FittedParagraph]) -> FittedParagraph:

--- a/pdf_craft/pipeline/pdf/text_layout.py
+++ b/pdf_craft/pipeline/pdf/text_layout.py
@@ -848,7 +848,14 @@ class QTextParagraphFiller:
                 )
                 if line_fragments:
                     line_height = max(line_height, *(fragment.height for fragment in line_fragments))
-                if not ignore_height and y + line_height > available_bottom + 1e-6:
+                # A frozen one-line OCR region may ignore its tight source
+                # bbox, but never the actual lower obstacle/page boundary.
+                # ``forbidden_bottom is None`` is the legacy direct-call
+                # spelling for “no independently computed forbidden line”.
+                if (
+                    (not ignore_height or forbidden_bottom is not None)
+                    and y + line_height > available_bottom + 1e-6
+                ):
                     break
                 # QTextLayout may wrap anywhere.  Never accept a line that
                 # cuts through one formula's width proxy: leave the complete
@@ -982,7 +989,9 @@ class QTextParagraphFiller:
         second pass may only reflow the text it consumed itself, and only while
         preserving its exact line count.  One-line OCR boxes intentionally do
         not constrain vertical glyph bounds: their height is often just the
-        tight ink box rather than a typographic line box.
+        tight ink box rather than a typographic line box.  The independently
+        computed forbidden line (a lower obstacle or page bottom) remains a
+        hard constraint in every case.
         """
         text = placement.assigned_text or placement.remaining_text
         if not text:

--- a/tests/test_pdf_inline_formula.py
+++ b/tests/test_pdf_inline_formula.py
@@ -332,7 +332,7 @@ class TestPDFInlineFormulaFallback(unittest.TestCase):
         QtCore, QtGui = _qt_modules()
         _ensure_qt_application(QtGui)
         layout = filler._create_layout(  # pylint: disable=protected-access
-            QtCore, QtGui, placement.remaining_text, placement.style, placement.font_size,
+            QtCore, QtGui, placement.remaining_text, placement.style, placement.font_size, 8,
         )
         marker_index = placement.remaining_text.index("\u00a0")
         marker_utf16_index = _utf16_index_for_python(placement.remaining_text, marker_index)
@@ -343,11 +343,13 @@ class TestPDFInlineFormulaFallback(unittest.TestCase):
                 line = layout.createLine()
                 if not line.isValid():
                     break
-                line.setLineWidth(placement.rectangle.width - 2 * placement.style.horizontal_padding)
+                line.setLineWidth(
+                    (placement.rectangle.width - 2 * placement.style.horizontal_padding) * 8,
+                )
                 if line.textStart() <= marker_utf16_index <= line.textStart() + line.textLength():
                     expected_x = (
                         placement.rectangle.x + placement.style.horizontal_padding
-                        + _x_coordinate(line.cursorToX(marker_utf16_index))
+                        + _x_coordinate(line.cursorToX(marker_utf16_index)) / 8
                     )
                     break
         finally:

--- a/tests/test_pdf_patch_smoke.py
+++ b/tests/test_pdf_patch_smoke.py
@@ -7,6 +7,7 @@ review workflow additionally renders its generated output for visual review.
 
 import tempfile
 import unittest
+import unicodedata
 from shutil import which
 from pathlib import Path
 from typing import Any
@@ -110,7 +111,7 @@ class TestPDFPatchSmoke(unittest.TestCase):
         self.assertGreater(fitted.font_size, 12)
         self.assertTrue(all(
             placement.rectangle.top <= top
-            and top + height <= placement.rectangle.bottom
+            and top + height <= (placement.forbidden_bottom or placement.rectangle.bottom)
             for placement in fitted.placements
             for top, height in zip(placement.line_tops, placement.line_heights)
         ))
@@ -171,6 +172,8 @@ class TestPDFPatchSmoke(unittest.TestCase):
 
             reader = pypdf.PdfReader(str(target))
             self.assertEqual(len(reader.pages), 3)
-            output_text = " ".join(reader.pages[0].extract_text().split())
+            output_text = unicodedata.normalize(
+                "NFKC", " ".join(reader.pages[0].extract_text().split()),
+            )
             self.assertIn(translated, output_text)
             self.assertNotIn(source_lines[0], output_text)

--- a/tests/test_pdf_patch_smoke.py
+++ b/tests/test_pdf_patch_smoke.py
@@ -138,3 +138,39 @@ class TestPDFPatchSmoke(unittest.TestCase):
                 pypdf.PdfReader(str(target)).pages[0].extract_text().split()
             )
             self.assertIn("The population was only 11.8%", output_text)
+
+    @unittest.skipUnless(which("gs"), "requires local Ghostscript")
+    def test_citation_fixture_replacement_is_rendered_and_searchable(self):
+        """Keep a real citation-page replacement in the PDF text layer."""
+        source = _ASSET_ROOT / "citation.pdf"
+        page_pixels = (4662, 6827)
+        source_lines = (
+            "时他把弗洛伊德的俄狄浦斯情结重新表述为父性隐喻，其中父亲禁止孩子对",
+            "母亲的欲望和母亲对孩子的欲望，并且确认母亲的缺失或欲望是与父亲相关",
+        )
+        translated = "Citation fixture replacement remains selectable and searchable PDF text."
+        with tempfile.TemporaryDirectory() as temp_dir:
+            root = Path(temp_dir)
+            target = root / "citation-translated.pdf"
+            extraction_root = root / "citation.pcex"
+            extraction = make_extraction(
+                extraction_root, page_pixel_sizes={1: page_pixels}, render_dpi=720,
+            )
+            chapter = Chapter(None, -1, [ParagraphLayout("text", 0, [
+                BlockLayout(1, 1, (576, 904, 4184, 1022), [source_lines[0]]),
+                BlockLayout(1, 2, (568, 1096, 4184, 1214), [source_lines[1]]),
+            ])])
+            (extraction_root / "chapters/chapter_1.xml").write_text(
+                '<?xml version="1.0" encoding="UTF-8"?>\n'
+                + tostring(encode(chapter), encoding="unicode")
+            )
+
+            PDFTranslationPipeline(patcher=PDFPatcher(
+                options=PatchTextOptions(max_font_size=8, min_font_size=8),
+            )).translate(source, target, extraction, lambda _text: translated)
+
+            reader = pypdf.PdfReader(str(target))
+            self.assertEqual(len(reader.pages), 3)
+            output_text = " ".join(reader.pages[0].extract_text().split())
+            self.assertIn(translated, output_text)
+            self.assertNotIn(source_lines[0], output_text)

--- a/tests/test_pdf_patcher.py
+++ b/tests/test_pdf_patcher.py
@@ -254,7 +254,7 @@ class TestPDFPatcher(unittest.TestCase):
             for placement in fitted.placements:
                 self.assertTrue(all(
                     placement.rectangle.top <= top
-                    and top + height <= placement.rectangle.bottom
+                    and top + height <= (placement.forbidden_bottom or placement.rectangle.bottom)
                     for top, height in zip(placement.line_tops, placement.line_heights)
                 ))
             source_fonts = set(source_page["/Resources"]["/Font"].get_object())

--- a/tests/test_pdf_text_layout.py
+++ b/tests/test_pdf_text_layout.py
@@ -12,7 +12,9 @@ from pdf_craft.pipeline.pdf.pipeline import PDFTranslationPipeline
 from pdf_craft.extractor.chapter.chapter import (
     AssetLayout, BlockLayout, Chapter, ParagraphLayout, Reference,
 )
-from pdf_craft.pipeline.pdf.text_layout import _LAYOUT_SCALE, _choose_automatic_font
+from pdf_craft.pipeline.pdf.text_layout import (
+    _LAYOUT_SCALE, _choose_automatic_font, _closest_to_aim,
+)
 
 
 def _replacement(text: str, regions, *, layout_ref: str = "text", layout_level: int = 0):
@@ -161,6 +163,21 @@ class TestQTextParagraphFiller(unittest.TestCase):
         self.assertGreater(placement.line_tops[-1] + placement.line_heights[-1], 10)
         self.assertLessEqual(placement.line_tops[-1] + placement.line_heights[-1], 12)
 
+    def test_aim_selection_prioritizes_the_actual_terminal_bbox(self):
+        """An exact terminal aim wins before a candidate's extra source box."""
+        style = PatchTextStyle(max_font_size=12, min_font_size=4)
+
+        def placement(bottom: float) -> RegionTextPlacement:
+            return RegionTextPlacement(
+                1, PageRectangle(0, 0, 100, 10), "line",
+                (0,), (20,), (bottom - 2,), (2,), 8, style, assigned_text="line",
+            )
+
+        extra_bbox = FittedParagraph("line", 8, (placement(2), placement(18)))
+        exact_terminal_bbox = FittedParagraph("line", 8, (placement(10),))
+
+        self.assertIs(_closest_to_aim((extra_bbox, exact_terminal_bbox)), exact_terminal_bbox)
+
     def test_lower_asset_top_is_a_forbidden_line(self):
         source = PDFReplacementRegion(1, (0, 0, 100, 10), (100, 100))
         figure = PDFReplacementRegion(1, (0, 14, 100, 30), (100, 100))
@@ -225,16 +242,71 @@ class TestQTextParagraphFiller(unittest.TestCase):
         self.assertEqual(placement.forbidden_bottom, 14)
         self.assertLessEqual(line_bottom, 14)
 
-    def test_high_precision_layout_uses_scaled_qt_font_coordinates(self):
-        """The layout font, rather than a post-layout heuristic, receives precision."""
-        from PySide6 import QtCore, QtGui
+    def test_high_precision_planning_and_pdf_draw_share_scaled_qt_coordinates(self):
+        """Planning and the real PDF overlay use one unrounded Qt coordinate space."""
+        import tempfile
+        from pathlib import Path
 
-        filler = QTextParagraphFiller(PatchTextOptions())
-        layout = filler._create_layout(  # pylint: disable=protected-access
-            QtCore, QtGui, "precision", PatchTextStyle(), 4.12, _LAYOUT_SCALE,
+        import pypdf
+
+        class RecordingFiller(QTextParagraphFiller):
+            layout_coordinates: list[tuple[float, float]] = []
+
+            def __init__(self):
+                super().__init__(PatchTextOptions(max_font_size=4.12, min_font_size=4.12))
+                type(self).layout_coordinates = []
+
+            @staticmethod
+            def _create_layout(QtCore, QtGui, text, style, font_size, scale=1.0):
+                layout = QTextParagraphFiller._create_layout(
+                    QtCore, QtGui, text, style, font_size, scale,
+                )
+                RecordingFiller.layout_coordinates.append((scale, layout.font().pointSizeF()))
+                return layout
+
+        filler = RecordingFiller()
+        region = PDFReplacementRegion(1, (0, 0, 160, 60), (160, 60))
+        fitted = filler.fit(_replacement("precision overlay", [region]), {1: (160, 60)})
+        with tempfile.TemporaryDirectory() as temp_dir:
+            output = Path(temp_dir) / "precision.pdf"
+            filler.draw_pdf_overlay(output, (160, 60), fitted.placements)
+            output_text = " ".join(pypdf.PdfReader(str(output)).pages[0].extract_text().split())
+            self.assertIn("precision overlay", output_text)
+
+        # The final call comes from ``draw_pdf_overlay``; all planning calls
+        # and the actual PDF drawing call use the same scaled Qt font metric.
+        self.assertGreaterEqual(len(filler.layout_coordinates), 2)
+        self.assertTrue(all(
+            scale == _LAYOUT_SCALE and point_size == 4.12 * _LAYOUT_SCALE
+            for scale, point_size in filler.layout_coordinates
+        ))
+
+    def test_headline_overflow_refuses_to_enter_a_lower_obstacle(self):
+        source = PDFReplacementRegion(1, (0, 0, 100, 10), (100, 100))
+        footnote = PDFReplacementRegion(1, (0, 14, 100, 30), (100, 100))
+        replacement = PDFReplacement(
+            1, source.bbox, "A long headline", source.page_pixel_size,
+            regions=(source,), obstacle_regions=(footnote,), layout_ref="sub_title",
+        )
+        filler = QTextParagraphFiller(PatchTextOptions(styles={
+            "sub_title": PatchTextStyle(max_font_size=20, min_font_size=20),
+        }))
+
+        with self.assertRaisesRegex(ValueError, "lower obstacle or page boundary"):
+            filler.fit_headline(replacement, {1: (100, 100)}, 20)
+
+    def test_frozen_overflow_headline_keeps_its_forbidden_line(self):
+        style = PatchTextStyle(max_font_size=20, min_font_size=4)
+        original = RegionTextPlacement(
+            1, PageRectangle(0, 0, 100, 10), "A headline",
+            (0,), (60,), (1,), (8,), 8, style,
+            allows_horizontal_overflow=True, assigned_text="A headline", forbidden_bottom=14,
+        )
+        reflowed = QTextParagraphFiller(PatchTextOptions(styles={"sub_title": style})).fit_frozen_region(
+            original, 20,
         )
 
-        self.assertAlmostEqual(layout.font().pointSizeF(), 4.12 * _LAYOUT_SCALE)
+        self.assertEqual(reflowed, original)
 
     def test_flows_a_paragraph_through_multiple_rectangles_once(self):
         regions = [
@@ -298,7 +370,10 @@ class TestQTextParagraphFiller(unittest.TestCase):
         ]
         filler = QTextParagraphFiller(PatchTextOptions(max_font_size=10, min_font_size=4))
         fitted = filler.fit(
-            _replacement("first line second line third line", regions), {1: (100, 100)},
+            _replacement(
+                "first line second line third line fourth line fifth line sixth line seventh line",
+                regions,
+            ), {1: (100, 100)},
         )
         self.assertGreaterEqual(len(fitted.placements), 2)
 

--- a/tests/test_pdf_text_layout.py
+++ b/tests/test_pdf_text_layout.py
@@ -188,12 +188,21 @@ class TestQTextParagraphFiller(unittest.TestCase):
             _replacement("one two three four five six seven eight", regions),
             {1: (220, 260)},
         )
+        minimum = QTextParagraphFiller(PatchTextOptions(min_font_size=4, max_font_size=4)).fit(
+            _replacement("one two three four five six seven eight", regions),
+            {1: (220, 260)},
+        )
 
         terminal = fitted.placements[-1]
         terminal_bottom = terminal.line_tops[-1] + terminal.line_heights[-1]
+        minimum_terminal = minimum.placements[-1]
+        minimum_delta = abs(
+            minimum_terminal.line_tops[-1] + minimum_terminal.line_heights[-1]
+            - minimum_terminal.rectangle.bottom
+        )
         self.assertEqual(len(fitted.placements), 2)
-        self.assertGreater(fitted.font_size, 6)
-        self.assertLess(abs(terminal_bottom - terminal.rectangle.bottom), 1.2)
+        self.assertGreater(fitted.font_size, 4 + 1e-6)
+        self.assertLess(abs(terminal_bottom - terminal.rectangle.bottom), minimum_delta)
         self.assertLessEqual(terminal_bottom, terminal.forbidden_bottom or 260)
 
     def test_lower_asset_top_is_a_forbidden_line(self):
@@ -204,7 +213,9 @@ class TestQTextParagraphFiller(unittest.TestCase):
             regions=(source,), obstacle_regions=(figure,),
         )
 
-        placement = QTextParagraphFiller(PatchTextOptions(max_font_size=8, min_font_size=8)).fit(
+        placement = QTextParagraphFiller(PatchTextOptions(
+            max_font_size=4, min_font_size=4, vertical_alignment="bottom",
+        )).fit(
             replacement, {1: (100, 100)},
         ).placements[0]
 
@@ -252,7 +263,9 @@ class TestQTextParagraphFiller(unittest.TestCase):
         )
         self.assertEqual([region.bbox for region in replacement.obstacle_regions], [(0, 14, 100, 30)])
 
-        placement = QTextParagraphFiller(PatchTextOptions(max_font_size=8, min_font_size=8)).fit(
+        placement = QTextParagraphFiller(PatchTextOptions(
+            max_font_size=4, min_font_size=4, vertical_alignment="bottom",
+        )).fit(
             replace(replacement, text="line"), {1: (100, 100)},
         ).placements[0]
         line_bottom = placement.line_tops[-1] + placement.line_heights[-1]

--- a/tests/test_pdf_text_layout.py
+++ b/tests/test_pdf_text_layout.py
@@ -178,6 +178,24 @@ class TestQTextParagraphFiller(unittest.TestCase):
 
         self.assertIs(_closest_to_aim((extra_bbox, exact_terminal_bbox)), exact_terminal_bbox)
 
+    def test_multi_bbox_aim_search_covers_qt_wrap_discontinuities(self):
+        """A changed Qt text flow may expose a better aim between end points."""
+        regions = [
+            PDFReplacementRegion(1, (0, 0, 70, 10), (220, 260)),
+            PDFReplacementRegion(1, (0, 20, 70, 40), (220, 260)),
+        ]
+        fitted = QTextParagraphFiller(PatchTextOptions(min_font_size=4, max_font_size=18)).fit(
+            _replacement("one two three four five six seven eight", regions),
+            {1: (220, 260)},
+        )
+
+        terminal = fitted.placements[-1]
+        terminal_bottom = terminal.line_tops[-1] + terminal.line_heights[-1]
+        self.assertEqual(len(fitted.placements), 2)
+        self.assertGreater(fitted.font_size, 6)
+        self.assertLess(abs(terminal_bottom - terminal.rectangle.bottom), 1.2)
+        self.assertLessEqual(terminal_bottom, terminal.forbidden_bottom or 260)
+
     def test_lower_asset_top_is_a_forbidden_line(self):
         source = PDFReplacementRegion(1, (0, 0, 100, 10), (100, 100))
         figure = PDFReplacementRegion(1, (0, 14, 100, 30), (100, 100))

--- a/tests/test_pdf_text_layout.py
+++ b/tests/test_pdf_text_layout.py
@@ -7,7 +7,9 @@ from pdf_craft.pipeline.pdf import (
     QTextParagraphFiller, RegionTextPlacement,
 )
 from pdf_craft.pipeline.pdf.geometry import PageRectangle
-from pdf_craft.pipeline.pdf.text_layout import _choose_automatic_font
+from pdf_craft.pipeline.pdf.pipeline import PDFTranslationPipeline
+from pdf_craft.extractor.chapter.chapter import AssetLayout, BlockLayout, Chapter, ParagraphLayout
+from pdf_craft.pipeline.pdf.text_layout import _LAYOUT_SCALE, _choose_automatic_font
 
 
 def _replacement(text: str, regions, *, layout_ref: str = "text", layout_level: int = 0):
@@ -131,6 +133,75 @@ class TestQTextParagraphFiller(unittest.TestCase):
         self.assertLessEqual(fitted.font_size, threshold)
         self.assertLess(threshold - fitted.font_size, 0.05)
         self.assertNotEqual(fitted.font_size * 4, round(fitted.font_size * 4))
+
+    def test_aim_line_can_be_crossed_when_that_is_closer_than_staying_above_it(self):
+        """A source bottom is scored as a target, never treated as a hard edge."""
+        class AimFiller(QTextParagraphFiller):
+            def _plan(self, text, replacement, page_sizes, style, font_size):
+                del replacement, page_sizes
+                if font_size > 7:
+                    return None
+                bottom = 8 if font_size <= 5 else 10.5
+                placement = RegionTextPlacement(
+                    1, PageRectangle(0, 0, 100, 10), text,
+                    (0,), (20,), (bottom - 2,), (2,), font_size, style,
+                    assigned_text=text, forbidden_bottom=12,
+                )
+                return FittedParagraph(text, font_size, (placement,))
+
+        region = PDFReplacementRegion(1, (0, 0, 100, 10), (100, 100))
+        fitted = AimFiller(PatchTextOptions(max_font_size=10, min_font_size=4)).fit(
+            _replacement("target", [region]), {1: (100, 100)},
+        )
+
+        placement = fitted.placements[0]
+        self.assertGreater(placement.line_tops[-1] + placement.line_heights[-1], 10)
+        self.assertLessEqual(placement.line_tops[-1] + placement.line_heights[-1], 12)
+
+    def test_lower_asset_top_is_a_forbidden_line(self):
+        source = PDFReplacementRegion(1, (0, 0, 100, 10), (100, 100))
+        figure = PDFReplacementRegion(1, (0, 14, 100, 30), (100, 100))
+        replacement = PDFReplacement(
+            1, source.bbox, "line", source.page_pixel_size,
+            regions=(source,), obstacle_regions=(figure,),
+        )
+
+        placement = QTextParagraphFiller(PatchTextOptions(max_font_size=8, min_font_size=8)).fit(
+            replacement, {1: (100, 100)},
+        ).placements[0]
+
+        line_bottom = placement.line_tops[-1] + placement.line_heights[-1]
+        self.assertEqual(placement.forbidden_bottom, 14)
+        self.assertGreater(line_bottom, 10)
+        self.assertLessEqual(line_bottom, 14)
+
+    def test_pdf_pipeline_attaches_asset_geometry_as_text_flow_obstacles(self):
+        chapter = Chapter(
+            id=1,
+            level=0,
+            layouts=[
+                ParagraphLayout("text", 0, [BlockLayout(1, 0, (0, 0, 100, 10), ["body"])]),
+                AssetLayout(1, "image", (0, 14, 100, 30), [], [], [], None),
+            ],
+        )
+
+        replacements = list(PDFTranslationPipeline()._iter_chapter_replacements(  # pylint: disable=protected-access
+            chapter, lambda text: text, {1: (100, 100)}, 300, structured=True,
+        ))
+
+        self.assertEqual(len(replacements), 1)
+        self.assertEqual(replacements[0].obstacle_regions[0].bbox, (0, 14, 100, 30))
+
+    def test_high_precision_layout_uses_scaled_qt_font_coordinates(self):
+        """The layout font, rather than a post-layout heuristic, receives precision."""
+        from PySide6 import QtCore, QtGui
+
+        filler = QTextParagraphFiller(PatchTextOptions())
+        layout = filler._create_layout(  # pylint: disable=protected-access
+            QtCore, QtGui, "precision", PatchTextStyle(), 4.12, _LAYOUT_SCALE,
+        )
+
+        self.assertAlmostEqual(layout.font().pointSizeF(), 4.12 * _LAYOUT_SCALE)
 
     def test_flows_a_paragraph_through_multiple_rectangles_once(self):
         regions = [
@@ -368,9 +439,12 @@ class TestQTextParagraphFiller(unittest.TestCase):
             multi_line.line_heights[0] * 1.6,
         )
 
-    def test_fails_only_when_even_minimum_size_cannot_fit_any_full_line(self):
+    def test_page_bottom_is_the_last_forbidden_line_when_no_lower_bbox_exists(self):
         regions = [PDFReplacementRegion(1, (0, 0, 20, 5), (100, 100))]
         filler = QTextParagraphFiller(PatchTextOptions(max_font_size=8, min_font_size=8))
 
-        with self.assertRaisesRegex(ValueError, "cannot fit paragraph source regions"):
-            filler.fit(_replacement("too much text", regions), {1: (100, 100)})
+        fitted = filler.fit(_replacement("too much text", regions), {1: (100, 100)})
+
+        placement = fitted.placements[0]
+        self.assertGreater(placement.line_tops[-1] + placement.line_heights[-1], 5)
+        self.assertLessEqual(placement.line_tops[-1] + placement.line_heights[-1], 100)

--- a/tests/test_pdf_text_layout.py
+++ b/tests/test_pdf_text_layout.py
@@ -1,4 +1,5 @@
 import unittest
+from dataclasses import replace
 
 # pylint: disable=no-member,c-extension-no-member
 
@@ -8,7 +9,9 @@ from pdf_craft.pipeline.pdf import (
 )
 from pdf_craft.pipeline.pdf.geometry import PageRectangle
 from pdf_craft.pipeline.pdf.pipeline import PDFTranslationPipeline
-from pdf_craft.extractor.chapter.chapter import AssetLayout, BlockLayout, Chapter, ParagraphLayout
+from pdf_craft.extractor.chapter.chapter import (
+    AssetLayout, BlockLayout, Chapter, ParagraphLayout, Reference,
+)
 from pdf_craft.pipeline.pdf.text_layout import _LAYOUT_SCALE, _choose_automatic_font
 
 
@@ -191,6 +194,36 @@ class TestQTextParagraphFiller(unittest.TestCase):
 
         self.assertEqual(len(replacements), 1)
         self.assertEqual(replacements[0].obstacle_regions[0].bbox, (0, 14, 100, 30))
+
+    def test_reference_footnote_stops_text_after_its_source_bottom(self):
+        """Reference layouts are obstacles even though they are not chapter body layouts."""
+        footnote = ParagraphLayout(
+            "text", 0, [BlockLayout(1, 1, (0, 14, 100, 30), ["footnote"])],
+        )
+        reference = Reference(1, 1, "①", [footnote])
+        chapter = Chapter(
+            id=1,
+            level=0,
+            layouts=[
+                ParagraphLayout(
+                    "text", 0,
+                    [BlockLayout(1, 0, (0, 0, 100, 10), ["body", reference])],
+                ),
+            ],
+        )
+
+        replacement, = PDFTranslationPipeline()._iter_chapter_replacements(  # pylint: disable=protected-access
+            chapter, lambda text: text, {1: (100, 100)}, 300, structured=True,
+        )
+        self.assertEqual([region.bbox for region in replacement.obstacle_regions], [(0, 14, 100, 30)])
+
+        placement = QTextParagraphFiller(PatchTextOptions(max_font_size=8, min_font_size=8)).fit(
+            replace(replacement, text="line"), {1: (100, 100)},
+        ).placements[0]
+        line_bottom = placement.line_tops[-1] + placement.line_heights[-1]
+        self.assertGreater(line_bottom, 10)
+        self.assertEqual(placement.forbidden_bottom, 14)
+        self.assertLessEqual(line_bottom, 14)
 
     def test_high_precision_layout_uses_scaled_qt_font_coordinates(self):
         """The layout font, rather than a post-layout heuristic, receives precision."""

--- a/tests/test_pdf_windowed_layout.py
+++ b/tests/test_pdf_windowed_layout.py
@@ -266,6 +266,11 @@ class TestWindowedParagraphPlanner(unittest.TestCase):
         larger_second_page_body = _replacement(
             "extra", [_line_region(2)], layout_level=1,
         )
+        # A figure below the first source box is a real forbidden line.  The
+        # page below it remains available through the paragraph's second box.
+        blocker = PDFReplacementRegion(1, (0, 34, 240, 96), (240, 100))
+        body = replace(body, obstacle_regions=(blocker,))
+        headline = replace(headline, obstacle_regions=(blocker,))
 
         window = next(planner.plan([headline, body, larger_second_page_body]))
 

--- a/tests/test_pdf_windowed_layout.py
+++ b/tests/test_pdf_windowed_layout.py
@@ -140,9 +140,9 @@ class TestWindowedParagraphPlanner(unittest.TestCase):
             window.close()
 
     def test_second_pass_is_local_and_allows_one_line_to_escape_tight_ocr_height(self):
-        region = PDFReplacementRegion(1, (0, 0, 160, 14), (160, 14))
+        region = PDFReplacementRegion(1, (0, 0, 160, 14), (160, 60))
         filler = QTextParagraphFiller(PatchTextOptions(max_font_size=20, min_font_size=4))
-        fitted = filler.fit(_replacement("one short line", [region]), {1: (160, 14)})
+        fitted = filler.fit(_replacement("one short line", [region]), {1: (160, 60)})
         original = fitted.placements[0]
         self.assertEqual(len(original.line_tops), 1)
 
@@ -153,6 +153,25 @@ class TestWindowedParagraphPlanner(unittest.TestCase):
         self.assertEqual(reflowed.font_size, 14)
         self.assertGreater(
             reflowed.line_tops[0] + reflowed.line_heights[0], reflowed.rectangle.bottom,
+        )
+
+    def test_second_pass_one_line_respects_a_lower_forbidden_line(self):
+        """Ignoring a tight OCR bbox must not allow overlap with a footnote."""
+        style = PatchTextStyle(max_font_size=12, min_font_size=4)
+        original = RegionTextPlacement(
+            1, PageRectangle(0, 0, 100, 10), "one short line",
+            (0,), (50,), (0,), (8,), 8, style,
+            assigned_text="one short line", forbidden_bottom=14,
+        )
+        filler = QTextParagraphFiller(PatchTextOptions(styles={"text": style}))
+
+        reflowed = filler.fit_frozen_region(original, 12)
+
+        self.assertEqual(reflowed.assigned_text, original.assigned_text)
+        self.assertEqual(len(reflowed.line_tops), 1)
+        self.assertLess(reflowed.font_size, 12)
+        self.assertLessEqual(
+            reflowed.line_tops[-1] + reflowed.line_heights[-1], 14 + 1e-6,
         )
 
     def test_second_pass_keeps_multi_line_runs_inside_their_bbox(self):

--- a/tests/test_pdf_windowed_layout.py
+++ b/tests/test_pdf_windowed_layout.py
@@ -198,7 +198,10 @@ class TestWindowedParagraphPlanner(unittest.TestCase):
             QTextParagraphFiller(options), {1: (200, 100)}, options,
         )
         headline = _replacement("Heading", [_region(1)], layout_ref="sub_title")
-        body = _replacement("Body", [_region(1)])
+        body = _replacement(
+            "Several body words keep the default body fit safely below the page boundary.",
+            [_region(1)],
+        )
 
         window = next(planner.plan([headline, body]))
 


### PR DESCRIPTION
## Summary
- fit PDF text to source bbox aim lines while enforcing lower obstacle/page boundaries
- include reference footnote geometry as obstacles and retain safety during second-pass/headline reflow
- use scaled QTextLayout coordinates and search multi-bbox Qt wrap discontinuities at 0.05pt
- add real citation PDF smoke coverage plus layout safety regressions

## Verification
- poetry run pytest tests/test_pdf_text_layout.py tests/test_pdf_windowed_layout.py tests/test_pdf_patch_smoke.py tests/test_pdf_inline_formula.py tests/test_pdf_patcher.py
- poetry run pyright pdf_craft tests
- poetry run pylint pdf_craft/pipeline/pdf/text_layout.py tests/test_pdf_text_layout.py
- poetry run python test.py