### PR TITLE
为 PDF fill 增加页级 ignore errors 回退并准备 2.2.1

### DIFF
--- a/docs/changelog/v2.2.1.md
+++ b/docs/changelog/v2.2.1.md
@@ -1,0 +1,15 @@
+# PDF Craft v2.2.1
+
+## What's Changed
+
+### Resilient PDF fill
+
+- Add `ignore_errors` to PDF translation and patching. When enabled, a page whose erase, text, formula, or PDF-composition work raises an exception is retained as its non-interactive visual base while the remaining pages continue to be filled.
+- Preserve the normal fail-fast behavior by default. If every page scheduled for fill falls back, PDF Craft now raises `NoUsableFillPagesError` rather than emitting a misleading successful output.
+- Keep fallback pages free of the source PDF's selectable text layer and retain the existing Annotation restoration policy.
+
+### Maintenance
+
+- Continue the paragraph-aware PDF fill improvements introduced in v2.2.0 with page-scoped recovery and regression coverage for page-level failures.
+
+**Full Changelog**: https://github.com/oomol-lab/pdf-craft/compare/v2.2.0...v2.2.1

--- a/docs/en/API_REFERENCE.md
+++ b/docs/en/API_REFERENCE.md
@@ -32,11 +32,13 @@ The two `convert_pdf_to_*` methods use a directory-backed extraction inside thei
 | Method | Signature and purpose |
 | --- | --- |
 | `translate_extraction` | `translate_extraction(extraction, output_path, translator, *, submit=SubmitKind.REPLACE, on_translation_event=None) -> PDFCraftExtraction` translates a `.pcex` into a new `.pcex`. |
-| `translate_pdf` | `translate_pdf(source, extraction, output, transformer, *, on_translation_event=None)` translates then patches text onto the source PDF. `transformer` may be a chapter transformer or `Callable[[str], str]`. |
-| `patch_pdf_with_extraction` | `patch_pdf_with_extraction(source, extraction, output)` patches a source PDF from a `PDFCraftExtraction` or `.pcex` path without OCR or LLM calls. |
+| `translate_pdf` | `translate_pdf(source, extraction, output, transformer, *, on_translation_event=None, ignore_errors=False)` translates then patches text onto the source PDF. `transformer` may be a chapter transformer or `Callable[[str], str]`. |
+| `patch_pdf_with_extraction` | `patch_pdf_with_extraction(source, extraction, output, *, ignore_errors=False)` patches a source PDF from a `PDFCraftExtraction` or `.pcex` path without OCR or LLM calls. |
 | `translate_epub` | `translate_epub(source, output, *, target_language, submit, **options)` translates an existing EPUB. See [EPUB translation](EPUB_TRANSLATION.md) for its options. |
 
 `translate_pdf` and `patch_pdf_with_extraction` require extraction page geometry that matches the source PDF. PDF patching rejects `SubmitKind.APPEND_BLOCK`.
+
+Set `ignore_errors=True` to preserve a page's non-interactive visual base when that page's fill transaction fails, then continue with later pages. The default remains fail-fast. If every page scheduled for fill falls back, `NoUsableFillPagesError` is raised and no output is written. This recovery scope intentionally covers ordinary page-level exceptions, including unexpected fill bugs; it does not recover a source PDF that cannot be opened, enumerated, or compiled into a visual base.
 
 ## `PDFCraftExtraction` and `.pcex`
 
@@ -197,6 +199,6 @@ The patcher merges two independent overlays over a Ghostscript-compiled, fontles
 - `OCRTokensMetering` exposes `input_tokens` and `output_tokens`.
 - `OCREvent` and `OCREventKind` support per-page progress and diagnostics.
 - `predownload_models(...)` prepares local OCR models before an offline `local_only=True` run.
-- `PDFError`, `OCRError`, and `InterruptedError` are exported error types for application-level handling.
+- `PDFError`, `OCRError`, `NoUsableFillPagesError`, and `InterruptedError` are exported error types for application-level handling.
 
 For complete workflows, start with [PDF conversion and translation](PDF_TRANSLATION.md) or [EPUB translation](EPUB_TRANSLATION.md), rather than composing internal modules.

--- a/docs/en/PDF_TRANSLATION.md
+++ b/docs/en/PDF_TRANSLATION.md
@@ -130,6 +130,8 @@ craft.translate_pdf(
     extraction,
     "book.zh.pdf",
     translator,
+    # Keep an unmodified visual-base page if one page's fill fails.
+    ignore_errors=True,
 )
 ```
 
@@ -151,6 +153,8 @@ craft.patch_pdf_with_extraction(
     "book.zh.pdf",
 )
 ```
+
+By default a PDF fill error stops the operation. Pass `ignore_errors=True` to either PDF entry point when a service should keep processing later pages: a failing page is emitted as its Ghostscript visual base, with no selectable source text, while successful pages retain their translation layers. If every page scheduled for fill fails, `NoUsableFillPagesError` is raised instead of producing an all-fallback PDF. This option deliberately catches any ordinary exception within a page fill transaction and records its traceback; it cannot recover a source document for which no visual pages can be produced.
 
 ### What PDF patching can and cannot preserve
 

--- a/docs/zh-CN/API_REFERENCE.md
+++ b/docs/zh-CN/API_REFERENCE.md
@@ -27,8 +27,8 @@ from pdf_craft import PDFCraft, PDFOptions
 - `PDFPatcher`、`PDFReplacement`、`PDFReplacementRegion`、`PDFInlineFormula`、
   `PatchTextOptions`、`PatchTextStyle`、`FontResolution`、`QTextParagraphFiller`、`EraseOptions`、
   `PDFTranslationPipeline`
-- `PDFError`、`OCRError`、`IgnorePDFErrorsChecker`、
-  `IgnoreOCRErrorsChecker`
+- `PDFError`、`OCRError`、`NoUsableFillPagesError`、`IgnorePDFErrorsChecker`、
+  `IgnoreOCRErrorsChecker`、`IgnoreFillErrorsChecker`
 - `translate_epub`
 
 `ChapterTransformer` 是公共协议，但导入路径为
