### PR TITLE
fix: align PDF virtual slot planning semantics

### DIFF
--- a/pdf_craft/pipeline/pdf/text_layout.py
+++ b/pdf_craft/pipeline/pdf/text_layout.py
@@ -1846,19 +1846,33 @@ def _signed_slot_plan_frontier(
 
     ordered_tight = sorted(tight_options, key=lambda item: (item[2], item[0]))
     maximum_tight = len(ordered_tight)
-    non_negative_count = min(maximum_tight, max(0, floor((base_delta + 1e-6) / advance)))
 
     def plan_with_tight_count(count: int) -> _SlotDecisionPlan:
         selected = {index: tight for index, tight, _ in ordered_tight[:count]}
         decisions = tuple(selected.get(index, item) for index, item in enumerate(loose))
         return _SlotDecisionPlan(decisions, base_delta - count * advance)
 
-    non_negative = plan_with_tight_count(non_negative_count)
-    negative_count = non_negative_count + 1
-    if negative_count > maximum_tight:
-        return (non_negative,)
-    negative = plan_with_tight_count(negative_count)
-    return (non_negative, negative)
+    # Keep the nearest candidate from *each actual sign side*.  In
+    # particular, a negative loose-only total has no non-negative companion:
+    # it is already the closest negative plan and must not be paired with an
+    # even more negative tight plan.
+    non_negative_count = min(
+        maximum_tight,
+        max(0, floor((base_delta + 1e-6) / advance)),
+    )
+    has_non_negative = base_delta >= -1e-6
+    non_negative = plan_with_tight_count(non_negative_count) if has_non_negative else None
+
+    if has_non_negative:
+        negative_count = non_negative_count + 1
+    else:
+        negative_count = 0
+    negative = (
+        plan_with_tight_count(negative_count)
+        if negative_count <= maximum_tight
+        else None
+    )
+    return tuple(plan for plan in (non_negative, negative) if plan is not None)
 
 
 def _replacement_obstacles(

--- a/pdf_craft/pipeline/pdf/text_layout.py
+++ b/pdf_craft/pipeline/pdf/text_layout.py
@@ -1856,12 +1856,25 @@ def _signed_slot_plan_frontier(
     # particular, a negative loose-only total has no non-negative companion:
     # it is already the closest negative plan and must not be paired with an
     # even more negative tight plan.
-    non_negative_count = min(
-        maximum_tight,
-        max(0, floor((base_delta + 1e-6) / advance)),
-    )
-    has_non_negative = base_delta >= -1e-6
-    non_negative = plan_with_tight_count(non_negative_count) if has_non_negative else None
+    has_non_negative = base_delta >= 0
+    non_negative_count = 0
+    non_negative = None
+    if has_non_negative:
+        non_negative_count = min(maximum_tight, max(0, floor(base_delta / advance)))
+        # ``floor`` gives the right count analytically, but confirm the final
+        # floating-point subtraction itself rather than allowing a tolerance
+        # to move a genuinely negative signed total onto the non-negative
+        # side.  This loop only adjusts around that one boundary.
+        while non_negative_count and (
+            base_delta - non_negative_count * advance < 0
+        ):
+            non_negative_count -= 1
+        while (
+            non_negative_count < maximum_tight
+            and base_delta - (non_negative_count + 1) * advance >= 0
+        ):
+            non_negative_count += 1
+        non_negative = plan_with_tight_count(non_negative_count)
 
     if has_non_negative:
         negative_count = non_negative_count + 1

--- a/pdf_craft/pipeline/pdf/text_layout.py
+++ b/pdf_craft/pipeline/pdf/text_layout.py
@@ -3,7 +3,7 @@
 
 from collections.abc import Callable, Iterable, Iterator, Mapping
 from dataclasses import dataclass, field, replace
-from math import isfinite
+from math import floor, isclose, isfinite
 import os
 import pickle
 from pathlib import Path
@@ -32,7 +32,6 @@ _HEADLINE_OVERFLOW_LINE_WIDTH = 1_000_000.0
 # while making a 0.05pt search a real typographic search rather than a screen
 # pixel search.
 _LAYOUT_SCALE = 8.0
-_SLOT_PLAN_BEAM_WIDTH = 64
 _CJK_FONT_CANDIDATES = (
     "PingFang SC",
     "Noto Sans CJK SC",
@@ -781,26 +780,6 @@ class QTextParagraphFiller:
             max(rectangle.width - 2 * style.horizontal_padding for rectangle in capacities),
             max(rectangle.height - 2 * style.vertical_padding for rectangle in capacities),
         )
-        if len(replacement.source_regions()) == 1:
-            source_region = replacement.source_regions()[0]
-            page_width, page_height = page_sizes[source_region.page_index]
-            rectangle = region_in_page_points(source_region, page_width, page_height)
-            forbidden_bottom = _forbidden_bottom(
-                rectangle,
-                self._layout_obstacles.get(source_region.page_index, ()),
-                page_height,
-            )
-            previous_forbidden_bottom = self._active_forbidden_bottom
-            self._active_forbidden_bottom = forbidden_bottom
-            try:
-                placement, consumed = self._fit_region(
-                    source_region.page_index, rectangle, text, style, font_size, spans,
-                )
-            finally:
-                self._active_forbidden_bottom = previous_forbidden_bottom
-            if placement is None or consumed != len(text):
-                return None
-            return FittedParagraph(text, font_size, (placement,))
         return self._plan_continuous_flow(text, spans, replacement, page_sizes, style, font_size)
 
     def _plan_continuous_flow(
@@ -1810,34 +1789,21 @@ def _slot_decision_is_valid(decision: _RegionSlotDecision) -> bool:
     )
 
 
-def _slot_plan_quality(plan: _SlotDecisionPlan) -> tuple[float, float, float, int]:
-    """Rank plans by per-bbox error, never by cancellable signed totals.
-
-    The signed sum is deliberately only a final tie-breaker.  A +99 miss in
-    one bbox and a -99 miss in another is not a good plan: its worst and total
-    absolute errors must lose to a plan with two one-point misses even when
-    both signed sums are zero.
-    """
-    distances = tuple(abs(decision.delta_to_aim) for decision in plan.decisions)
-    return (
-        max(distances, default=0.0),
-        sum(distances),
-        abs(plan.signed_delta),
-        -sum(decision.line_count for decision in plan.decisions),
-    )
-
-
 def _signed_slot_plan_frontier(
     choices: tuple[tuple[_RegionSlotDecision, ...], ...],
 ) -> tuple[_SlotDecisionPlan, ...]:
-    """Keep a bounded per-bbox-error frontier instead of enumerating 2**N.
+    """Return the nearest sparse and tight signed-aim combinations.
 
-    Each region supplies one loose and, when safe, one tight choice.  The
-    frontier retains equally bounded candidates from both aggregate signs
-    after every step.  Its primary score is each candidate's largest and total
-    *absolute* per-bbox miss, so opposite signs cannot hide a severe local
-    error.  The aggregate sign merely keeps the traditional sparse/tight
-    alternatives available for real Qt validation.
+    A slot decision comes from one nominal font metric: switching one region
+    from loose to tight always adds one row and changes its signed aim delta
+    by the same negative line advance.  Consequently a combination's signed
+    total depends only on how many safe tight choices it contains, not on
+    which regions supply them.  This gives the exact nearest non-negative and
+    negative totals with arithmetic instead of enumerating ``2**N`` plans.
+
+    Which equally signed regions become tight is a deterministic tie-break:
+    prefer the smallest change in that region's absolute aim miss, then source
+    order.  It never changes the signed-total objective.
     """
     if not choices or any(
         not region_choices
@@ -1845,39 +1811,54 @@ def _signed_slot_plan_frontier(
         for region_choices in choices
     ):
         return ()
-    states = [_SlotDecisionPlan((), 0.0)]
-    per_side = max(1, _SLOT_PLAN_BEAM_WIDTH // 2)
-    for region_choices in choices:
-        expanded = [
-            _SlotDecisionPlan(state.decisions + (choice,), state.signed_delta + choice.delta_to_aim)
-            for state in states for choice in region_choices
-        ]
-        non_negative = sorted(
-            (state for state in expanded if state.signed_delta >= -1e-6),
-            key=_slot_plan_quality,
-        )[:per_side]
-        negative = sorted(
-            (state for state in expanded if state.signed_delta < -1e-6),
-            key=_slot_plan_quality,
-        )[:per_side]
-        states = non_negative + negative
-        if not states:
+
+    loose: list[_RegionSlotDecision] = []
+    tight_options: list[tuple[int, _RegionSlotDecision, float]] = []
+    advances: list[float] = []
+    for index, region_choices in enumerate(choices):
+        loose_choice = next((item for item in region_choices if item.choice == "loose"), None)
+        if loose_choice is None:
             return ()
-    positive = min(
-        (state for state in states if state.signed_delta >= -1e-6),
-        default=None,
-        key=_slot_plan_quality,
-    )
-    negative = min(
-        (state for state in states if state.signed_delta < -1e-6),
-        default=None,
-        key=_slot_plan_quality,
-    )
-    if positive is None:
-        return (negative,) if negative is not None else ()
-    if negative is None or negative.decisions == positive.decisions:
-        return (positive,)
-    return tuple(sorted((positive, negative), key=_slot_plan_quality))
+        loose.append(loose_choice)
+        tight_choice = next((item for item in region_choices if item.choice == "tight"), None)
+        if tight_choice is None:
+            continue
+        advance = loose_choice.delta_to_aim - tight_choice.delta_to_aim
+        if not _positive_finite(advance):
+            return ()
+        advances.append(advance)
+        tight_options.append((
+            index,
+            tight_choice,
+            abs(tight_choice.delta_to_aim) - abs(loose_choice.delta_to_aim),
+        ))
+
+    base_delta = sum(item.delta_to_aim for item in loose)
+    if not tight_options:
+        return (_SlotDecisionPlan(tuple(loose), base_delta),)
+    advance = advances[0]
+    if not all(isclose(value, advance, rel_tol=1e-9, abs_tol=1e-6) for value in advances):
+        # This helper receives choices generated from a single font metric.
+        # A different advance would mean malformed planner input; returning no
+        # plan is safer than silently replacing the specified signed objective
+        # with an approximate beam search.
+        return ()
+
+    ordered_tight = sorted(tight_options, key=lambda item: (item[2], item[0]))
+    maximum_tight = len(ordered_tight)
+    non_negative_count = min(maximum_tight, max(0, floor((base_delta + 1e-6) / advance)))
+
+    def plan_with_tight_count(count: int) -> _SlotDecisionPlan:
+        selected = {index: tight for index, tight, _ in ordered_tight[:count]}
+        decisions = tuple(selected.get(index, item) for index, item in enumerate(loose))
+        return _SlotDecisionPlan(decisions, base_delta - count * advance)
+
+    non_negative = plan_with_tight_count(non_negative_count)
+    negative_count = non_negative_count + 1
+    if negative_count > maximum_tight:
+        return (non_negative,)
+    negative = plan_with_tight_count(negative_count)
+    return (non_negative, negative)
 
 
 def _replacement_obstacles(

--- a/tests/test_pdf_patch_smoke.py
+++ b/tests/test_pdf_patch_smoke.py
@@ -109,9 +109,12 @@ class TestPDFPatchSmoke(unittest.TestCase):
             {1: (float(page.mediabox.width), float(page.mediabox.height))},
         )
         self.assertGreater(fitted.font_size, 12)
+        # A source rectangle's bottom is an aim line rather than a hard edge:
+        # the centred tight slot plan may straddle it slightly.  The actual
+        # projected guard is still absolute (the page edge in this fixture).
         self.assertTrue(all(
-            placement.rectangle.top <= top
-            and top + height <= (placement.forbidden_bottom or placement.rectangle.bottom)
+            0 <= top
+            and top + height <= (placement.forbidden_bottom or float(page.mediabox.height))
             for placement in fitted.placements
             for top, height in zip(placement.line_tops, placement.line_heights)
         ))

--- a/tests/test_pdf_patcher.py
+++ b/tests/test_pdf_patcher.py
@@ -251,10 +251,13 @@ class TestPDFPatcher(unittest.TestCase):
             # font), so Unicode extraction is platform dependent. The English
             # patch tests cover extraction; here prove that CJK layout fits and
             # produces a genuine PDF font/content layer instead of an image.
+            # The source bbox bottom is an aim line, so a centred tight plan
+            # can straddle it.  The real projected guard (the page edge for
+            # this fixture) remains mandatory across Qt font backends.
             for placement in fitted.placements:
                 self.assertTrue(all(
-                    placement.rectangle.top <= top
-                    and top + height <= (placement.forbidden_bottom or placement.rectangle.bottom)
+                    0 <= top
+                    and top + height <= (placement.forbidden_bottom or 200)
                     for top, height in zip(placement.line_tops, placement.line_heights)
                 ))
             source_fonts = set(source_page["/Resources"]["/Font"].get_object())

--- a/tests/test_pdf_text_layout.py
+++ b/tests/test_pdf_text_layout.py
@@ -503,6 +503,36 @@ class TestQTextParagraphFiller(unittest.TestCase):
         self.assertEqual(plans[0].signed_delta, -2)
         self.assertTrue(all(item.choice == "loose" for item in plans[0].decisions))
 
+    def test_slot_frontier_keeps_a_near_zero_negative_on_the_negative_side(self):
+        """Sign classification is exact even when a miss is below 1e-6pt."""
+        rectangle = PageRectangle(0, 0, 1, 1)
+
+        def decision(delta, choice):
+            return _RegionSlotDecision(1, rectangle, 1, delta, delta / 2, 0, 2, choice)
+
+        plans = _signed_slot_plan_frontier((
+            (decision(-0.0000005, "loose"), decision(-1.0000005, "tight")),
+        ))
+
+        self.assertEqual(len(plans), 1)
+        self.assertEqual(plans[0].signed_delta, -0.0000005)
+        self.assertEqual(plans[0].decisions[0].choice, "loose")
+
+    def test_slot_frontier_keeps_a_near_zero_negative_separate_from_positive(self):
+        """An actual negative tight value must not replace a positive loose value."""
+        rectangle = PageRectangle(0, 0, 1, 1)
+
+        def decision(delta, choice):
+            return _RegionSlotDecision(1, rectangle, 1, delta, delta / 2, 0, 2, choice)
+
+        plans = _signed_slot_plan_frontier((
+            (decision(0.9999995, "loose"), decision(-0.0000005, "tight")),
+        ))
+
+        self.assertGreater(plans[0].signed_delta, 0)
+        self.assertLess(plans[1].signed_delta, 0)
+        self.assertEqual([plan.decisions[0].choice for plan in plans], ["loose", "tight"])
+
     def test_slot_frontier_returns_only_nearest_positive_when_no_negative_exists(self):
         """If every allowed choice is loose-side, retain only the closest one."""
         rectangle = PageRectangle(0, 0, 1, 1)

--- a/tests/test_pdf_text_layout.py
+++ b/tests/test_pdf_text_layout.py
@@ -227,7 +227,7 @@ class TestQTextParagraphFiller(unittest.TestCase):
         self.assertLess(abs(terminal_bottom - terminal.rectangle.bottom), minimum_delta)
         self.assertLessEqual(terminal_bottom, terminal.forbidden_bottom or 260)
 
-    def test_lower_asset_top_is_a_forbidden_line(self):
+    def test_lower_asset_top_filters_a_single_bbox_tight_choice(self):
         source = PDFReplacementRegion(1, (0, 0, 100, 10), (100, 100))
         figure = PDFReplacementRegion(1, (0, 14, 100, 30), (100, 100))
         replacement = PDFReplacement(
@@ -241,10 +241,11 @@ class TestQTextParagraphFiller(unittest.TestCase):
             replacement, {1: (100, 100)},
         ).placements[0]
 
-        line_bottom = placement.line_tops[-1] + placement.line_heights[-1]
         self.assertEqual(placement.forbidden_bottom, 14)
-        self.assertGreater(line_bottom, 10)
-        self.assertLessEqual(line_bottom, 14)
+        line_bottom = placement.line_tops[-1] + placement.line_heights[-1]
+        # With no space above the source bbox, a centred tight plan would
+        # escape through the page top and must be rejected.
+        self.assertLessEqual(line_bottom, 10)
 
     def test_pdf_pipeline_attaches_asset_geometry_as_text_flow_obstacles(self):
         chapter = Chapter(
@@ -263,7 +264,7 @@ class TestQTextParagraphFiller(unittest.TestCase):
         self.assertEqual(len(replacements), 1)
         self.assertEqual(replacements[0].obstacle_regions[0].bbox, (0, 14, 100, 30))
 
-    def test_reference_footnote_stops_text_after_its_source_bottom(self):
+    def test_reference_footnote_filters_single_bbox_tight_overflow(self):
         """Reference layouts are obstacles even though they are not chapter body layouts."""
         footnote = ParagraphLayout(
             "text", 0, [BlockLayout(1, 1, (0, 14, 100, 30), ["footnote"])],
@@ -291,9 +292,8 @@ class TestQTextParagraphFiller(unittest.TestCase):
             replace(replacement, text="line"), {1: (100, 100)},
         ).placements[0]
         line_bottom = placement.line_tops[-1] + placement.line_heights[-1]
-        self.assertGreater(line_bottom, 10)
         self.assertEqual(placement.forbidden_bottom, 14)
-        self.assertLessEqual(line_bottom, 14)
+        self.assertLessEqual(line_bottom, 10)
 
     def test_high_precision_planning_and_pdf_draw_share_scaled_qt_coordinates(self):
         """Planning and the real PDF overlay use one unrounded Qt coordinate space."""
@@ -457,22 +457,45 @@ class TestQTextParagraphFiller(unittest.TestCase):
             for plan in plans for decision in plan.decisions
         ))
 
-    def test_slot_frontier_never_cancels_large_opposite_bbox_errors(self):
-        """A zero signed total cannot conceal two badly misfitted source boxes."""
+    def test_slot_frontier_returns_nearest_non_negative_and_negative_signed_totals(self):
+        """The global choice is defined by signed distance, not local error ranking."""
         rectangle = PageRectangle(0, 0, 1, 1)
 
         def decision(delta, choice):
             return _RegionSlotDecision(1, rectangle, 1, delta, delta / 2, 0, 2, choice)
 
         plans = _signed_slot_plan_frontier((
-            (decision(99, "loose"), decision(-1, "tight")),
-            (decision(1, "loose"), decision(-99, "tight")),
+            (decision(9, "loose"), decision(-1, "tight")),
+            (decision(9, "loose"), decision(-1, "tight")),
+            (decision(9, "loose"), decision(-1, "tight")),
         ))
 
-        self.assertTrue(plans)
-        first_deltas = tuple(decision.delta_to_aim for decision in plans[0].decisions)
-        self.assertEqual(first_deltas, (-1, 1))
-        self.assertEqual(max(abs(delta) for delta in first_deltas), 1)
+        self.assertEqual([plan.signed_delta for plan in plans], [7, -3])
+        self.assertEqual(
+            [sum(item.choice == "tight" for item in plan.decisions) for plan in plans], [2, 3],
+        )
+
+    def test_single_bbox_uses_slot_planning_and_is_vertically_centred(self):
+        """One source region is a normal slot-plan case, not a legacy branch."""
+        class RecordingFiller(QTextParagraphFiller):
+            slot_plan_calls = 0
+
+            def _slot_decision_plans(self, *args, **kwargs):
+                type(self).slot_plan_calls += 1
+                return super()._slot_decision_plans(*args, **kwargs)
+
+        region = PDFReplacementRegion(1, (0, 0, 180, 100), (200, 140))
+        filler = RecordingFiller(PatchTextOptions(max_font_size=10, min_font_size=10))
+
+        fitted = filler.fit(_replacement("one short line", [region]), {1: (200, 140)})
+
+        self.assertGreater(filler.slot_plan_calls, 0)
+        placement = fitted.placements[0]
+        top_margin = placement.line_tops[0] - placement.rectangle.top
+        bottom_margin = placement.rectangle.bottom - (
+            placement.line_tops[-1] + placement.line_heights[-1]
+        )
+        self.assertAlmostEqual(top_margin, bottom_margin, places=4)
 
     def test_text_can_exhaust_before_all_virtual_slots_without_fake_lines(self):
         """Empty continuation slots are retained as counts, never as QTextLines."""
@@ -773,7 +796,7 @@ class TestQTextParagraphFiller(unittest.TestCase):
         self.assertAlmostEqual(placement.line_text_lefts[0], 5.0)
         self.assertAlmostEqual(placement.line_text_widths[0], 70.0)
 
-    def test_line_height_and_vertical_alignment_position_complete_lines(self):
+    def test_single_bbox_slot_plan_centres_complete_lines(self):
         region = PDFReplacementRegion(1, (0, 0, 120, 100), (120, 100))
         vertical_placements = {}
         for alignment in ("top", "center", "bottom"):
@@ -789,11 +812,13 @@ class TestQTextParagraphFiller(unittest.TestCase):
         top = vertical_placements["top"]
         center = vertical_placements["center"]
         bottom = vertical_placements["bottom"]
-        self.assertAlmostEqual(top.line_tops[0], 10.0)
+        self.assertAlmostEqual(top.line_tops[0], center.line_tops[0])
+        self.assertAlmostEqual(center.line_tops[0], bottom.line_tops[0])
+        line_bottom = center.line_tops[-1] + center.line_heights[-1]
         self.assertAlmostEqual(
-            center.line_tops[0], 10.0 + (80.0 - center.line_heights[0]) / 2,
+            center.line_tops[0] - center.rectangle.top,
+            center.rectangle.bottom - line_bottom,
         )
-        self.assertAlmostEqual(bottom.line_tops[0], 90.0 - bottom.line_heights[0])
 
         multi_line_style = PatchTextStyle(
             max_font_size=10, min_font_size=10, line_height=1.6,
@@ -812,12 +837,9 @@ class TestQTextParagraphFiller(unittest.TestCase):
             multi_line.line_heights[0] * 1.6,
         )
 
-    def test_page_bottom_is_the_last_forbidden_line_when_no_lower_bbox_exists(self):
+    def test_single_bbox_slot_exhaustion_does_not_extend_to_page_bottom(self):
         regions = [PDFReplacementRegion(1, (0, 0, 20, 5), (100, 100))]
         filler = QTextParagraphFiller(PatchTextOptions(max_font_size=8, min_font_size=8))
 
-        fitted = filler.fit(_replacement("too much text", regions), {1: (100, 100)})
-
-        placement = fitted.placements[0]
-        self.assertGreater(placement.line_tops[-1] + placement.line_heights[-1], 5)
-        self.assertLessEqual(placement.line_tops[-1] + placement.line_heights[-1], 100)
+        with self.assertRaisesRegex(ValueError, "cannot fit paragraph source regions"):
+            filler.fit(_replacement("too much text", regions), {1: (100, 100)})

--- a/tests/test_pdf_text_layout.py
+++ b/tests/test_pdf_text_layout.py
@@ -458,7 +458,7 @@ class TestQTextParagraphFiller(unittest.TestCase):
         ))
 
     def test_slot_frontier_returns_nearest_non_negative_and_negative_signed_totals(self):
-        """The global choice is defined by signed distance, not local error ranking."""
+        """The global choice is signed distance, not per-bbox absolute error."""
         rectangle = PageRectangle(0, 0, 1, 1)
 
         def decision(delta, choice):
@@ -470,10 +470,54 @@ class TestQTextParagraphFiller(unittest.TestCase):
             (decision(9, "loose"), decision(-1, "tight")),
         ))
 
-        self.assertEqual([plan.signed_delta for plan in plans], [7, -3])
+        self.assertEqual(len(plans), 2)
+        positive = plans[0]
+        negative = plans[1]
+        self.assertEqual((positive.signed_delta, negative.signed_delta), (7, -3))
         self.assertEqual(
-            [sum(item.choice == "tight" for item in plan.decisions) for plan in plans], [2, 3],
+            (sum(item.choice == "tight" for item in positive.decisions),
+             sum(item.choice == "tight" for item in negative.decisions)),
+            (2, 3),
         )
+        # A legacy local-absolute-error ranking prefers all three tight
+        # decisions (three 1pt misses) over the positive side (two 1pt and
+        # one 9pt miss).  The planner must still expose the latter because it
+        # is the closest non-negative signed total.
+        positive_local_error = sum(abs(item.delta_to_aim) for item in positive.decisions)
+        negative_local_error = sum(abs(item.delta_to_aim) for item in negative.decisions)
+        self.assertGreater(positive_local_error, negative_local_error)
+
+    def test_slot_frontier_returns_only_nearest_negative_when_no_non_negative_exists(self):
+        """A negative loose plan has no fictitious non-negative companion."""
+        rectangle = PageRectangle(0, 0, 1, 1)
+
+        def decision(delta, choice):
+            return _RegionSlotDecision(1, rectangle, 1, delta, delta / 2, 0, 2, choice)
+
+        plans = _signed_slot_plan_frontier((
+            (decision(-1, "loose"), decision(-3, "tight")),
+            (decision(-1, "loose"), decision(-3, "tight")),
+        ))
+
+        self.assertEqual(len(plans), 1)
+        self.assertEqual(plans[0].signed_delta, -2)
+        self.assertTrue(all(item.choice == "loose" for item in plans[0].decisions))
+
+    def test_slot_frontier_returns_only_nearest_positive_when_no_negative_exists(self):
+        """If every allowed choice is loose-side, retain only the closest one."""
+        rectangle = PageRectangle(0, 0, 1, 1)
+
+        def decision(delta, choice):
+            return _RegionSlotDecision(1, rectangle, 1, delta, delta / 2, 0, 2, choice)
+
+        plans = _signed_slot_plan_frontier((
+            (decision(5, "loose"), decision(3, "tight")),
+            (decision(5, "loose"), decision(3, "tight")),
+        ))
+
+        self.assertEqual(len(plans), 1)
+        self.assertEqual(plans[0].signed_delta, 6)
+        self.assertTrue(all(item.choice == "tight" for item in plans[0].decisions))
 
     def test_single_bbox_uses_slot_planning_and_is_vertically_centred(self):
         """One source region is a normal slot-plan case, not a legacy branch."""


### PR DESCRIPTION
## Summary
- choose lazy PDF line-slot plans by the actual nearest signed aim-distance on each available side
- route single-bbox paragraphs through the same guarded, centered virtual-slot planner as multi-bbox paragraphs
- cover one-sided and near-zero signed frontier cases

## Verification
- `poetry run pytest tests/test_pdf_text_layout.py tests/test_pdf_windowed_layout.py tests/test_pdf_inline_formula.py tests/test_pdf_patcher.py tests/test_pdf_patch_smoke.py`
- `poetry run pyright pdf_craft tests`
- `poetry run pylint pdf_craft tests`
- `poetry run python test.py`