@@ -220,6 +220,7 @@ def accepts_transformer(transformer: ChapterTransformer) -> None:
 extraction = craft.extract_pdf("input.pdf", "work/book.pcex")
 craft.translate_pdf(
     "input.pdf", extraction, "translated.pdf", translator,
+    ignore_errors=True,  # 某一页写回失败时保留该页视觉底图，并继续后续页
 )
 ```
 
@@ -233,6 +234,12 @@ craft.translate_pdf(
 ```python
 craft.patch_pdf_with_extraction("input.pdf", "work/translated.pcex", "translated.pdf")
 ```
+
+`translate_pdf` 与 `patch_pdf_with_extraction` 默认在写回错误时立即失败。传入
+`ignore_errors=True` 后，能够归属到某一页的擦除、文字层、公式或 PDF 合成异常（包括未知代码
+异常）会记录完整 traceback，并让该页退回为不可交互的视觉底图；其余页仍继续写回。若所有需要
+写回的页面都退回，会抛出 `NoUsableFillPagesError`，不会产生伪成功文件。不能打开、枚举或编译
+为视觉底图的源 PDF 没有可回退页，仍会直接失败。
 
 ## PDFCraftExtraction 与 `.pcex`
 
@@ -475,8 +482,9 @@ LLM(
 方法以及一键转换方法返回。`OCREvent` 和 `OCREventKind` 用于 `on_ocr_event` 回调，适合
 记录页面级 OCR 状态。
 
-`PDFError`、`OCRError` 可用于日志和错误判断。`ignore_pdf_errors`、`ignore_ocr_errors` 可
-传 `True`、`False` 或 callable。`FillFailedEvent` 用于 EPUB XML 结构修复失败回调，包含
+`PDFError`、`OCRError`、`NoUsableFillPagesError` 可用于日志和错误判断。`ignore_pdf_errors`、
+`ignore_ocr_errors` 以及 PDF 写回的 `ignore_errors` 可传 `True`、`False` 或 callable。
+`FillFailedEvent` 用于 EPUB XML 结构修复失败回调，包含
 `error_message`、`retried_count` 和 `over_maximum_retries`。
 
 `ExtractionOptions.aborted` 返回 `True`，以及 `max_ocr_tokens` /

--- a/docs/zh-CN/PDF_TRANSLATION.md
+++ b/docs/zh-CN/PDF_TRANSLATION.md
@@ -154,6 +154,7 @@ craft.translate_pdf(
     extraction,
     "translated.pdf",
     translator,
+    ignore_errors=True,  # 某页写回失败时保留该页视觉底图
 )
 ```
 
@@ -169,23 +170,31 @@ craft.translate_pdf("input.pdf", extraction, "translated.pdf", translator)
 
 PDF 输出不接受 `APPEND_BLOCK` 模式，因为 PDF pipeline 不能在原页面中安全追加新的块级内容。
 
+默认情况下，PDF 写回的异常会立即终止操作。线上服务可以为 `translate_pdf` 或
+`patch_pdf_with_extraction` 传入 `ignore_errors=True`：某页的擦除、译文文字层、行内公式或 PDF
+合成发生任意普通异常时，该页会保留 Ghostscript 生成的不可交互视觉底图，其他页继续写回；完整
+traceback 会写入日志。若所有需要写回的页面都退回，则抛出 `NoUsableFillPagesError`，而不是生成
+看似成功、实际未写入译文的 PDF。无法打开、枚举或建立视觉底图的源 PDF 没有页级恢复载体，仍会
+直接失败。
+
 ### PDF 输出的限制
 
 - PDF 写回明确不支持 `APPEND_BLOCK`，因为 PDF pipeline 不能在原页面中安全追加新的
   块级内容；`REPLACE` 与 `APPEND_TEXT` 不会被该入口预先拒绝。
-- 写回前会检查结果是否带有页面几何元数据、章节和几何中涉及的页码是否落在源 PDF 页数
+- 默认写回会检查结果是否带有页面几何元数据、章节和几何中涉及的页码是否落在源 PDF 页数
   范围内，以及每个章节页面是否具有对应的几何记录。它不验证结果目录是否确实由该源 PDF
-  提取而来，因此调用方应自行确保二者匹配。
+  提取而来，因此调用方应自行确保二者匹配；开启 `ignore_errors=True` 后，能归属到某页的
+  几何错误会让该页回退为视觉底图。
 - 写回前，Ghostscript 会将每个源页的非 Annotation 内容编译为无字体的纯视觉底图。源矢量
   文字仍以线条显示，但不再可选中、搜索或提取；隐藏 OCR 文字也会被移除。源页完整的
   `/Annots` 数组会在译文之上重新挂载，因此链接、高亮、批注、表单控件及其他 PDF Annotation
   保持独立且可交互。译文是唯一普通可选择的文字层。
 - 写回只处理 `ref` 为 `text` 或 `sub_title` 的 `ParagraphLayout`。图片、表格以及其他
   布局不会成为可替换项。
-- 正文译文必须在对应 OCR bbox 内排版。默认排版策略会在允许的字号范围内寻找可容纳的
-  字号；最小字号仍无法容纳时抛出 `ValueError`。标题在最终选定字号仍无法装入 bbox 时，
-  会从 bbox 左侧中点起按自然宽度向右绘制，而不会中断或跳过整份输出。所有 bbox
-  会先完成预检，因此正文失败时不会留下部分输出文件。
+- 正文译文优先在对应 OCR bbox 内排版。默认排版策略会在允许的字号范围内寻找可容纳的
+  字号；最小字号仍无法容纳时，会以最小字号从首个 bbox 强制写入全文，即使越过普通 bbox
+  与障碍物边界。标题在最终选定字号仍无法装入 bbox 时，
+  会从 bbox 左侧中点起按自然宽度向右绘制，而不会中断或跳过整份输出。
 - `patch_pdf_with_extraction` 是写回已有 PDF 的操作，不是通用 PDF 排版器，不能只凭提取结果
   生成一个没有原始页面的全新 PDF。
 
@@ -360,8 +369,8 @@ extraction, metering = craft.extract_pdf_with_metering(
   可用于记录 OCR token 使用量。
 - `ExtractionOptions.on_ocr_event` 在 OCR 页面事件发生时回调，适合显示页面级进度。
 - `ExtractionOptions.aborted` 会在提取和渲染阶段被检查；返回 `True` 时当前操作中断。
-- PDF 写回和内容变换中的异常应由调用方捕获；`ignore_*_errors` 只针对提取阶段的页面级
-  错误。
+- PDF 写回和内容变换中的异常通常应由调用方捕获；但 `translate_pdf` 与
+  `patch_pdf_with_extraction` 的 `ignore_errors=True` 会恢复可明确归属到某一页的写回异常。
 
 ## 相关限制
 

--- a/pdf_craft/__init__.py
+++ b/pdf_craft/__init__.py
@@ -1,10 +1,12 @@
 from epub_generator import BookMeta, LaTeXRender, TableRender
 
 from .error import (
+    IgnoreFillErrorsChecker,
     IgnoreOCRErrorsChecker,
     IgnorePDFErrorsChecker,
     InterruptedError,
     NoUsableOCRPagesError,
+    NoUsableFillPagesError,
     OCRBillingError,
     OCRFatalError,
     OCRError,

--- a/pdf_craft/craft.py
+++ b/pdf_craft/craft.py
@@ -16,7 +16,7 @@ from epub_generator import BookMeta, LaTeXRender, TableRender
 from .document import PDFCraftExtraction
 from .extractor.chapter.chapter import Chapter, ParagraphLayout
 from .extractor.chapter.reader import create_chapters_reader
-from .error import IgnoreOCRErrorsChecker, IgnorePDFErrorsChecker
+from .error import IgnoreFillErrorsChecker, IgnoreOCRErrorsChecker, IgnorePDFErrorsChecker
 from .extractor import PDFExtractor
 from .llm import LLM
 from .metering import AbortedCheck, OCRTokensMetering
@@ -149,28 +149,33 @@ class PDFCraft:
     def translate_pdf(
         self, source: PathLike | str, extraction: PDFCraftExtraction | PathLike | str,
         output: PathLike | str, transformer: ChapterTransformer | Callable[[str], str],
-        *, on_translation_event: Callable[[TranslationEvent], None] | None = None,
+        *,
+        on_translation_event: Callable[[TranslationEvent], None] | None = None,
+        ignore_errors: IgnoreFillErrorsChecker = False,
     ) -> None:
         with TemporaryDirectory(prefix="pdf-craft-translated-extraction-") as directory:
             translated = self._translate_for_pdf(
                 _ensure_extraction(extraction), Path(directory), transformer,
                 on_translation_event=on_translation_event,
             )
-            self.patch_pdf_with_extraction(source, translated, output)
+            self.patch_pdf_with_extraction(source, translated, output, ignore_errors=ignore_errors)
 
     def patch_pdf_with_extraction(
         self,
         source: PathLike | str,
         extraction: PDFCraftExtraction | PathLike | str,
         output: PathLike | str,
+        *,
+        ignore_errors: IgnoreFillErrorsChecker = False,
     ) -> None:
         """Patch an existing PDF with text and geometry from a PDFCraftExtraction."""
         extraction = _ensure_extraction(extraction)
         extraction.validate()
-        _validate_extraction_for_pdf(Path(source), extraction)
+        if not _ignore_errors_requested(ignore_errors):
+            _validate_extraction_for_pdf(Path(source), extraction)
         PDFTranslationPipeline(
             pdf_handler=self._pdf.pdf_handler if self._pdf else None
-        ).patch(Path(source), Path(output), extraction)
+        ).patch(Path(source), Path(output), extraction, ignore_errors=ignore_errors)
 
     def translate_epub(self, source: PathLike | str, output: PathLike | str, *,
                        target_language: str, submit: SubmitKind,
@@ -363,6 +368,11 @@ def _validate_extraction_for_pdf(source: Path, extraction: PDFCraftExtraction) -
             "PDFCraftExtraction is missing page geometry for chapter pages: "
             f"{missing}"
         )
+
+
+def _ignore_errors_requested(checker: IgnoreFillErrorsChecker) -> bool:
+    """Defer page-addressable validation when a fill recovery policy exists."""
+    return checker is True or callable(checker)
 
 
 def _ensure_extraction(value: PDFCraftExtraction | PathLike | str) -> PDFCraftExtraction:

--- a/pdf_craft/error.py
+++ b/pdf_craft/error.py
@@ -48,6 +48,19 @@ def is_inline_error(error: Exception) -> bool:
 
 IgnorePDFErrorsChecker = bool | Callable[[PDFError], bool]
 IgnoreOCRErrorsChecker = bool | Callable[[OCRError], bool]
+IgnoreFillErrorsChecker = bool | Callable[[Exception], bool]
+
+
+class NoUsableFillPagesError(Exception):
+    """Raised when every page scheduled for PDF fill fell back to its base."""
+
+    def __init__(self, failed_page_indexes: tuple[int, ...]) -> None:
+        self.failed_page_indexes = failed_page_indexes
+        pages = ", ".join(str(index) for index in failed_page_indexes)
+        super().__init__(
+            "PDF fill produced no usable pages; all pages scheduled for fill "
+            f"failed after errors were ignored: {pages}"
+        )
 
 
 # 不可直接用 doc-page-extractor 的 Error，该库的一切都是懒加载，若暴露，则无法懒加载

--- a/pdf_craft/pipeline/pdf/patcher.py
+++ b/pdf_craft/pipeline/pdf/patcher.py
@@ -2,6 +2,7 @@
 
 from collections.abc import Iterable
 from io import BytesIO
+import logging
 from pathlib import Path
 import pickle
 from tempfile import NamedTemporaryFile, TemporaryDirectory
@@ -9,12 +10,16 @@ from typing import Any
 
 from pdf_craft.pdf.handler import DefaultPDFHandler, PDFHandler
 from pdf_craft.formula import latex_to_plain_text
+from pdf_craft.error import IgnoreFillErrorsChecker, NoUsableFillPagesError
 
 from .eraser import EraseOptions, EraseRectangle, RectangularEraser
 from .models import PDFReplacement, PDFReplacementRegion
 from .text_layout import (
     FontResolution, PatchTextOptions, QTextParagraphFiller, WindowedParagraphPlanner, _contains_cjk,
 )
+
+
+_LOGGER = logging.getLogger(__name__)
 from .visual_base import (
     GhostscriptVisualBaseCompiler, extract_annotations, reattach_annotations,
     VisualBaseCompiler, write_annotation_free_copy,
@@ -66,13 +71,26 @@ class PDFPatcher:
         self._pdf_handler = pdf_handler or DefaultPDFHandler()
         self._visual_base_compiler = visual_base_compiler or GhostscriptVisualBaseCompiler()
         self.dpi = dpi
+        self._failed_page_indexes: tuple[int, ...] = ()
 
     @property
     def font_resolutions(self) -> tuple[FontResolution, ...]:
         """Qt font choices made during the most recent :meth:`patch` run."""
         return getattr(self._filler, "font_resolutions", ())
 
-    def patch(self, source_path: Path, target_path: Path, replacements: Iterable[PDFReplacement]) -> None:
+    @property
+    def failed_page_indexes(self) -> tuple[int, ...]:
+        """Pages retained as visual bases during the most recent patch run."""
+        return self._failed_page_indexes
+
+    def patch(
+        self,
+        source_path: Path,
+        target_path: Path,
+        replacements: Iterable[PDFReplacement],
+        *,
+        ignore_errors: IgnoreFillErrorsChecker = False,
+    ) -> None:
         """Compose visual bases, rectangular erasure, Qt text, then Annotations."""
         try:
             import pypdf
@@ -83,6 +101,7 @@ class PDFPatcher:
         reset_font_resolutions = getattr(self._filler, "reset_font_resolutions", None)
         if reset_font_resolutions is not None:
             reset_font_resolutions()
+        self._failed_page_indexes = ()
         source_reader = pypdf.PdfReader(str(source_path))
         page_sizes = {
             index: (float(page.mediabox.width), float(page.mediabox.height))
@@ -98,25 +117,58 @@ class PDFPatcher:
             write_annotation_free_copy(source_reader, annotation_free_source)
             self._visual_base_compiler.compile(annotation_free_source, visual_base_path)
             reader = pypdf.PdfReader(str(visual_base_path))
+            fallback_reader = pypdf.PdfReader(str(visual_base_path))
             self._restore_source_page_geometry(source_reader, reader)
+            self._restore_source_page_geometry(source_reader, fallback_reader)
             self._validate_visual_base(reader, page_sizes)
             replacements_path = root / "replacements.pickle"
             has_automatic_font = False
             contains_cjk = False
+            target_page_indexes: set[int] = set()
+            failed_page_indexes: set[int] = set()
+
+            def record_page_failure(page_index: int, error: Exception) -> None:
+                failed_page_indexes.add(page_index)
+                _LOGGER.error(
+                    "PDF fill failed for page %s; preserving its visual base", page_index,
+                    exc_info=(type(error), error, error.__traceback__),
+                )
+
+            def record_replacement_failure(replacement: PDFReplacement, error: Exception) -> None:
+                pages = _replacement_pages_in_source(replacement, len(source_reader.pages))
+                if not pages:
+                    raise error
+                for page_index in pages:
+                    target_page_indexes.add(page_index)
+                    record_page_failure(page_index, error)
+
             with replacements_path.open("wb") as stream:
                 for replacement in replacements:
-                    self.validate(replacement, pages_count=len(source_reader.pages))
-                    style = self.options.style_for(
-                        replacement.layout_ref, replacement.layout_level,
-                    )
-                    if not style.font_name or not style.font_name.strip():
-                        has_automatic_font = True
-                        contains_cjk = contains_cjk or _contains_cjk(replacement.text)
-                    pickle.dump(replacement, stream, protocol=pickle.HIGHEST_PROTOCOL)
+                    try:
+                        pages = _replacement_pages_in_source(replacement, len(source_reader.pages))
+                        target_page_indexes.update(pages)
+                        self.validate(replacement, pages_count=len(source_reader.pages))
+                        style = self.options.style_for(
+                            replacement.layout_ref, replacement.layout_level,
+                        )
+                        if not style.font_name or not style.font_name.strip():
+                            has_automatic_font = True
+                            contains_cjk = contains_cjk or _contains_cjk(replacement.text)
+                        pickle.dump(replacement, stream, protocol=pickle.HIGHEST_PROTOCOL)
+                    except Exception as error:
+                        if not _check_ignore_error(ignore_errors, error):
+                            raise
+                        record_replacement_failure(replacement, error)
             if has_automatic_font:
                 prepare_automatic_font = getattr(self._filler, "prepare_automatic_font", None)
                 if prepare_automatic_font is not None:
-                    prepare_automatic_font(contains_cjk)
+                    try:
+                        prepare_automatic_font(contains_cjk)
+                    except Exception as error:
+                        if not _check_ignore_error(ignore_errors, error):
+                            raise
+                        for page_index in target_page_indexes:
+                            record_page_failure(page_index, error)
 
             def spooled_replacements():
                 with replacements_path.open("rb") as stream:
@@ -126,16 +178,26 @@ class PDFPatcher:
                         except EOFError:
                             return
 
+            def on_window_error(window_replacements: tuple[PDFReplacement, ...], error: Exception) -> None:
+                if not _check_ignore_error(ignore_errors, error):
+                    raise error
+                for replacement in window_replacements:
+                    record_replacement_failure(replacement, error)
+
             planner = WindowedParagraphPlanner(self._filler, page_sizes, self.options)
-            for window in planner.plan(spooled_replacements()):
+            for window in planner.plan(spooled_replacements(), on_window_error=on_window_error):
                 for index in range(next_page_index, window.first_page_index):
-                    writer.add_page(reader.pages[index - 1])
+                    writer.add_page(fallback_reader.pages[index - 1])
                 self._compose_window(
-                    pypdf, canvas, source_path, reader, writer, root, page_sizes, window,
+                    pypdf, canvas, source_path, reader, fallback_reader, writer, root, page_sizes, window,
+                    ignore_errors, failed_page_indexes, record_page_failure,
                 )
                 next_page_index = window.last_page_index + 1
             for index in range(next_page_index, len(reader.pages) + 1):
-                writer.add_page(reader.pages[index - 1])
+                writer.add_page(fallback_reader.pages[index - 1])
+            self._failed_page_indexes = tuple(sorted(failed_page_indexes))
+            if target_page_indexes and target_page_indexes.issubset(failed_page_indexes):
+                raise NoUsableFillPagesError(tuple(sorted(target_page_indexes)))
             source_catalog: Any = source_reader.trailer["/Root"]
             reattach_annotations(
                 writer,
@@ -183,51 +245,63 @@ class PDFPatcher:
                 )
 
     def _compose_window(
-        self, pypdf, canvas, source_path: Path, reader, writer, root: Path,
+        self, pypdf, canvas, source_path: Path, reader, fallback_reader, writer, root: Path,
         page_sizes: dict[int, tuple[float, float]], window,
+        ignore_errors: IgnoreFillErrorsChecker,
+        failed_page_indexes: set[int],
+        record_page_failure,
     ) -> None:
         """Compose one window while loading one serialized page plan at a time."""
         document = None
         try:
-            if window.has_page_contributions:
-                document = self._pdf_handler.open(source_path)
             for index in range(window.first_page_index, window.last_page_index + 1):
-                page = reader.pages[index - 1]
-                page_width, page_height = page_sizes[index]
-                contributions = tuple(window.page_contributions(index))
-                page_regions = tuple(
-                    region
-                    for contribution in contributions
-                    for region in contribution.regions
-                )
-                page_erasures = self._plan_page_erasures(
-                    document, index, page_regions, page_sizes,
-                )
-                if page_erasures:
-                    erasure_path = root / f"erase-{index}.pdf"
-                    self._write_erasure_overlay(canvas, erasure_path, page_width, page_height, page_erasures)
-                    page.merge_page(pypdf.PdfReader(str(erasure_path)).pages[0])
-                page_placements = tuple(
-                    placement
-                    for contribution in contributions
-                    for placement in contribution.placements
-                )
-                if page_placements:
-                    self._merge_text_placements(
-                        pypdf, page, root, index, (page_width, page_height), page_placements,
+                if index in failed_page_indexes:
+                    writer.add_page(fallback_reader.pages[index - 1])
+                    continue
+                try:
+                    page = reader.pages[index - 1]
+                    page_width, page_height = page_sizes[index]
+                    contributions = tuple(window.page_contributions(index))
+                    page_regions = tuple(
+                        region
+                        for contribution in contributions
+                        for region in contribution.regions
                     )
-                    for placement in page_placements:
-                        for formula in placement.formula_draws:
-                            fragment = _formula_fragment_with_actual_text(pypdf, formula.pdf, formula.latex)
-                            page.merge_transformed_page(
-                                fragment,
-                                pypdf.Transformation().scale(
-                                    1 / formula.scale, 1 / formula.scale,
-                                ).translate(
-                                    formula.x, page_height - formula.baseline - formula.descent,
-                                ),
-                            )
-                writer.add_page(page)
+                    if page_regions and document is None:
+                        document = self._pdf_handler.open(source_path)
+                    page_erasures = self._plan_page_erasures(
+                        document, index, page_regions, page_sizes,
+                    )
+                    if page_erasures:
+                        erasure_path = root / f"erase-{index}.pdf"
+                        self._write_erasure_overlay(canvas, erasure_path, page_width, page_height, page_erasures)
+                        page.merge_page(pypdf.PdfReader(str(erasure_path)).pages[0])
+                    page_placements = tuple(
+                        placement
+                        for contribution in contributions
+                        for placement in contribution.placements
+                    )
+                    if page_placements:
+                        self._merge_text_placements(
+                            pypdf, page, root, index, (page_width, page_height), page_placements,
+                        )
+                        for placement in page_placements:
+                            for formula in placement.formula_draws:
+                                fragment = _formula_fragment_with_actual_text(pypdf, formula.pdf, formula.latex)
+                                page.merge_transformed_page(
+                                    fragment,
+                                    pypdf.Transformation().scale(
+                                        1 / formula.scale, 1 / formula.scale,
+                                    ).translate(
+                                        formula.x, page_height - formula.baseline - formula.descent,
+                                    ),
+                                )
+                    writer.add_page(page)
+                except Exception as error:
+                    if not _check_ignore_error(ignore_errors, error):
+                        raise
+                    record_page_failure(index, error)
+                    writer.add_page(fallback_reader.pages[index - 1])
         finally:
             if document is not None:
                 document.close()
@@ -401,3 +475,17 @@ def _set_page_actual_text(page, actual_text: str):
 def _pdf_utf16_hex_string(text: str) -> bytes:
     """Encode a PDF Unicode text string as a syntax-safe hexadecimal literal."""
     return b"<FEFF" + text.encode("utf-16-be").hex().upper().encode("ascii") + b">"
+
+
+def _check_ignore_error(checker: IgnoreFillErrorsChecker, error: Exception) -> bool:
+    """Apply the fill policy without narrowing recoverable page exceptions."""
+    return checker(error) if callable(checker) else checker
+
+
+def _replacement_pages_in_source(replacement: PDFReplacement, pages_count: int) -> tuple[int, ...]:
+    """Return real source pages touched by a replacement, even if its bbox is bad."""
+    return tuple(sorted({
+        region.page_index
+        for region in replacement.source_regions()
+        if 1 <= region.page_index <= pages_count
+    }))

--- a/pdf_craft/pipeline/pdf/pipeline.py
+++ b/pdf_craft/pipeline/pdf/pipeline.py
@@ -14,6 +14,7 @@ from pdf_craft.transformer.events import TranslationEvent, TranslationEventKind,
 from pdf_craft.transformer.chapter_xml import ChapterXMLTransformer
 from pdf_craft.transformer.xml_translator.segment import search_text_segments
 from pdf_craft.pdf.handler import PDFHandler
+from pdf_craft.error import IgnoreFillErrorsChecker
 from pdf_craft.pipeline.pdf.models import PDFInlineFormula, PDFReplacement, PDFReplacementRegion
 from pdf_craft.pipeline.pdf.patcher import PDFPatcher
 from pdf_craft.transformer import ChapterTransformer
@@ -35,6 +36,8 @@ class PDFTranslationPipeline:
         extraction: PDFCraftExtraction | Path,
         transformer: Callable[[str], str] | ChapterTransformer,
         on_translation_event: Callable[[TranslationEvent], None] | None = None,
+        *,
+        ignore_errors: IgnoreFillErrorsChecker = False,
     ) -> None:
         extraction = _ensure_extraction(extraction)
         extraction.validate()
@@ -95,6 +98,7 @@ class PDFTranslationPipeline:
                     callback = transformer if callable(transformer) else (lambda text: text)
                     yield from self._iter_chapter_replacements(
                         transformed, callback, pages, render_dpi, structured,
+                        ignore_errors=ignore_errors,
                     )
                     completed_characters += character_count
                     if on_translation_event is not None and not is_xml_transformer:
@@ -117,7 +121,9 @@ class PDFTranslationPipeline:
                             total_characters=total_characters,
                         ))
 
-            self.patcher.patch(pdf_path, target_path, translated_replacements())
+            self._patch_replacements(
+                pdf_path, target_path, translated_replacements(), ignore_errors,
+            )
         if on_translation_event is not None:
             on_translation_event(TranslationEvent(
                 kind=TranslationEventKind.COMPLETE,
@@ -130,6 +136,8 @@ class PDFTranslationPipeline:
         pdf_path: Path,
         target_path: Path,
         extraction: PDFCraftExtraction | Path,
+        *,
+        ignore_errors: IgnoreFillErrorsChecker = False,
     ) -> None:
         """Write text already present in ``extraction`` back to ``pdf_path``.
 
@@ -147,15 +155,35 @@ class PDFTranslationPipeline:
                 for chapter in reader():
                     yield from self._iter_chapter_replacements(
                         chapter, lambda text: text, pages, render_dpi, structured=True,
+                        ignore_errors=ignore_errors,
                     )
 
-            self.patcher.patch(pdf_path, target_path, replacements())
+            self._patch_replacements(pdf_path, target_path, replacements(), ignore_errors)
+
+    def _patch_replacements(
+        self,
+        pdf_path: Path,
+        target_path: Path,
+        replacements: Iterator[PDFReplacement],
+        ignore_errors: IgnoreFillErrorsChecker,
+    ) -> None:
+        """Keep existing custom patchers compatible until they opt into recovery."""
+        if _ignore_errors_enabled(ignore_errors):
+            self.patcher.patch(
+                pdf_path, target_path, replacements, ignore_errors=ignore_errors,
+            )
+            return
+        self.patcher.patch(pdf_path, target_path, replacements)
 
     def _iter_chapter_replacements(
         self, chapter: Chapter, transformer, pages,
         render_dpi: int, structured: bool = False,
+        *,
+        ignore_errors: IgnoreFillErrorsChecker = False,
     ) -> Iterator[PDFReplacement]:
-        obstacle_regions = _chapter_obstacle_regions(chapter, pages, render_dpi)
+        obstacle_regions = _chapter_obstacle_regions(
+            chapter, pages, render_dpi, ignore_errors=ignore_errors,
+        )
         for layout in chapter.layouts:
             if not isinstance(layout, ParagraphLayout) or layout.ref not in {"text", "sub_title"}:
                 continue
@@ -180,11 +208,16 @@ class PDFTranslationPipeline:
             regions: list[PDFReplacementRegion] = []
             for block in layout.blocks:
                 if block.page_index not in pages:
-                    raise ValueError(
+                    error = ValueError(
                         f"PDFCraftExtraction pages.xml is missing page {block.page_index}"
                     )
+                    if not _check_ignore_error(ignore_errors, error):
+                        raise error
+                    page_pixel_size = (0, 0)
+                else:
+                    page_pixel_size = pages[block.page_index]
                 regions.append(PDFReplacementRegion(
-                    block.page_index, block.det, pages[block.page_index], render_dpi,
+                    block.page_index, block.det, page_pixel_size, render_dpi,
                     reading_order=block.order,
                 ))
             if not regions:  # A ParagraphLayout without blocks has no source geometry.
@@ -198,6 +231,16 @@ class PDFTranslationPipeline:
                 inline_formulas=inline_formulas,
                 obstacle_regions=obstacle_regions,
             )
+
+
+def _check_ignore_error(checker: IgnoreFillErrorsChecker, error: Exception) -> bool:
+    """Match PDF patcher's bool-or-callable page-fill error policy."""
+    return checker(error) if callable(checker) else checker
+
+
+def _ignore_errors_enabled(checker: IgnoreFillErrorsChecker) -> bool:
+    """A callable policy needs an error instance before it can opt in."""
+    return checker is True or callable(checker)
 
 
 def _to_patch_text(items) -> str:
@@ -252,7 +295,13 @@ def _to_pdf_patch_content(items) -> tuple[str, tuple[PDFInlineFormula, ...]]:
     return "".join(parts), tuple(formulas)
 
 
-def _chapter_obstacle_regions(chapter: Chapter, pages, render_dpi: int) -> tuple[PDFReplacementRegion, ...]:
+def _chapter_obstacle_regions(
+    chapter: Chapter,
+    pages,
+    render_dpi: int,
+    *,
+    ignore_errors: IgnoreFillErrorsChecker = False,
+) -> tuple[PDFReplacementRegion, ...]:
     """Collect non-flow geometry that may stop text from extending downward.
 
     Top-level paragraph blocks are already represented by the replacement
@@ -268,7 +317,10 @@ def _chapter_obstacle_regions(chapter: Chapter, pages, render_dpi: int) -> tuple
 
     def add_region(page_index: int, det: tuple[int, int, int, int]) -> None:
         if page_index not in pages:
-            raise ValueError(f"PDFCraftExtraction pages.xml is missing page {page_index}")
+            error = ValueError(f"PDFCraftExtraction pages.xml is missing page {page_index}")
+            if not _check_ignore_error(ignore_errors, error):
+                raise error
+            return
         key = (page_index, det)
         if key not in seen_regions:
             seen_regions.add(key)

--- a/pdf_craft/pipeline/pdf/text_layout.py
+++ b/pdf_craft/pipeline/pdf/text_layout.py
@@ -2115,7 +2115,12 @@ class WindowedParagraphPlanner:
         self._options = options or filler.options
         self._previous_body_font_size: float | None = None
 
-    def plan(self, replacements: Iterable[PDFReplacement]) -> Iterator[FillWindowPlan]:
+    def plan(
+        self,
+        replacements: Iterable[PDFReplacement],
+        *,
+        on_window_error: Callable[[tuple[PDFReplacement, ...], Exception], None] | None = None,
+    ) -> Iterator[FillWindowPlan]:
         """Yield completed windows in page order without retaining the full book."""
         window: list[PDFReplacement] = []
         first_page: int | None = None
@@ -2128,7 +2133,9 @@ class WindowedParagraphPlanner:
             previous_first_page = replacement_first
             if window and replacement_first > last_page:
                 assert first_page is not None
-                yield self._plan_window(first_page, last_page, window)
+                yield from self._plan_or_report_failure(
+                    first_page, last_page, window, on_window_error,
+                )
                 window = []
                 first_page = None
                 last_page = 0
@@ -2138,7 +2145,31 @@ class WindowedParagraphPlanner:
             last_page = max(last_page, replacement_last)
         if window:
             assert first_page is not None
-            yield self._plan_window(first_page, last_page, window)
+            yield from self._plan_or_report_failure(
+                first_page, last_page, window, on_window_error,
+            )
+
+    def _plan_or_report_failure(
+        self,
+        first_page: int,
+        last_page: int,
+        replacements: list[PDFReplacement],
+        on_window_error: Callable[[tuple[PDFReplacement, ...], Exception], None] | None,
+    ) -> Iterator[FillWindowPlan]:
+        """Plan a closed window or hand its recoverable failure to the caller.
+
+        The planner deliberately has no error policy of its own.  The PDF
+        composer is the layer that can decide whether an isolated window may
+        fall back to its visual source pages.  Keeping this callback at the
+        window boundary preserves bounded memory while allowing callers to
+        recover page-addressable layout failures.
+        """
+        try:
+            yield self._plan_window(first_page, last_page, replacements)
+        except Exception as error:
+            if on_window_error is None:
+                raise
+            on_window_error(tuple(replacements), error)
 
     def _plan_window(
         self,

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "poetry.core.masonry.api"
 
 [project]
 name = "pdf-craft"
-version = "2.2.0"
+version = "2.2.1"
 description = "PDF craft can convert PDF files into various other formats. This project will focus on processing PDF files of scanned books."
 license = {text = "MIT"}
 authors = [{name = "Tao Zeyu", email = "i@taozeyu.com"}]

--- a/tests/test_craft.py
+++ b/tests/test_craft.py
@@ -100,6 +100,19 @@ class TestPDFCraft(unittest.TestCase):
             validate.assert_called_once()
             patch_pdf.assert_called_once()
 
+    def test_patch_pdf_with_extraction_defers_page_validation_when_ignoring_errors(self):
+        with tempfile.TemporaryDirectory() as directory:
+            extraction = _source_extraction(Path(directory) / "source")
+            with patch("pdf_craft.craft._validate_extraction_for_pdf") as validate, \
+                    patch("pdf_craft.craft.PDFTranslationPipeline.patch") as patch_pdf:
+                PDFCraft().patch_pdf_with_extraction(
+                    "source.pdf", extraction, "target.pdf", ignore_errors=True,
+                )
+            validate.assert_not_called()
+            patch_pdf.assert_called_once_with(
+                Path("source.pdf"), Path("target.pdf"), extraction, ignore_errors=True,
+            )
+
     def test_extraction_transform_creates_independent_archive(self):
         with tempfile.TemporaryDirectory() as directory:
             root = Path(directory)

--- a/tests/test_pdf_patcher.py
+++ b/tests/test_pdf_patcher.py
@@ -15,6 +15,7 @@ from PIL import Image
 from reportlab.pdfgen import canvas
 
 from pdf_craft.pdf.handler import PDFHandler
+from pdf_craft.error import NoUsableFillPagesError
 from pdf_craft.pipeline.pdf import (
     FillWindowPlan, FittedParagraph, GhostscriptVisualBaseCompiler, PDFInlineFormula, PDFPatcher, PDFReplacement,
     PDFReplacementRegion, PatchTextOptions, PatchTextStyle,
@@ -42,6 +43,171 @@ class TestPDFPatcher(unittest.TestCase):
 
     def patcher(self, *args, **kwargs) -> PDFPatcher:
         return PDFPatcher(*args, visual_base_compiler=self._compiler, **kwargs)
+
+    @staticmethod
+    def _two_page_source(path: Path) -> None:
+        document = canvas.Canvas(str(path), pagesize=(200, 100))
+        document.drawString(20, 70, "Original first page")
+        document.showPage()
+        document.drawString(20, 70, "Original second page")
+        document.save()
+
+    @staticmethod
+    def _page_document() -> Any:
+        document: Any = Mock()
+        document.render_page.side_effect = lambda *_args: Image.new("RGB", (200, 100), "white")
+        return document
+
+    @staticmethod
+    def _two_page_replacements() -> list[PDFReplacement]:
+        return [
+            PDFReplacement(1, (10, 10, 190, 70), "First translated", (200, 100)),
+            PDFReplacement(2, (10, 10, 190, 70), "Second translated", (200, 100)),
+        ]
+
+    def test_ignore_errors_preserves_visual_base_for_one_failed_fill_page(self):
+        with tempfile.TemporaryDirectory() as temp_dir:
+            root = Path(temp_dir)
+            source = root / "source.pdf"
+            target = root / "target.pdf"
+            self._two_page_source(source)
+            document = self._page_document()
+            handler: Any = Mock()
+            handler.open.return_value = document
+            patcher = self.patcher(font_size=8, pdf_handler=handler)
+            write_erasure = patcher._write_erasure_overlay  # pylint: disable=protected-access
+
+            def fail_first_page(canvas_module, output_path, *args):
+                if output_path.name == "erase-1.pdf":
+                    raise RuntimeError("deliberate page bug")
+                return write_erasure(canvas_module, output_path, *args)
+
+            with patch.object(patcher, "_write_erasure_overlay", side_effect=fail_first_page), \
+                    self.assertLogs("pdf_craft.pipeline.pdf.patcher", "ERROR") as logged:
+                patcher.patch(source, target, self._two_page_replacements(), ignore_errors=True)
+
+            reader = pypdf.PdfReader(str(target))
+            self.assertEqual(len(reader.pages), 2)
+            self.assertNotIn("Original first page", reader.pages[0].extract_text() or "")
+            self.assertNotIn("First translated", reader.pages[0].extract_text() or "")
+            self.assertIn("Second translated", " ".join((reader.pages[1].extract_text() or "").split()))
+            self.assertEqual(patcher.failed_page_indexes, (1,))
+            self.assertIn("RuntimeError: deliberate page bug", "\n".join(logged.output))
+
+    def test_fill_page_errors_remain_fail_fast_without_ignore_errors(self):
+        with tempfile.TemporaryDirectory() as temp_dir:
+            root = Path(temp_dir)
+            source = root / "source.pdf"
+            target = root / "target.pdf"
+            self._two_page_source(source)
+            document = self._page_document()
+            handler: Any = Mock()
+            handler.open.return_value = document
+            patcher = self.patcher(font_size=8, pdf_handler=handler)
+
+            with patch.object(
+                patcher, "_write_erasure_overlay", side_effect=RuntimeError("deliberate page bug"),
+            ), self.assertRaisesRegex(RuntimeError, "deliberate page bug"):
+                patcher.patch(source, target, self._two_page_replacements())
+
+            self.assertFalse(target.exists())
+
+    def test_ignore_errors_rejects_an_output_with_no_usable_fill_pages(self):
+        with tempfile.TemporaryDirectory() as temp_dir:
+            root = Path(temp_dir)
+            source = root / "source.pdf"
+            target = root / "target.pdf"
+            self._two_page_source(source)
+            document = self._page_document()
+            handler: Any = Mock()
+            handler.open.return_value = document
+            patcher = self.patcher(font_size=8, pdf_handler=handler)
+
+            with patch.object(
+                patcher, "_write_erasure_overlay", side_effect=RuntimeError("deliberate page bug"),
+            ), self.assertRaises(NoUsableFillPagesError) as raised:
+                patcher.patch(source, target, self._two_page_replacements(), ignore_errors=True)
+
+            self.assertEqual(raised.exception.failed_page_indexes, (1, 2))
+            self.assertFalse(target.exists())
+
+    def test_ignore_errors_recovers_a_page_scoped_invalid_bbox(self):
+        with tempfile.TemporaryDirectory() as temp_dir:
+            root = Path(temp_dir)
+            source = root / "source.pdf"
+            target = root / "target.pdf"
+            self._two_page_source(source)
+            document = self._page_document()
+            handler: Any = Mock()
+            handler.open.return_value = document
+            patcher = self.patcher(font_size=8, pdf_handler=handler)
+            replacements = [
+                PDFReplacement(1, (10, 10, 9, 70), "Invalid", (200, 100)),
+                PDFReplacement(2, (10, 10, 190, 70), "Second translated", (200, 100)),
+            ]
+
+            patcher.patch(source, target, replacements, ignore_errors=True)
+
+            reader = pypdf.PdfReader(str(target))
+            self.assertNotIn("Invalid", reader.pages[0].extract_text() or "")
+            self.assertIn("Second translated", " ".join((reader.pages[1].extract_text() or "").split()))
+            self.assertEqual(patcher.failed_page_indexes, (1,))
+
+    def test_ignore_errors_recovers_a_page_scoped_planning_bug(self):
+        with tempfile.TemporaryDirectory() as temp_dir:
+            root = Path(temp_dir)
+            source = root / "source.pdf"
+            target = root / "target.pdf"
+            self._two_page_source(source)
+            document = self._page_document()
+            handler: Any = Mock()
+            handler.open.return_value = document
+            patcher = self.patcher(font_size=8, pdf_handler=handler)
+            fit = patcher._filler.fit  # pylint: disable=protected-access
+
+            def fail_first_page(replacement, page_sizes):
+                if replacement.page_index == 1:
+                    raise RuntimeError("deliberate layout bug")
+                return fit(replacement, page_sizes)
+
+            observed: list[Exception] = []
+            with patch.object(patcher._filler, "fit", side_effect=fail_first_page):  # pylint: disable=protected-access
+                patcher.patch(
+                    source,
+                    target,
+                    self._two_page_replacements(),
+                    ignore_errors=lambda error: observed.append(error) is None,
+                )
+
+            reader = pypdf.PdfReader(str(target))
+            self.assertNotIn("First translated", reader.pages[0].extract_text() or "")
+            self.assertIn("Second translated", " ".join((reader.pages[1].extract_text() or "").split()))
+            self.assertEqual(patcher.failed_page_indexes, (1,))
+            self.assertEqual([str(error) for error in observed], ["deliberate layout bug"])
+
+    def test_pages_without_fill_work_do_not_count_toward_usable_fill_pages(self):
+        with tempfile.TemporaryDirectory() as temp_dir:
+            root = Path(temp_dir)
+            source = root / "source.pdf"
+            target = root / "target.pdf"
+            self._two_page_source(source)
+            document = self._page_document()
+            handler: Any = Mock()
+            handler.open.return_value = document
+            patcher = self.patcher(font_size=8, pdf_handler=handler)
+
+            with patch.object(
+                patcher, "_write_erasure_overlay", side_effect=RuntimeError("deliberate page bug"),
+            ), self.assertRaises(NoUsableFillPagesError) as raised:
+                patcher.patch(
+                    source,
+                    target,
+                    [PDFReplacement(1, (10, 10, 190, 70), "First translated", (200, 100))],
+                    ignore_errors=True,
+                )
+
+            self.assertEqual(raised.exception.failed_page_indexes, (1,))
+            self.assertFalse(target.exists())
 
     def test_legacy_font_size_remains_an_explicit_maximum(self):
         patcher = self.patcher(font_size=12)


### PR DESCRIPTION
## Summary\n- add page-scoped PDF fill recovery under \n- retain visual-base fallback pages and fail only when every scheduled fill page falls back\n- prepare v2.2.1 changelog and release metadata\n\n## Verification\n- 0 errors, 0 warnings, 0 informations
WARNING: there is a new pyright version available (v1.1.407 -> v1.1.414).
Please install the new version or set PYRIGHT_PYTHON_FORCE_VERSION to `latest`\n- 
--------------------------------------------------------------------
Your code has been rated at 10.00/10 (previous run: 10.00/10, +0.00)\n- /var/folders/z1/mv6k1h1n5fd41cypgbwm0s7w0000gn/T/tmpnh71gslk/output/Cambridge-epub-translate-20260910-001
pdf-craft-output/smoke/citation-markdown-20260910-004\n- Building pdf-craft (2.2.1)
Building sdist
  - Building sdist
  - Built pdf_craft-2.2.1.tar.gz
Building wheel
  - Building wheel
  - Built pdf_craft-2.2.1-py3-none-any.whl